### PR TITLE
Specify activesupport/to_json load order to fix to_json bug

### DIFF
--- a/sunspot_rails/lib/sunspot_rails.rb
+++ b/sunspot_rails/lib/sunspot_rails.rb
@@ -1,3 +1,8 @@
+# This needs to be loaded before sunspot/search/paginated_collection
+# or #to_json gets defined in Object breaking delegation to Array via
+# method_missing
+require 'active_support/core_ext/object/to_json' if Rails::VERSION::MAJOR == 3
+
 require 'sunspot/rails'
 
 if Rails::VERSION::MAJOR == 3


### PR DESCRIPTION
This was a nasty bug to track down. In brief, I was getting an empty json hash returned when calling to_json on  collection.results. 

The problem was that we are defining the proxy class before activesupport injects to_json into Object. This commit makes sure that doesn't happen.
