### PR TITLE
Fix sunspot:reindex task to contemplate namespaced and 'moduled' models

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -49,7 +49,7 @@ namespace :sunspot do
     unless args[:models]
       models_path = Rails.root.join('app', 'models')
       all_files = Dir.glob(models_path.join('**', '*.rb'))
-      all_models = all_files.map { |path| path.sub(models_path.to_s, '')[0..-4].camelize.constantize rescue nil }.compact
+      all_models = all_files.map { |path| path.sub(models_path.to_s, '')[0..-4].camelize.sub(/^::/, '').constantize rescue nil }.compact
       sunspot_models = all_models.select { |m| m < ActiveRecord::Base and m.searchable? }
     else
       sunspot_models = args[:models].split('+').map{|m| m.constantize}


### PR DESCRIPTION
Currently the rake task `sunspot:reindex` only processes models directly under `app/models/`. This patch fixes this issue, processing models such as `app/models/path/to/model.rb`
