### PR TITLE
Use POST for all requests

### DIFF
--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -1,6 +1,11 @@
 module Sunspot
   module Search #:nodoc:
-    
+    # We need this class to encode the params Hash in a querystring
+    #
+    class Helper
+      include Singleton
+      include RSolr::Connection::Utils
+    end
     # 
     # This class encapsulates the results of a Solr search. It provides access
     # to search results, total result count, facets, and pagination information.
@@ -33,7 +38,8 @@ module Sunspot
       def execute
         reset
         params = @query.to_params
-        @solr_result = @connection.request("/#{request_handler}", params, {:header => {'Content-Type' => 'application/x-www-form-urlencoded'}})
+        response = @connection.connection.post("/#{request_handler}", Helper.instance.hash_to_query(params), {:wt=>:ruby}, {'Content-Type' => 'application/x-www-form-urlencoded'})
+        @solr_result = @connection.send(:adapt_response, response)
         self
       end
 


### PR DESCRIPTION
Use POST for all requests, preventing bugs caused by URLs becoming too long because of too many parameters.
