### PR TITLE
Update spec_helper path to run specs on ruby 1.9.2

### DIFF
--- a/sunspot/spec/api/adapters_spec.rb
+++ b/sunspot/spec/api/adapters_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::Adapters::InstanceAdapter do
   it "finds adapter by superclass" do

--- a/sunspot/spec/api/binding_spec.rb
+++ b/sunspot/spec/api/binding_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe "DSL bindings" do
   it 'should give access to calling context\'s methods in search DSL' do

--- a/sunspot/spec/api/indexer/attributes_spec.rb
+++ b/sunspot/spec/api/indexer/attributes_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 require 'bigdecimal'
 
 describe 'indexing attribute fields', :type => :indexer do

--- a/sunspot/spec/api/indexer/batch_spec.rb
+++ b/sunspot/spec/api/indexer/batch_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'batch indexing', :type => :indexer do
   it 'should send all batched adds in a single request' do

--- a/sunspot/spec/api/indexer/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/indexer/dynamic_fields_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'indexing dynamic fields' do
   it 'indexes string data' do

--- a/sunspot/spec/api/indexer/fixed_fields_spec.rb
+++ b/sunspot/spec/api/indexer/fixed_fields_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'indexing fixed fields', :type => :indexer do
   it 'should index id' do

--- a/sunspot/spec/api/indexer/fulltext_spec.rb
+++ b/sunspot/spec/api/indexer/fulltext_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'indexing fulltext fields' do
   it 'indexes text field' do

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'document removal', :type => :indexer do
   it 'removes an object from the index' do

--- a/sunspot/spec/api/indexer/spec_helper.rb
+++ b/sunspot/spec/api/indexer/spec_helper.rb
@@ -1,1 +1,1 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))

--- a/sunspot/spec/api/indexer_spec.rb
+++ b/sunspot/spec/api/indexer_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'indexer', :type => :indexer do
   it 'should completely wipe setup if class redefined (reloaded)' do

--- a/sunspot/spec/api/query/advanced_manipulation_examples.rb
+++ b/sunspot/spec/api/query/advanced_manipulation_examples.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 shared_examples_for "query with advanced manipulation" do
   describe 'adjust_solr_params' do

--- a/sunspot/spec/api/query/dsl_spec.rb
+++ b/sunspot/spec/api/query/dsl_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'query DSL', :type => :query do
   it 'should allow building search using block argument rather than instance_eval' do

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -1,5 +1,3 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
-
 shared_examples_for "facetable query" do
   describe 'on fields' do
     it 'does not turn faceting on if no facet requested' do

--- a/sunspot/spec/api/query/fulltext_examples.rb
+++ b/sunspot/spec/api/query/fulltext_examples.rb
@@ -1,5 +1,3 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
-
 shared_examples_for 'fulltext query' do
   it 'searches by keywords' do
     search do

--- a/sunspot/spec/api/query/function_spec.rb
+++ b/sunspot/spec/api/query/function_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'function query' do
   it "should send query to solr with boost function" do

--- a/sunspot/spec/api/query/geo_examples.rb
+++ b/sunspot/spec/api/query/geo_examples.rb
@@ -1,4 +1,3 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'bigdecimal'
 
 shared_examples_for 'geohash query' do

--- a/sunspot/spec/api/query/highlighting_examples.rb
+++ b/sunspot/spec/api/query/highlighting_examples.rb
@@ -1,5 +1,3 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
-
 shared_examples_for "query with highlighting support" do
   it 'should not send highlight parameter when highlight not requested' do
     search do

--- a/sunspot/spec/api/query/more_like_this_spec.rb
+++ b/sunspot/spec/api/query/more_like_this_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'more_like_this' do
   before :each do

--- a/sunspot/spec/api/query/ordering_pagination_examples.rb
+++ b/sunspot/spec/api/query/ordering_pagination_examples.rb
@@ -1,5 +1,3 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
-
 shared_examples_for 'sortable query' do
   it 'paginates using default per_page when page not provided' do
     search

--- a/sunspot/spec/api/query/spec_helper.rb
+++ b/sunspot/spec/api/query/spec_helper.rb
@@ -1,1 +1,1 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))

