### PR TITLE
Differentiate between false and nil in S::Search::Hit#stored_value

### DIFF
--- a/sunspot/lib/sunspot/search/hit.rb
+++ b/sunspot/lib/sunspot/search/hit.rb
@@ -120,15 +120,15 @@ module Sunspot
 
       def stored_value(field_name, dynamic_field_name)
         setup.stored_fields(field_name, dynamic_field_name).each do |field|
-          if value = @stored_values[field.indexed_name]
-            case value
-            when Array
-              return value.map { |item| field.cast(item) }
-            else
-              return field.cast(value)
-            end
+          value = @stored_values[field.indexed_name]
+
+          if Array === value
+            return value.map { |item| field.cast(item) }
+          elsif !value.nil?
+            return field.cast(value)
           end
         end
+
         nil
       end
     end

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -122,6 +122,11 @@ describe 'hits', :type => :search do
     session.search(Post, Namespaced::Comment).hits.first.stored(:featured).should be_true
   end
 
+  it 'should return stored boolean fields that evaluate to false' do
+    stub_full_results('instance' => Post.new, 'featured_bs' => false)
+    session.search(Post, Namespaced::Comment).hits.first.stored(:featured).should == false
+  end
+
   it 'should return stored dynamic fields' do
     stub_full_results('instance' => Post.new, 'custom_string:test_ss' => 'Custom')
     session.search(Post, Namespaced::Comment).hits.first.stored(:custom_string, :test).should == 'Custom'


### PR DESCRIPTION
From the commit message, with some typos corrected:

> As far as I can tell, Sunspot uses nil to represent the non-existence of
> a value for indexing or (in this case) data stored in the Solr index.
> False is a valid value for stored data of boolean type; however, the
> code in Hit#stored_value prior to this commit did not differentiate
> between the two.
