### PR TITLE
sunspot_rails adapters

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/railtie.rb
+++ b/sunspot_rails/lib/sunspot/rails/railtie.rb
@@ -3,9 +3,9 @@ module Sunspot
     class Railtie < ::Rails::Railtie
       initializer 'sunspot_rails.init' do
         Sunspot.session = Sunspot::Rails.build_session
-        Sunspot::Adapters::InstanceAdapter.register(Sunspot::Rails::Adapters::ActiveRecordInstanceAdapter, ActiveRecord::Base)
-        Sunspot::Adapters::DataAccessor.register(Sunspot::Rails::Adapters::ActiveRecordDataAccessor, ActiveRecord::Base)
         ActiveSupport.on_load(:active_record) do
+          Sunspot::Adapters::InstanceAdapter.register(Sunspot::Rails::Adapters::ActiveRecordInstanceAdapter, ActiveRecord::Base)
+          Sunspot::Adapters::DataAccessor.register(Sunspot::Rails::Adapters::ActiveRecordDataAccessor, ActiveRecord::Base)
           include(Sunspot::Rails::Searchable)
         end
         ActiveSupport.on_load(:action_controller) do


### PR DESCRIPTION
I'm using mongoid as my orm instead of AR and have custom adapters. This commit moves AR adapter registration into the on_load(:active_record) block.

Christos
