### PR TITLE
rake sunspot:reindex uses ActiveRecord::Base.subclasses and eager_load!s all Engines

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -47,9 +47,16 @@ namespace :sunspot do
       reindex_options[:batch_size] = args[:batch_size].to_i if args[:batch_size].to_i > 0
     end
     unless args[:models]
-      Rails::Application.eager_load!
-      Rails::Application.railties.engines.map { |e| e.eager_load! }
-      all_models = ActiveRecord::Base.subclasses
+      if defined?(Rails) && Rails::VERSION::MAJOR == 3
+        Rails::Application.eager_load!
+        Rails::Application.railties.engines.map { |e| e.eager_load! }
+        all_models = ActiveRecord::Base.subclasses
+      else
+        models_path = Rails.root.join('app', 'models')
+        all_files = Dir.glob(models_path.join('**', '*.rb'))
+        all_models = all_files.map { |path| path.sub(models_path.to_s, '')[0..-4].camelize.sub(/^::/, '').constantize rescue nil }.compact
+        all_models = all_models.select { |m| m < ActiveRecord::Base }
+      end
       sunspot_models = all_models.select { |m| m.searchable? }
     else
       sunspot_models = args[:models].split('+').map{|m| m.constantize}


### PR DESCRIPTION
Fixes the problem where you have models not under Rails.root/app/models