--- a/sunspot/spec/api/query/standard_spec.rb
+++ b/sunspot/spec/api/query/standard_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'standard query', :type => :query do
   it_should_behave_like "scoped query"

--- a/sunspot/spec/api/search/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/search/dynamic_fields_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'search with dynamic fields' do
   it 'returns dynamic string facet' do

--- a/sunspot/spec/api/search/faceting_spec.rb
+++ b/sunspot/spec/api/search/faceting_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'faceting', :type => :search do
   it 'returns field name for facet' do

--- a/sunspot/spec/api/search/highlighting_spec.rb
+++ b/sunspot/spec/api/search/highlighting_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'search with highlighting results', :type => :search do
   before :each do

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'hits', :type => :search do
   it 'should return hits without loading instances' do

--- a/sunspot/spec/api/search/results_spec.rb
+++ b/sunspot/spec/api/search/results_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'search results', :type => :search do
   it 'loads single result' do

--- a/sunspot/spec/api/search/search_spec.rb
+++ b/sunspot/spec/api/search/search_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::Search do
   it 'should allow access to the data accessor' do

--- a/sunspot/spec/api/search/spec_helper.rb
+++ b/sunspot/spec/api/search/spec_helper.rb
@@ -1,1 +1,1 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))

--- a/sunspot/spec/api/server_spec.rb
+++ b/sunspot/spec/api/server_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 require 'tempfile'
 
 describe Sunspot::Server do

--- a/sunspot/spec/api/session_proxy/class_sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/class_sharding_session_proxy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::SessionProxy::ClassShardingSessionProxy do
   before do

--- a/sunspot/spec/api/session_proxy/id_sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/id_sharding_session_proxy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::SessionProxy::ShardingSessionProxy do
   before do

--- a/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::SessionProxy::MasterSlaveSessionProxy do
   before :each do

--- a/sunspot/spec/api/session_proxy/sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/sharding_session_proxy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::SessionProxy::ShardingSessionProxy do
   before do

--- a/sunspot/spec/api/session_proxy/silent_fail_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/silent_fail_session_proxy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::SessionProxy::ShardingSessionProxy do
   

--- a/sunspot/spec/api/session_proxy/spec_helper.rb
+++ b/sunspot/spec/api/session_proxy/spec_helper.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))
 
 shared_examples_for 'session proxy' do
   Sunspot::Session.public_instance_methods(false).each do |method|

--- a/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 require 'weakref'
 
 describe Sunspot::SessionProxy::ThreadLocalSessionProxy do

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 shared_examples_for 'all sessions' do
   context '#index()' do

--- a/sunspot/spec/api/spec_helper.rb
+++ b/sunspot/spec/api/spec_helper.rb
@@ -1,3 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))
 
 Dir.glob(File.join(File.dirname(__FILE__), '**', '*_examples.rb')).each { |shared| require(shared) }

--- a/sunspot/spec/api/sunspot_spec.rb
+++ b/sunspot/spec/api/sunspot_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot do
   describe "reset!" do

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'search faceting' do
   def self.test_field_type(name, attribute, field, *args)

--- a/sunspot/spec/integration/indexing_spec.rb
+++ b/sunspot/spec/integration/indexing_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'indexing' do
   it 'should index non-multivalued field with newlines' do

--- a/sunspot/spec/integration/keyword_search_spec.rb
+++ b/sunspot/spec/integration/keyword_search_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'keyword search' do
   describe 'generally' do

--- a/sunspot/spec/integration/local_search_spec.rb
+++ b/sunspot/spec/integration/local_search_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'local search' do
   ORIGIN = [40.7246062, -73.9969018]

--- a/sunspot/spec/integration/more_like_this_spec.rb
+++ b/sunspot/spec/integration/more_like_this_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'more_like_this' do
   before :all do

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'scoped_search' do
   def self.test_field_type(name, attribute, field, *values)

--- a/sunspot/spec/integration/spec_helper.rb
+++ b/sunspot/spec/integration/spec_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))
 
 Spec::Runner.configure do |config|
   config.before(:each) do

--- a/sunspot/spec/integration/test_pagination.rb
+++ b/sunspot/spec/integration/test_pagination.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'pagination' do
   before :all do


### PR DESCRIPTION
Ruby 1.9.2 no longer includes "." in LOAD_PATH.
