### PR TITLE
Parsing config via ERB first so more advanced config (eg, per machine) becomes possible.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -55,7 +55,7 @@ module Sunspot #:nodoc:
         end
         @hostname
       end
-      
+
       #
       # The port at which to connect to Solr.
       # Defaults to 8981 in test, 8982 in development and 8983 in production.
@@ -138,7 +138,7 @@ module Sunspot #:nodoc:
         @has_master = !!user_configuration_from_key('master_solr')
       end
 
-      # 
+      #
       # The default log_level that should be passed to solr. You can
       # change the individual log_levels in the solr admin interface.
       # Default 'INFO'.
@@ -150,39 +150,39 @@ module Sunspot #:nodoc:
       def log_level
         @log_level ||= (user_configuration_from_key('solr', 'log_level') || 'INFO')
       end
-      
+
       #
       # Should the solr index receive a commit after each http-request.
       # Default true
       #
       # ==== Returns
-      # 
+      #
       # Boolean: auto_commit_after_request?
       #
       def auto_commit_after_request?
-        @auto_commit_after_request ||= 
+        @auto_commit_after_request ||=
           user_configuration_from_key('auto_commit_after_request') != false
       end
-      
+
       #
       # As for #auto_commit_after_request? but only for deletes
       # Default false
       #
       # ==== Returns
-      # 
+      #
       # Boolean: auto_commit_after_delete_request?
       #
       def auto_commit_after_delete_request?
-        @auto_commit_after_delete_request ||= 
+        @auto_commit_after_delete_request ||=
           (user_configuration_from_key('auto_commit_after_delete_request') || false)
       end
-      
-      
+
+
       #
       # The log directory for solr logfiles
       #
       # ==== Returns
-      # 
+      #
       # String:: log_dir
       #
       def log_file
@@ -192,14 +192,14 @@ module Sunspot #:nodoc:
       def data_path
         @data_path ||= user_configuration_from_key('solr', 'data_path') || File.join(::Rails.root, 'solr', 'data', ::Rails.env)
       end
-      
+
       def pid_path
         @pids_path ||= user_configuration_from_key('solr', 'pid_path') || File.join(::Rails.root, 'solr', 'pids', ::Rails.env)
       end
-      
-      # 
+
+      #
       # The solr home directory. Sunspot::Rails expects this directory
-      # to contain a config, data and pids directory. See 
+      # to contain a config, data and pids directory. See
       # Sunspot::Rails::Server.bootstrap for more information.
       #
       # ==== Returns
@@ -215,31 +215,31 @@ module Sunspot #:nodoc:
           end
       end
 
-      # 
+      #
       # Solr start jar
       #
       def solr_jar
         @solr_jar ||= user_configuration_from_key('solr', 'solr_jar')
       end
 
-      # 
+      #
       # Minimum java heap size for Solr instance
       #
       def min_memory
         @min_memory ||= user_configuration_from_key('solr', 'min_memory')
       end
 
-      # 
+      #
       # Maximum java heap size for Solr instance
       #
       def max_memory
         @max_memory ||= user_configuration_from_key('solr', 'max_memory')
       end
-      
+
       private
-      
+
       #
-      # Logging in rails_root/log as solr_<environment>.log as a 
+      # Logging in rails_root/log as solr_<environment>.log as a
       # default.
       #
       # ===== Returns
@@ -249,8 +249,8 @@ module Sunspot #:nodoc:
       def default_log_file_location
         File.join(::Rails.root, 'log', "solr_" + ::Rails.env + ".log")
       end
-      
-      # 
+
+      #
       # return a specific key from the user configuration in config/sunspot.yml
       #
       # ==== Returns
@@ -262,7 +262,7 @@ module Sunspot #:nodoc:
           hash[key] if hash
         end
       end
-      
+
       #
       # Memoized hash of configuration options for the current Rails environment
       # as specified in config/sunspot.yml
@@ -276,44 +276,46 @@ module Sunspot #:nodoc:
           begin
             path = File.join(::Rails.root, 'config', 'sunspot.yml')
             if File.exist?(path)
-              File.open(path) do |file|
-                YAML.load(file)[::Rails.env]
-              end
+              # parse through ERB
+              yaml = ERB.new(File.read(path)).result
+              # parse through YAML
+              YAML.load(yaml)[::Rails.env]
             else
               {}
             end
           end
       end
-    
+
     protected
-    
+
       #
       # When a specific hostname, port and path aren't provided in the
       # sunspot.yml file, look for a key named 'url', then check the
       # environment, then fall back to a sensible localhost default.
       #
-      
+
       def solr_url
         if ENV['SOLR_URL'] || ENV['WEBSOLR_URL']
           URI.parse(ENV['SOLR_URL'] || ENV['WEBSOLR_URL'])
         end
       end
-      
+
       def default_hostname
         'localhost'
       end
-      
+
       def default_port
         { 'test'        => 8981,
           'development' => 8982,
           'production'  => 8983
         }[::Rails.env]  || 8983
       end
-      
+
       def default_path
         '/solr'
       end
-      
+
     end
   end
 end
+


### PR DESCRIPTION
There are many trailing space changes in this commit which may digress. However, the real change is:
- ```
           File.open(path) do |file|
  ```
- ```
             YAML.load(file)[::Rails.env]
  ```
- ```
           end
  ```
- ```
           # parse through ERB
  ```
- ```
           yaml = ERB.new(File.read(path)).result
  ```
- ```
           # parse through YAML
  ```
- ```
           YAML.load(yaml)[::Rails.env]
  ```

A use case for this feature is, I usually put this at the end of YAML config files:
# override the above with local settings from config/private/sunspot.yml

<%=
  file = File.join(Rails.root, "config", "private", "sunspot.yml")
  IO.read(file) if File.exist?(file)
%>

So each machine or developer can have its / her own specific settings which override the common settings in config/sunspot.yml. Powerful and flexible idea, simple implementation.
