### PR TITLE
Ability to specify which IP address Solr binds to

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/server.rb
+++ b/sunspot_rails/lib/sunspot/rails/server.rb
@@ -45,6 +45,13 @@ module Sunspot
       end
 
       # 
+      # Host on which to run Solr
+      #
+      def host
+        configuration.hostname
+      end
+
+      # 
       # Port on which to run Solr
       #
       def port

--- a/sunspot_solr/bin/sunspot-solr
+++ b/sunspot_solr/bin/sunspot-solr
@@ -22,6 +22,10 @@ OptionParser.new do |opts|
     server.port = p
   end
 
+  opts.on '-h', '--hostname=host', 'Host on which to run Solr (default 0.0.0.0)' do |h|
+    server.host = h
+  end
+
   opts.on '-d', '--data-directory=DIRECTORY', 'Solr data directory' do |d|
     server.solr_data_dir = File.expand_path(d)
   end

--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -20,7 +20,7 @@ module Sunspot
 
       LOG_LEVELS = Set['SEVERE', 'WARNING', 'INFO', 'CONFIG', 'FINE', 'FINER', 'FINEST']
 
-      attr_accessor :min_memory, :max_memory, :port, :solr_data_dir, :solr_home, :log_file
+      attr_accessor :min_memory, :max_memory, :host, :port, :solr_data_dir, :solr_home, :log_file
       attr_writer :pid_dir, :pid_file, :log_level, :solr_data_dir, :solr_home, :solr_jar
 
       def initialize(*args)
@@ -95,6 +95,7 @@ module Sunspot
         command << "-Xms#{min_memory}" if min_memory
         command << "-Xmx#{max_memory}" if max_memory
         command << "-Djetty.port=#{port}" if port
+        command << "-Djetty.host=#{host}" if host
         command << "-Dsolr.data.dir=#{solr_data_dir}" if solr_data_dir
         command << "-Dsolr.solr.home=#{solr_home}" if solr_home
         command << "-Djava.util.logging.config.file=#{logging_config_path}" if logging_config_path

--- a/sunspot_solr/solr/etc/jetty.xml
+++ b/sunspot_solr/solr/etc/jetty.xml
@@ -70,6 +70,7 @@
     <Call name="addConnector">
       <Arg>
           <New class="org.mortbay.jetty.bio.SocketConnector">
+            <Set name="host"><SystemProperty name="jetty.host" default="0.0.0.0"/></Set>
             <Set name="port"><SystemProperty name="jetty.port" default="8983"/></Set>
             <Set name="maxIdleTime">50000</Set>
             <Set name="lowResourceMaxIdleTime">1500</Set>


### PR DESCRIPTION
Add the ability to specify on which IP address Solr will be bound, 0.0.0.0 seems not a good default candidate ;)
