### PR TITLE
check that java is installed upon creation of a Sunspot::Server

### DIFF
--- a/sunspot/lib/sunspot/java.rb
+++ b/sunspot/lib/sunspot/java.rb
@@ -1,0 +1,8 @@
+module Sunspot
+  module Java
+    def self.installed?
+      `java -version &> /dev/null`
+      $?.success?
+    end
+  end
+end

--- a/sunspot/spec/api/server_spec.rb
+++ b/sunspot/spec/api/server_spec.rb
@@ -52,6 +52,13 @@ describe Sunspot::Server do
     @server.run
   end
 
+  it 'raises an error if java is missing' do
+    Sunspot::Java.stub(:installed? => false)
+    expect {
+     Sunspot::Server.new
+    }.to raise_error(Sunspot::Server::JavaMissing)
+  end
+
   describe 'with logging' do
     before :each do
       @server.log_level = 'info'


### PR DESCRIPTION
I set up a new dev environment the other day that had no JRE installed and found that Sunspot::Server.new.start doesnt complain about it, leaving me confused as to why my solr server wasnt being started. This patch makes it fail loudly
