### PR TITLE
Update outdated rdoc mentioning Sunspot::DSL::Query

### DIFF
--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -328,7 +328,8 @@ module Sunspot
     #   end
     #
     # See Sunspot::DSL::Search, Sunspot::DSL::Scope, Sunspot::DSL::FieldQuery
-    # and Sunspot::DSL::Query for the full API presented inside the block.
+    # and Sunspot::DSL::StandardQuery for the full API presented inside the
+    # block.
     #
     def search(*types, &block)
       session.search(*types, &block)

--- a/sunspot/lib/sunspot/dsl/scope.rb
+++ b/sunspot/lib/sunspot/dsl/scope.rb
@@ -3,9 +3,9 @@ module Sunspot
     # 
     # This DSL presents methods for constructing restrictions and other query
     # elements that are specific to fields. As well as being a superclass of
-    # Sunspot::DSL::Query, which presents the main query block, this DSL class
-    # is also used directly inside the #dynamic() block, which only allows
-    # operations on specific fields.
+    # Sunspot::DSL::StandardQuery, which presents the main query block, this
+    # DSL class is also used directly inside the #dynamic() block, which only
+    # allows operations on specific fields.
     #
     class Scope
       NONE = Object.new
@@ -41,7 +41,7 @@ module Sunspot
       #
       # ==== Returns
       #
-      # Sunspot::DSL::Query::Restriction::
+      # Sunspot::DSL::Restriction::
       #   Restriction DSL object (if only one argument is passed which is a
       #   field name)
       #

--- a/sunspot/lib/sunspot/dsl/search.rb
+++ b/sunspot/lib/sunspot/dsl/search.rb
@@ -2,8 +2,8 @@ module Sunspot
   module DSL
     # 
     # This top-level DSL class is the context in which the block passed to
-    # Sunspot.query. See Sunspot::DSL::Query, Sunspot::DSL::FieldQuery, and
-    # Sunspot::DSL::Scope for the full API presented.
+    # Sunspot.query. See Sunspot::DSL::StandardQuery, Sunspot::DSL::FieldQuery,
+    # and Sunspot::DSL::Scope for the full API presented.
     #
     class Search < StandardQuery
       def initialize(search, setup) #:nodoc:


### PR DESCRIPTION
Query has been renamed to StandardQuery, but the rdoc documentation
still included references to Query, leading to missing links.
