### PR TITLE
Update pagination instructions to work with WillPaginate 3

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -132,12 +132,17 @@ See Sunspot.search for more information.
 === Work with search results (Haml for readability):
 
   .facets
-    ul.blog_facet
+    %ul.blog_facet
       - @search.facet(:blog_id).rows.each do |row|
-        li.facet_row
+        %li.facet_row
           = link_to(row.instance.name, params.merge(:blog_id => row.value))
           %span.count== (#{row.count})
-  .page_info== Displaying page #{@search.hits.page} of #{@search.hits.per_page} out of #{@search.total} results
+
+  .page_info
+    %h4
+      %span.count= pluralize(@search.total, 'result')
+      %span.pages Page #{@search.hits.current_page} of #{@search.hits.total_pages} 
+
   - @search.each_hit_with_result do |hit, post|
     .search_result
       %h3.title


### PR DESCRIPTION
I've updated the read me so pagination instructions are compatible with WillPaginate 3 and tweaked the markup slightly to try to make it more explanatory.

I'm not sure whether using `pluralize` in the example is a huge issue. It is of course a Rails view helper so anyone using Sunspot outside of Rails won't be able to use it. Maybe worth removing or at least mentioning. What do you think?

BTW, I wanted to use syntax highlighting but I'm not sure RDoc can handle Github's

``` ruby
Backtick.style(:code_blocks)
```

Thanks for Sunspot. It's amazing!
