### PR TITLE
Custom solr url integration test fix

### DIFF
--- a/sunspot/spec/integration/dynamic_fields_spec.rb
+++ b/sunspot/spec/integration/dynamic_fields_spec.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), 'spec_helper')
+
 describe 'dynamic fields' do
   before :each do
     Sunspot.remove_all

--- a/sunspot/spec/integration/highlighting_spec.rb
+++ b/sunspot/spec/integration/highlighting_spec.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), 'spec_helper')
+
 describe 'keyword highlighting' do
   before :all do
     @posts = []

--- a/sunspot/spec/integration/spec_helper.rb
+++ b/sunspot/spec/integration/spec_helper.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 Spec::Runner.configure do |config|
-  config.before(:each) do
+  config.before(:all) do
     Sunspot.config.solr.url = ENV['SOLR_URL'] || 'http://localhost:8983/solr'
   end
 end

--- a/sunspot/spec/integration/stored_fields_spec.rb
+++ b/sunspot/spec/integration/stored_fields_spec.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), 'spec_helper')
+
 describe 'stored fields' do
   before :all do
     Sunspot.remove_all


### PR DESCRIPTION
Currently, the before(:all) execution from some tests is executed prior the config.before(:each) is executed. It triggers the Session#connection before the custom url setup is done, therefore the default value is used instead of the customized one.

Also, not all spec files required the spec_helper which is fault, because the test are not deterministic.
