### PR TITLE
Added sunspot rails instrumentation

### DIFF
--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -6,6 +6,7 @@ require File.join(File.dirname(__FILE__), 'rails', 'searchable')
 
 module Sunspot #:nodoc:
   module Rails #:nodoc:
+    autoload :SolrInstrumentation, File.join(File.dirname(__FILE__), 'rails', 'solr_instrumentation')
     autoload :StubSessionProxy, File.join(File.dirname(__FILE__), 'rails', 'stub_session_proxy')
     autoload :Server, File.join(File.dirname(__FILE__), 'rails', 'server')
     autoload :VERSION, File.join(File.dirname(__FILE__), 'rails', 'version')

--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -1,0 +1,33 @@
+module Sunspot
+  module Rails
+    class LogSubscriber < ActiveSupport::LogSubscriber
+      def self.runtime=(value)
+        Thread.current["sorl_runtime"] = value
+      end
+
+      def self.runtime
+        Thread.current["sorl_runtime"] ||= 0
+      end
+
+      def self.reset_runtime
+        rt, self.runtime = runtime, 0
+        rt
+      end
+
+      def request(event)
+        self.class.runtime += event.duration
+        return unless logger.debug?
+
+        name = '%s (%.1fms)' % ["SOLR Resquest", event.duration]
+
+        # produces: path=/select parameters={fq: ["type:Tag"], q: rossi, fl: * score, qf: tag_name_text, defType: dismax, start: 0, rows: 20}
+        parameters = event.payload[:parameters].map { |k, v| "#{k}: #{color(v, BOLD, true)}" }.join(', ')
+        request = "path=#{event.payload[:path]} parameters={#{parameters}}"
+
+        debug "  #{color(name, GREEN, true)}  [ #{request} ]"
+      end
+    end
+  end
+end
+
+Sunspot::Rails::LogSubscriber.attach_to :rsolr

--- a/sunspot_rails/lib/sunspot/rails/railtie.rb
+++ b/sunspot_rails/lib/sunspot/rails/railtie.rb
@@ -11,6 +11,16 @@ module Sunspot
         ActiveSupport.on_load(:action_controller) do
           include(Sunspot::Rails::RequestLifecycle)
         end
+        require 'sunspot/rails/log_subscriber'
+        RSolr::Client.module_eval{ include Sunspot::Rails::SolrInstrumentation }
+      end
+
+      # Expose database runtime to controller for logging.
+      initializer "sunspot_rails.log_runtime" do |app|
+        require "sunspot/rails/railties/controller_runtime"
+        ActiveSupport.on_load(:action_controller) do
+          include Sunspot::Rails::Railties::ControllerRuntime
+        end
       end
 
       rake_tasks do

--- a/sunspot_rails/lib/sunspot/rails/railties/controller_runtime.rb
+++ b/sunspot_rails/lib/sunspot/rails/railties/controller_runtime.rb
@@ -1,0 +1,36 @@
+module Sunspot
+  module Rails
+    module Railties
+      module ControllerRuntime
+        extend ActiveSupport::Concern
+
+        protected
+
+        attr_internal :solr_runtime
+
+        def cleanup_view_runtime
+          # TODO only if solr is connected? if not call to super
+
+          solr_rt_before_render = Sunspot::Rails::LogSubscriber.reset_runtime
+          runtime = super
+          solr_rt_after_render = Sunspot::Rails::LogSubscriber.reset_runtime
+          self.solr_runtime = solr_rt_before_render + solr_rt_after_render
+          runtime - solr_rt_after_render
+        end
+
+        def append_info_to_payload(payload)
+          super
+          payload[:solr_runtime] = solr_runtime
+        end
+
+        module ClassMethods
+          def log_process_action(payload)
+            messages, solr_runtime = super, payload[:solr_runtime]
+            messages << ("Solr: %.1fms" % solr_runtime.to_f) if solr_runtime
+            messages
+          end
+        end
+      end
+    end
+  end
+end

--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -1,0 +1,21 @@
+module Sunspot
+  module Rails
+    module SolrInstrumentation
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method :request_without_as_instrumentation, :request
+        alias_method :request, :request_with_as_instrumentation
+      end
+
+      module InstanceMethods
+        def request_with_as_instrumentation(path, params={}, *extra)
+          ActiveSupport::Notifications.instrument("request.rsolr",
+                                                  {:path => path, :parameters => params}) do
+            request_without_as_instrumentation(path, params, *extra)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi!

I've added instrumentation of the request command for rails 3 applications.

Maybe someone consider it interesting

Example log for one action:

.....
 SOLR Resquest (4.6ms)  [ path=/select parameters={fq: ["type:Product"], start: 0, rows: 30, facet: true, f.product_category_id_i.facet.mincount: 1, facet.field: ["product_category_id_i"], q: _:_} ]
......

Completed 200 OK in 348ms (Views: 226.1ms | ActiveRecord: 1.4ms | Solr: 4.6ms)
