### PR TITLE
Fixed deprecation warning for class_inheritable_attribute in rails 3.1

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -67,8 +67,8 @@ module Sunspot #:nodoc:
             extend ClassMethods
             include InstanceMethods
 
-            class_inheritable_hash :sunspot_options
-            
+            class_attribute :sunspot_options
+
             unless options[:auto_index] == false
               before_save :maybe_mark_for_auto_indexing
               after_save :maybe_auto_index


### PR DESCRIPTION
I kept getting these warnings with my Rails 3.1 app:

```
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from searchable at /Users/steveschwartz/.rvm/gems/ruby-1.9.2-p0@jshub/bundler/gems/sunspot-53175c3be926/sunspot_rails/lib/sunspot/rails/searchable.rb:70)
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from searchable at /Users/steveschwartz/.rvm/gems/ruby-1.9.2-p0@jshub/bundler/gems/sunspot-53175c3be926/sunspot_rails/lib/sunspot/rails/searchable.rb:84)
```

From what I understand, `class_inheritable_hash` functioned like `class_inheritable_attribute` but performed a merge with the attribute of the superclass (unsure whether or not `class_inheritable_attribute` did that or not). At any rate, those methods are gone, so I just changed to using `class_attribute`.

I ran the specs with the rails2 and rails3 dependencies and everything seems to check out, but I'm not sure if there were any specs that tested the superclass merging behavior. Also, in case there's anything I missed, [see relevant fix](https://github.com/norman/friendly_id/pull/93/files) in the friendly_id gem
