### PR TITLE
Pick the user configuration from sunspot.yml

### DIFF
--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -48,9 +48,9 @@ module Sunspot #:nodoc:
       def slave_config(sunspot_rails_configuration)
         config = Sunspot::Configuration.build
         config.solr.url = URI::HTTP.build(
-          :host => configuration.hostname,
-          :port => configuration.port,
-          :path => configuration.path
+          :host => sunspot_rails_configuration.hostname,
+          :port => sunspot_rails_configuration.port,
+          :path => sunspot_rails_configuration.path
         ).to_s
         config
       end


### PR DESCRIPTION
Although, the sunspot_rails_configuration is passed in as a parameter, the solr url is built with the default configuration object.  
