### PR TITLE
in sunspot_rails, sunspot.yml doesn't pass 'pid_path' option to Sunspot::Server

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -195,9 +195,10 @@ module Sunspot #:nodoc:
         @data_path ||= user_configuration_from_key('solr', 'data_path') || File.join(::Rails.root, 'solr', 'data', ::Rails.env)
       end
       
-      def pid_path
-        @pids_path ||= user_configuration_from_key('solr', 'pid_path') || File.join(::Rails.root, 'solr', 'pids', ::Rails.env)
+      def pid_dir
+        @pid_dir ||= user_configuration_from_key('solr', 'pid_dir') || File.join(::Rails.root, 'solr', 'pids', ::Rails.env)
       end
+
       
       # 
       # The solr home directory. Sunspot::Rails expects this directory

--- a/sunspot_rails/lib/sunspot/rails/server.rb
+++ b/sunspot_rails/lib/sunspot/rails/server.rb
@@ -41,7 +41,7 @@ module Sunspot
       # Directory in which to store PID files
       #
       def pid_dir
-        File.join(::Rails.root, 'tmp', 'pids')
+        configuration.pid_dir || File.join(::Rails.root, 'tmp', 'pids')
       end
 
       # 

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -55,9 +55,9 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
     @config.data_path.should == '/some/path/solr/data/test'
   end
 
-  it "should handle the 'pid_path' property when not set" do
+  it "should handle the 'pid_dir' property when not set" do
     Rails.should_receive(:root).at_least(1).and_return('/some/path')
-    @config.pid_path.should == '/some/path/solr/pids/test'
+    @config.pid_dir.should == '/some/path/solr/pids/test'
   end
   
   it "should handle the 'auto_commit_after_request' propery when not set" do
@@ -99,8 +99,8 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
     @config.data_path.should == '/my_superior_path/data'
   end
 
-  it "should handle the 'pid_path' property when set" do
-    @config.pid_path.should == '/my_superior_path/pids'
+  it "should handle the 'pid_dir' property when set" do
+    @config.pid_dir.should == '/my_superior_path/pids'
   end
   
   it "should handle the 'solr_home' property when set" do

--- a/sunspot_rails/spec/rails2/config/sunspot.yml
+++ b/sunspot_rails/spec/rails2/config/sunspot.yml
@@ -13,7 +13,7 @@ config_test:
     path: /solr/idx
     log_level: WARNING
     data_path: /my_superior_path/data
-    pid_path: /my_superior_path/pids
+    pid_dir: /my_superior_path/pids
     solr_home: /my_superior_path
   auto_commit_after_request: false
   auto_commit_after_delete_request: true

--- a/sunspot_rails/spec/rails3/config/sunspot.yml
+++ b/sunspot_rails/spec/rails3/config/sunspot.yml
@@ -13,7 +13,7 @@ config_test:
     path: /solr/idx
     log_level: WARNING
     data_path: /my_superior_path/data
-    pid_path: /my_superior_path/pids
+    pid_dir: /my_superior_path/pids
     solr_home: /my_superior_path
   auto_commit_after_request: false
   auto_commit_after_delete_request: true

--- a/sunspot_rails/spec/server_spec.rb
+++ b/sunspot_rails/spec/server_spec.rb
@@ -16,7 +16,7 @@ describe Sunspot::Rails::Server do
   end
 
   it "sets the correct Solr PID path" do
-    @server.pid_path.should == File.join(Rails.root, 'tmp', 'pids', 'sunspot-solr-test.pid')
+    @server.pid_path.should == File.join(@server.pid_dir, 'sunspot-solr-test.pid')
   end
 
   it "sets the correct Solr data dir" do


### PR DESCRIPTION
When starting Solr via `rake sunspot:solr:start`, it set's a PID file in /tmp/pids/sunspot-solr-RAILS_ENV.pid

The Sunspot::Rails::Configuration currently reads a 'pid_path' attribute from the sunspot.yml, but the Sunspot::Rails::Server ignores this setting in its `pid_dir` function.

There were tests in the specs to make sure that the 'pid_path' setting got read, but none that it applied the Server class instance.

Writing this patch, I tried to keep the changes to the Sunspot::Rails code consistant to the terminology used in Sunspot, so I changed the function names and references to 'pid_dir', as a 'pid_path' most likely implies the full name of a file rather than a .pid file's location. 

Let me know if you'd like to see anything more or less out of this changeset. 
