### PR TITLE
Added disable_solr to sunspot.yml for temporarily disabling solr

### DIFF
--- a/sunspot_rails/.gitignore
+++ b/sunspot_rails/.gitignore
@@ -1,3 +1,4 @@
+spec/rails3
 sunspot-solr.pid
 doc
 pkg/*

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -238,7 +238,19 @@ module Sunspot #:nodoc:
       def max_memory
         @max_memory ||= user_configuration_from_key('solr', 'max_memory')
       end
-      
+
+      #
+      # Whether or not to disable Solr.
+      # Defaults to false. 
+      #
+      def disable_solr?
+        @disable_solr ||= (user_configuration_from_key('disable_solr') || false)
+        if @disable_solr==true && Sunspot.session != Sunspot::Rails::StubSessionProxy
+          Sunspot.session = StubSessionProxy.new(Sunspot.session)
+        end
+        @disable_solr
+      end
+ 
       private
       
       #

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -114,8 +114,32 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
   it "should handle the 'auto_commit_after_delete_request' propery when set" do
     @config.auto_commit_after_delete_request?.should == true
   end
+
+  it "should not change the session when false (the default value)" do
+    @config.disable_solr?.should == false
+    Sunspot.session.class.should == Sunspot::SessionProxy::ThreadLocalSessionProxy
+  end
 end
 
+describe "disable_solr" do
+  before(:each) do
+    ::Rails.stub!(:env => 'disabled')
+    @config = Sunspot::Rails::Configuration.new
+  end
+
+  after(:each) do
+    ::Rails.stub!(:env => 'config_test')
+    if Sunspot.session.class == Sunspot::Rails::StubSessionProxy
+      Sunspot.session = Sunspot.session.original_session
+    end
+  end
+
+  it "should should disable Solr when set to true" do
+    ::Rails.stub!(:env => 'disabled')
+    @config = Sunspot::Rails::Configuration.new
+    @config.disable_solr?.should == true
+  end
+end
 
 describe Sunspot::Rails::Configuration, "with ENV['SOLR_URL'] overriding sunspot.yml" do
   before(:all) do

--- a/sunspot_rails/spec/rails_template/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot.yml
@@ -17,3 +17,5 @@ config_test:
     solr_home: /my_superior_path
   auto_commit_after_request: false
   auto_commit_after_delete_request: true
+disabled:
+  disable_solr: true

--- a/sunspot_rails/spec/session_spec.rb
+++ b/sunspot_rails/spec/session_spec.rb
@@ -10,6 +10,32 @@ describe 'Sunspot::Rails session' do
   it 'should not create a separate master/slave session if no master configured' do
   end
 
+  it 'should do nothing to the session if disable_solr: false (default) ' do
+    @config = Sunspot::Rails::Configuration.new
+    @config.disable_solr?.should == false
+    Sunspot.session.class.should == Sunspot::SessionProxy::ThreadLocalSessionProxy
+  end
+
+  describe 'disable_solr' do
+    before(:each) do
+      ::Rails.stub!(:env => 'disabled')
+      @config = Sunspot::Rails::Configuration.new
+    end
+
+    after(:each) do
+      ::Rails.stub!(:env => 'config_test')
+      if Sunspot.session.class == Sunspot::Rails::StubSessionProxy
+        Sunspot.session = Sunspot.session.original_session
+      end
+    end
+
+    it 'should stub the session if disable_solr: true' do
+      @config.disable_solr?.should == true
+      Sunspot.session.class.should == Sunspot::Rails::StubSessionProxy
+      Sunspot.session = Sunspot.session.original_session
+    end
+  end
+
   private
 
   def with_configuration(options)


### PR DESCRIPTION
Hi,
  I added a disable_solr to sunspot.yml for temporarily disabling your rails application's communications with Solr.  This is useful for us because we're using a mounted file system that takes several seconds to synchronize.  It's nice to be able to disable your Solr communications before seeding your database, because it allows time for the files to propagate on your shared network file system.  Once the files finish propagating, you can reenable  Solr, by modifying the sunspot.yml file, and then run 

rake sunspot:solr:reindex

  David :)
