### PR TITLE
Added formatter and fragmenter advanced highlighter options.

### DIFF
--- a/sunspot/lib/sunspot/query/highlighting.rb
+++ b/sunspot/lib/sunspot/query/highlighting.rb
@@ -9,7 +9,7 @@ module Sunspot
         @options = options
       end
 
-      # 
+      #
       # Return Solr highlighting params
       #
       def to_params
@@ -36,6 +36,13 @@ module Sunspot
             params.merge!(make_params('requireFieldMatch', 'true'))
           end
         end
+        if formatter = @options[:formatter]
+          params.merge!(make_params('formatter', formatter))
+        end
+        if fragmenter = @options[:fragmenter]
+          params.merge!(make_params('fragmenter', fragmenter))
+        end
+
         params
       end
 

--- a/sunspot/spec/api/query/highlighting_examples.rb
+++ b/sunspot/spec/api/query/highlighting_examples.rb
@@ -220,4 +220,26 @@ shared_examples_for "query with highlighting support" do
       :"f.body_textsv.hl.snippets" => 1
     )
   end
+
+  it 'sets the formatter for highlight output' do
+    search do
+      keywords 'test' do
+        highlight :title, :formatter => 'formatter'
+      end
+    end
+    connection.should have_last_search_with(
+      :"f.title_text.hl.formatter" => 'formatter'
+    )
+  end
+
+  it 'sets the text snippet generator for highlighted text' do
+    search do
+      keywords 'test' do
+        highlight :title, :fragmenter => 'example_fragmenter'
+      end
+    end
+    connection.should have_last_search_with(
+      :"f.title_text.hl.fragmenter" => 'example_fragmenter'
+    )
+  end
 end


### PR DESCRIPTION
I wanted to have access to some of the more advanced highlighter options like formatter and fragmenter. This patch adds support for those.

Currently, the only valid value for :formatter is "simple", but it could be nice for future support.

I want to use a regex-based fragmenter, and the :fragmenter setting is necessary for that. This is a Solr 1.3 feature.
