### PR TITLE
Added support for "more_like_this" searches to the proxy stub

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -67,11 +67,11 @@ module Sunspot
         end
 
         def results
-          []
+          PaginatedCollection.new
         end
 
         def hits(options = {})
-          []
+          PaginatedCollection.new
         end
 
         def total
@@ -87,6 +87,10 @@ module Sunspot
         def execute
           self
         end
+      end
+      
+      
+      class PaginatedCollection < Array
         
         def total_count
           0
@@ -130,6 +134,7 @@ module Sunspot
         def offset
           0
         end
+        
       end
       
     end


### PR DESCRIPTION
Hi,

Just added a method to respond to calls for "new_more_like_this" searches.  Didn't see any tests for the session proxy, so I did not add any.

Thanks again,
Dave
