### PR TITLE
Java dependency belongs in sunspot_solr

### DIFF
--- a/sunspot/lib/sunspot/java.rb
+++ b/sunspot/lib/sunspot/java.rb
@@ -1,8 +1,0 @@
-module Sunspot
-  module Java
-    def self.installed?
-      `java -version &> /dev/null`
-      $?.success?
-    end
-  end
-end

--- a/sunspot_solr/lib/sunspot/solr/java.rb
+++ b/sunspot_solr/lib/sunspot/solr/java.rb
@@ -1,0 +1,10 @@
+module Sunspot
+  module Solr
+    module Java
+      def self.installed?
+        `java -version &> /dev/null`
+        $?.success?
+      end
+    end
+  end
+end

--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -1,7 +1,7 @@
 require 'escape'
 require 'set'
 require 'tempfile'
-require 'sunspot/java'
+require 'sunspot/solr/java'
 
 module Sunspot
   module Solr
@@ -144,7 +144,7 @@ module Sunspot
 
       def ensure_java_installed
         unless defined?(@java_installed)
-          @java_installed = Sunspot::Java.installed?
+          @java_installed = Sunspot::Solr::Java.installed?
           unless @java_installed
             raise JavaMissing.new("You need a Java Runtime Environment to run the Solr server")
           end

--- a/sunspot_solr/spec/server_spec.rb
+++ b/sunspot_solr/spec/server_spec.rb
@@ -53,7 +53,7 @@ describe Sunspot::Solr::Server do
   end
 
   it 'raises an error if java is missing' do
-    Sunspot::Java.stub(:installed? => false)
+    Sunspot::Solr::Java.stub(:installed? => false)
     expect {
      Sunspot::Solr::Server.new
     }.to raise_error(Sunspot::Solr::Server::JavaMissing)


### PR DESCRIPTION
Fixes http://groups.google.com/group/ruby-sunspot/browse_thread/thread/92c79721218ca565?hl=en

Perhaps master README changes associated with sunspot_solr extraction should be backed out until sunspot 1.3 final is out as well?
