### PR TITLE
patch to fix bug in maybe_mark_for_auto_indexing

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -392,7 +392,8 @@ module Sunspot #:nodoc:
 
         def maybe_mark_for_auto_indexing
           @marked_for_auto_indexing =
-            if !new_record? && ignore_attributes = self.class.sunspot_options[:ignore_attribute_changes_of]
+            if !new_record?
+              ignore_attributes = self.class.sunspot_options[:ignore_attribute_changes_of] || []
               @marked_for_auto_indexing = !(changed.map { |attr| attr.to_sym } - ignore_attributes).blank?
             else
               true

--- a/sunspot_rails/spec/model_lifecycle_spec.rb
+++ b/sunspot_rails/spec/model_lifecycle_spec.rb
@@ -61,3 +61,14 @@ describe 'searchable with lifecycle - ignoring specific attributes' do
     @post.update_attribute :updated_at, 123.seconds.from_now
   end
 end
+
+describe 'searchable with lifecycle - without ignoring specific attributes' do
+  before(:each) do
+    @author = Author.create
+  end
+
+  it "should not reindex the object when no attributes change" do
+    Sunspot.should_not_receive(:index).with(@author)
+    @author.save
+  end
+end


### PR DESCRIPTION
I noticed that my models were generating index jobs (we use a resque session proxy) even when there were no changes to the data.  This patch includes a spec and fix, I'm pretty sure this is the correct behavior, but I might be missing something.
