### PR TITLE
Distributed Search - Search from multiple cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.gem
 Gemfile.lock
+*.swp
+**/*.swp

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -46,11 +46,15 @@ module Sunspot #:nodoc:
 
       def slave_config(sunspot_rails_configuration)
         config = Sunspot::Configuration.build
-        config.solr.url = URI::HTTP.build(
-          :host => configuration.hostname,
-          :port => configuration.port,
-          :path => configuration.path
-        ).to_s
+				options = {
+					:host => configuration.hostname,
+					:port => configuration.port,
+					:path => configuration.path
+				}
+				if configuration.shards.present?
+					options.merge!(:query => URI.escape("shards=#{configuration.shards}"))
+				end
+        config.solr.url = URI::HTTP.build(options).to_s
         config
       end
     end

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -12,6 +12,7 @@ module Sunspot #:nodoc:
     #       min_memory: 512M
     #       max_memory: 1G
     #       solr_jar: /some/path/solr15/start.jar
+		# 			shards: "localhost:8982/solr,localhost:8983/solr"
     #   test:
     #     solr:
     #       hostname: localhost
@@ -102,6 +103,17 @@ module Sunspot #:nodoc:
       def master_hostname
         @master_hostname ||= (user_configuration_from_key('master_solr', 'hostname') || hostname)
       end
+
+			# 
+			# Comma separated list of shards. Defaults to empty string
+			# Eg: localhost:8983/solr,localhost:8982/solr
+			#
+			# ==== Returns
+			# String:: comma separated shards
+			#
+			def shards
+				@shards ||= (user_configuration_from_key('solr', 'shards') || '')
+			end
 
       #
       # The port at which to connect to the master Solr instance. Defaults to


### PR DESCRIPTION
Search from multiple solr cores or distributed solr index. 

Sample sunspot.yml

production:
  solr:
    hostname: localhost
    port: 8983
    log_level: WARNING
development:
  solr:
    hostname: localhost
    port: 8982
    log_level: INFO
    shards: "localhost:8982/solr,localhost:8983/solr"

More about Distributed Solr Search

http://wiki.apache.org/solr/DistributedSearch
