### PR TITLE
Update testing proxy with generic pagination methods

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -67,11 +67,11 @@ module Sunspot
         end
 
         def results
-          []
+          PaginatedCollection.new
         end
 
         def hits(options = {})
-          []
+          PaginatedCollection.new
         end
 
         def total
@@ -87,6 +87,10 @@ module Sunspot
         def execute
           self
         end
+      end
+      
+      
+      class PaginatedCollection < Array
         
         def total_count
           0
@@ -130,6 +134,7 @@ module Sunspot
         def offset
           0
         end
+        
       end
       
     end


### PR DESCRIPTION
Propagate the generic pagination methods added in this commit:

https://github.com/outoftime/sunspot/blob/08dc66b45179d3332987b95467aad70d1f444b84/sunspot/lib/sunspot/search/paginated_collection.rb

to the testing proxy.
