### PR TITLE
Send search parameters in the body, not the query string.

### DIFF
--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -35,7 +35,7 @@ module Sunspot
       def execute
         reset
         params = @query.to_params
-        @solr_result = @connection.post "#{request_handler}", :params => params, :headers => { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        @solr_result = @connection.post "#{request_handler}", :data => params
         self
       end
 


### PR DESCRIPTION
The version of Jetty bundled with Sunspot (as of this commit) aggregates
query parameters and POST data when it presents parameters to a webapp.

Winstone 0.9.10, which otherwise runs Solr well, doesn't do this.
Sending POST /select to Winstone yields a response with a 500 status
code and report errors like this in the log:

```
INFO: [] webapp=/solr path=/select params={} status=500 QTime=1
Oct 10, 2011 12:31:00 AM org.apache.solr.common.SolrException log
SEVERE: java.lang.NullPointerException
  at java.io.StringReader.<init>(StringReader.java:33)
  at org.apache.lucene.queryParser.QueryParser.parse(QueryParser.java:197)
  at org.apache.solr.search.LuceneQParser.parse(LuceneQParserPlugin.java:78)
  at org.apache.solr.search.QParser.getQuery(QParser.java:131)
  at org.apache.solr.handler.component.QueryComponent.prepare(QueryComponent.java:89)
  at org.apache.solr.handler.component.SearchHandler.handleRequestBody(SearchHandler.java:174)
  at org.apache.solr.handler.RequestHandlerBase.handleRequest(RequestHandlerBase.java:131)
  at org.apache.solr.core.SolrCore.execute(SolrCore.java:1316)
  at org.apache.solr.servlet.SolrDispatchFilter.execute(SolrDispatchFilter.java:338)
  at org.apache.solr.servlet.SolrDispatchFilter.doFilter(SolrDispatchFilter.java:241)
  at winstone.FilterConfiguration.execute(FilterConfiguration.java:195)
  at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:368)
  at winstone.RequestDispatcher.forward(RequestDispatcher.java:333)
  at winstone.RequestHandlerThread.processRequest(RequestHandlerThread.java:244)
  at winstone.RequestHandlerThread.run(RequestHandlerThread.java:150)
  at java.lang.Thread.run(Thread.java:680)
```

which looks like Solr is receiving POST /select with no parameters.

To be fair, I think Winstone is actually violating Servlet API v2.4 in
this case.  Section SRV.4.1 of the API specification states "Data from
the query string and the post body are aggregated into the request
parameter set", which doesn't seem to be happening here.  However, this
fix is not that large, and even saves on some code by saving us the
hassle of having to set the body's content type (RSolr 1.0.2 will do
that for us when given a post body).
