### PR TITLE
made Sunspot::Rails::slave_config method actually use the arguments passed into it

### DIFF
--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -48,9 +48,9 @@ module Sunspot #:nodoc:
       def slave_config(sunspot_rails_configuration)
         config = Sunspot::Configuration.build
         config.solr.url = URI::HTTP.build(
-          :host => configuration.hostname,
-          :port => configuration.port,
-          :path => configuration.path
+          :host => sunspot_rails_configuration.hostname,
+          :port => sunspot_rails_configuration.port,
+          :path => sunspot_rails_configuration.path
         ).to_s
         config
       end


### PR DESCRIPTION
Pretty sure this patch is a no-brainer.
