### PR TITLE
fixing specs failing with a 3 for 2 argument error (caused by 81ef102)

### DIFF
--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -54,7 +54,7 @@ module Mock
       @optims << Time.now
     end
 
-    def request(path, params)
+    def request(path, params, args = {})
       unless path == "/#{@expected_handler}"
         raise ArgumentError, "Expected request to #{@expected_handler} request handler"
       end


### PR DESCRIPTION
Adding an optional 3rd argument on the mock connection to be compatible with the changes in 81ef102
