### PR TITLE
Ambiguous ID on join query

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -233,7 +233,7 @@ module Sunspot #:nodoc:
             last_id = options[:first_id]
             while(offset < record_count)
               solr_benchmark options[:batch_size], counter do
-                records = all(:include => options[:include], :conditions => ["#{table_name}.#{primary_key} > ?", last_id], :limit => options[:batch_size], :order => primary_key)
+                records = all(:include => options[:include], :conditions => ["#{table_name}.#{primary_key} > ?", last_id], :limit => options[:batch_size], :order => "#{table_name}.#{primary_key}")
                 Sunspot.index(records)
                 last_id = records.last.id
               end


### PR DESCRIPTION
Hey there,

We had an issue with sunspot where we joined two tables, both with primary keys of ID. The query was ordering by ID, but SQL didn't know which table the query was talking about. Our fix was to be explicit about which table we were ordering with.

I didn't find an obvious place to write a test so there's no test for this fix. If you point me somewhere appropriate I'll write the test.

Thanks,

Alex.
