### PR TITLE
Restore spec:api and spec:integration tasks

### DIFF
--- a/sunspot/tasks/spec.rake
+++ b/sunspot/tasks/spec.rake
@@ -1,0 +1,38 @@
+require 'spec/rake/spectask'
+
+namespace :spec do
+  desc 'Run API specs'
+  Spec::Rake::SpecTask.new(:api) do |t|
+    t.spec_files = FileList['spec/api/**/*_spec.rb']
+  end
+
+  desc 'Run integration specs'
+  task :integration => 'spec:solr:start' do
+    begin
+      Rake::Task['spec:integration_runner'].invoke
+    ensure
+      Rake::Task['spec:solr:stop'].invoke
+    end
+  end
+
+  Spec::Rake::SpecTask.new(:integration_runner) do |t|
+    t.spec_files = FileList['spec/integration/**/*_spec.rb']
+  end
+
+  namespace :solr do
+    desc 'Start a Solr instance for testing'
+    task :start => :calculate_path do
+      sh "#{@sunspot_solr} start"
+      sleep 5
+    end
+
+    desc 'Stop a Solr instance started with spec:solr:start'
+    task :stop => :calculate_path do
+      sh "#{@sunspot_solr} stop"
+    end
+
+    task :calculate_path do
+      @sunspot_solr = File.expand_path(File.join(File.dirname(__FILE__), %w(.. bin sunspot-solr)))
+    end
+  end
+end


### PR DESCRIPTION
From the commit message:

> First cut at tasks for running API and integration specs.
> 
> The integration test task currently uses a very crude synchronization
> method w/r/t synchronizing with Solr startup.  A more sophisticated
> approach would be to poll http://#{host}:#{port}/solr/ for 200 OK, but
> doing so will require more invasive changes to Sunspot's Solr control
> wrapper, and sleeping is good enough for use cases like running the
> spec:integration task by hand.  (However, not good enough for things
> like continuous integration.)

That "more sophisticated approach" is in the works, but here's what I've got for now.  It was a prerequisite for fixing an error in Sunspot::Search::Hit.   I will describe that error and a proposed fix in a separate pull request.
