### PR TITLE
Allow faceting on text fields

### DIFF
--- a/sunspot/lib/sunspot/composite_setup.rb
+++ b/sunspot/lib/sunspot/composite_setup.rb
@@ -82,6 +82,15 @@ module Sunspot
       )
     end
 
+    def facetable_field(field_name)
+      field = fields_hash[field_name.to_sym]
+      field ||= text_fields_hash[field_name.to_sym]
+      field || raise(
+        UnrecognizedFieldError,
+        "No field configured for #{@types * ', '} with name '#{field_name}'"
+      )
+    end
+
     # 
     # Get a dynamic field factory for the given base name.
     #

--- a/sunspot/lib/sunspot/dsl/field_query.rb
+++ b/sunspot/lib/sunspot/dsl/field_query.rb
@@ -204,7 +204,7 @@ module Sunspot
         else
           field_names.each do |field_name|
             search_facet = nil
-            field = @setup.field(field_name)
+            field = @setup.facetable_field(field_name)
             facet =
               if options[:time_range]
                 unless field.type.is_a?(Sunspot::Type::TimeType)

--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -100,6 +100,8 @@ module Sunspot
       #
       alias_method :field, :build
 
+      alias_method :facetable_field, :build
+
       # 
       # Generate dynamic fields based on hash returned by data accessor and
       # add the field data to the document.

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -134,6 +134,19 @@ module Sunspot
       [text_field]
     end
 
+    def facetable_field(field_name)
+      field_factory = @field_factories_cache[field_name.to_sym]
+      field_factory ||= @text_field_factories_cache[field_name.to_sym]
+      if field_factory
+        field_factory.build
+      else
+        raise(
+          UnrecognizedFieldError,
+          "No field configured for #{@class_name} with name '#{field_name}'"
+        )
+      end
+    end
+
     #
     # Return one or more stored fields (can be either attribute or text fields)
     # for the given name.

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -40,6 +40,7 @@ describe 'search faceting' do
   end
 
   test_field_type('String', :title, :title, 'Title 1', 'Title 2')
+  test_field_type('Text', :body, :body, 'description1', 'description2')
   test_field_type('Integer', :blog_id, :blog_id, 3, 4)
   test_field_type('Float', :ratings_average, :average_rating, 2.2, 1.1)
   test_field_type('Time', :published_at, :published_at, Time.mktime(2008, 02, 17, 17, 45, 04),


### PR DESCRIPTION
Currently sunspot doesn't recognize text fields as facetable even though it appears to work in solr itself. This patch adds the ability to use text fields in the facet() method.

<!---
@huboard:{"order":24.5}
-->
