### PR TITLE
Ran into a problem with uuids, turns out the rails adapter was converting ids to integers

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/adapters.rb
+++ b/sunspot_rails/lib/sunspot/rails/adapters.rb
@@ -48,7 +48,7 @@ module Sunspot #:nodoc:
         # 
         def load(id)
           @clazz.first(options_for_find.merge(
-            :conditions => { @clazz.primary_key => id.to_i}
+            :conditions => { @clazz.primary_key => id}
           ))
         end
 
@@ -65,7 +65,7 @@ module Sunspot #:nodoc:
         #
         def load_all(ids)
           @clazz.all(options_for_find.merge(
-            :conditions => { @clazz.primary_key => ids.map { |id| id.to_i }}
+            :conditions => { @clazz.primary_key => ids.map { |id| id }}
           ))
         end
         


### PR DESCRIPTION
I could have sworn this was fixed before at some point and it must have sneaked back in there.

SELECT `clubs`.\* FROM `clubs` WHERE (`clubs`.`id` IN (494789))
that 494789 should be "494789a0-cfcb-11df-80b0-003048c3cf84"

/home/max/.rvm/gems/jruby-head/gems/sunspot_rails-1.2.rc4/lib/sunspot/rails/adapters.rb:68
:conditions => { @clazz.primary_key => ids.map { |id| id.to_i }}
