### PR TITLE
Allow to specify an ActiveRecord scope to filter search results

### DIFF
--- a/sunspot/lib/sunspot/adapters.rb
+++ b/sunspot/lib/sunspot/adapters.rb
@@ -1,5 +1,5 @@
 module Sunspot
-  # 
+  #
   # Sunspot works by saving references to the primary key (or natural ID) of
   # each indexed object, and then retrieving the objects from persistent storage
   # when their IDs are referenced in search results. In order for Sunspot to
@@ -53,7 +53,7 @@ module Sunspot
         @instance = instance
       end
 
-      # 
+      #
       # The universally-unique ID for this instance that will be stored in solr
       #
       # ==== Returns
@@ -182,7 +182,7 @@ module Sunspot
       #
       # Array:: collection of instances, in order of IDs given
       #
-      def load_all(ids)
+      def load_all(ids, options = {})
         ids.map { |id| self.load(id) }
       end
 

--- a/sunspot/lib/sunspot/dsl.rb
+++ b/sunspot/lib/sunspot/dsl.rb
@@ -1,4 +1,4 @@
-%w(fields scope paginatable adjustable field_query standard_query query_facet
+%w(fields scope paginatable adjustable field_query store_options standard_query query_facet
    functional fulltext restriction restriction_with_near search
    more_like_this_query function).each do |file|
   require File.join(File.dirname(__FILE__), 'dsl', file)

--- a/sunspot/lib/sunspot/dsl/standard_query.rb
+++ b/sunspot/lib/sunspot/dsl/standard_query.rb
@@ -9,7 +9,7 @@ module Sunspot
     # See Sunspot.search for usage examples
     #
     class StandardQuery < FieldQuery
-      include Paginatable, Adjustable
+      include Paginatable, Adjustable, StoreOptions
 
       # Specify a phrase that should be searched as fulltext. Only +text+
       # fields are searched - see DSL::Fields.text

--- a/sunspot/lib/sunspot/dsl/store_options.rb
+++ b/sunspot/lib/sunspot/dsl/store_options.rb
@@ -1,0 +1,9 @@
+module Sunspot
+  module DSL #:nodoc:
+    module StoreOptions
+      def store_options(options)
+        @query.store_options = options
+      end
+    end
+  end
+end

--- a/sunspot/lib/sunspot/query/common_query.rb
+++ b/sunspot/lib/sunspot/query/common_query.rb
@@ -1,6 +1,8 @@
 module Sunspot
   module Query #:nodoc:
     class CommonQuery
+      attr_accessor :store_options
+
       def initialize(types)
         @scope = Scope.new
         @sort = SortComposite.new

--- a/sunspot/spec/mocks/mock_adapter.rb
+++ b/sunspot/spec/mocks/mock_adapter.rb
@@ -12,7 +12,7 @@ module MockAdapter
       @clazz.get(id.to_i)
     end
 
-    def load_all(ids)
+    def load_all(ids, options = {})
       all = @clazz.get_all(ids.map { |id| id.to_i })
       if @custom_title
         all.each { |item| item.title = @custom_title }

--- a/sunspot_rails/README.rdoc
+++ b/sunspot_rails/README.rdoc
@@ -144,6 +144,7 @@ Do it like this:
     with :blog_id, 1
     with(:updated_at).greater_than(Time.now - 2.weeks)
     order :sort_title, :asc
+    store_options :activerecord_scope => Post.published
     paginate :page => 1, :per_page => 15
   end
 

--- a/sunspot_rails/lib/sunspot/rails/adapters.rb
+++ b/sunspot_rails/lib/sunspot/rails/adapters.rb
@@ -1,16 +1,16 @@
 module Sunspot #:nodoc:
   module Rails #:nodoc:
-    # 
+    #
     # This module provides Sunspot Adapter implementations for ActiveRecord
     # models.
     #
     module Adapters
       class ActiveRecordInstanceAdapter < Sunspot::Adapters::InstanceAdapter
-        # 
+        #
         # Return the primary key for the adapted instance
         #
         # ==== Returns
-        # 
+        #
         # Integer:: Database ID of model
         #
         def id
@@ -34,8 +34,8 @@ module Sunspot #:nodoc:
           value = value.join(', ') if value.respond_to?(:join)
           @select = value
         end
-        
-        # 
+
+        #
         # Get one ActiveRecord instance out of the database by ID
         #
         # ==== Parameters
@@ -45,14 +45,14 @@ module Sunspot #:nodoc:
         # ==== Returns
         #
         # ActiveRecord::Base:: ActiveRecord model
-        # 
+        #
         def load(id)
           @clazz.first(options_for_find.merge(
             :conditions => { @clazz.primary_key => id}
           ))
         end
 
-        # 
+        #
         # Get a collection of ActiveRecord instances out of the database by ID
         #
         # ==== Parameters
@@ -63,14 +63,15 @@ module Sunspot #:nodoc:
         #
         # Array:: Collection of ActiveRecord models
         #
-        def load_all(ids)
-          @clazz.all(options_for_find.merge(
+        def load_all(ids, options = nil)
+          scope = (options || {})[:activerecord_scope] || @clazz
+          scope.all(options_for_find.merge(
             :conditions => { @clazz.primary_key => ids.map { |id| id }}
           ))
         end
-        
+
         private
-        
+
         def options_for_find
           options = {}
           options[:include] = @include unless @include.blank?

--- a/sunspot_rails/spec/active_record_adapter_spec.rb
+++ b/sunspot_rails/spec/active_record_adapter_spec.rb
@@ -1,0 +1,21 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+
+describe Sunspot::Rails::Adapters::ActiveRecordDataAccessor, '#load_all' do
+  before(:each) do
+    @clazz = stub(:clazz, :primary_key => :id)
+    @accessor = Sunspot::Rails::Adapters::ActiveRecordDataAccessor.new(@clazz)
+  end
+
+  it 'calls #all on the active record class if no scope was given' do
+    @clazz.should_receive(:all).with(:conditions => {:id => [1]})
+
+    @accessor.load_all [1]
+  end
+
+  it 'calls #all on the given scope if one was given' do
+    scope = stub(:scope)
+    scope.should_receive(:all).with(:conditions => {:id => [1]})
+
+    @accessor.load_all [1], :activerecord_scope => scope
+  end
+end

--- a/sunspot_rails/spec/integration/active_record_scope_search_spec.rb
+++ b/sunspot_rails/spec/integration/active_record_scope_search_spec.rb
@@ -1,0 +1,317 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+describe 'activerecord scope search' do
+  describe 'generally' do
+    before :all do
+      Sunspot.remove_all
+      @posts = []
+      @posts << Post.new(:title => 'The toast elects the insufficient spirit',
+                         :body => 'Does the wind write?')
+      @posts << Post.new(:title => 'A nail abbreviates the recovering insight outside the moron',
+                         :body => 'The interpreted strain scans the buffer around the upper temper')
+      @posts << Post.new(:title => 'The toast abbreviates the recovering spirit',
+                         :body => 'Does the host\'s wind interpret the buffer, moron?')
+      Sunspot.index!(*@posts)
+      @comment = Namespaced::Comment.new(:body => 'Hey there where ya goin, not exactly knowin, who says you have to call just one place toast.')
+      Sunspot.index!(@comment)
+    end
+
+    it 'matches a single keyword out of a single field' do
+      results = Sunspot.search(Post) { keywords 'toast' }.results
+      [0, 2].each { |i| results.should include(@posts[i]) }
+      [1].each { |i| results.should_not include(@posts[i]) }
+    end
+
+    it 'matches multiple words out of a single field' do
+      results = Sunspot.search(Post) { keywords 'elects toast' }.results
+      results.should == [@posts[0]]
+    end
+
+    it 'matches multiple words in multiple fields' do
+      results = Sunspot.search(Post) { keywords 'toast wind' }.results
+      [0, 2].each { |i| results.should include(@posts[i]) }
+      [1].each { |i| results.should_not include(@posts[i]) }
+    end
+
+    it 'matches multiple types' do
+      results = Sunspot.search(Post, Namespaced::Comment) do
+        keywords 'toast'
+      end.results
+      [@posts[0], @posts[2], @comment].each  { |obj| results.should include(obj) }
+      results.should_not include(@posts[1])
+    end
+
+    it 'matches keywords from only the fields specified' do
+      results = Sunspot.search(Post) do
+        keywords 'moron', :fields => [:title]
+      end.results
+      results.should == [@posts[1]]
+    end
+
+    it 'matches multiple keywords on different fields using subqueries' do
+      search = Sunspot.search(Post) do
+        keywords 'moron', :fields => [:title]
+        keywords 'wind',  :fields => [:body]
+      end
+      search.results.should == []
+
+      search = Sunspot.search(Post) do
+        keywords 'moron',   :fields => [:title]
+        keywords 'buffer',  :fields => [:body]
+      end
+      search.results.should == [@posts[1]]
+    end
+
+    it 'matches multiple keywords with escaped characters' do
+      search = Sunspot.search(Post) do
+        keywords 'spirit',   :fields => [:title]
+        keywords 'host\'s',  :fields => [:body]
+      end
+      search.results.should == [@posts[2]]
+    end
+
+    it 'matches multiple keywords with phrase-based search' do
+      search = Sunspot.search(Post) do
+        keywords 'spirit', :fields => [:title]
+        keywords '"interpret the buffer"', :fields => [:body]
+        keywords '"does the"', :fields => [:body]
+      end
+      search.results.should == [@posts[2]]
+    end
+
+    it 'matches multiple keywords different options' do
+      search = Sunspot.search(Post) do
+        keywords 'insufficient nonexistent', :fields => [:title], :minimum_match => 1
+        keywords 'wind does', :fields => [:body], :minimum_match => 2
+      end
+      search.results.should == [@posts[0]]
+    end
+  end
+
+  describe 'with field boost' do
+    before :all do
+      Sunspot.remove_all
+      @posts = [:title, :body].map { |field| Post.new(field => 'rhinoceros') }
+      Sunspot.index!(*@posts)
+    end
+
+    it 'should assign a higher score to the result matching the higher-boosted field' do
+      search = Sunspot.search(Post) { keywords 'rhinoceros' }
+      search.hits.map { |hit| hit.primary_key }.should ==
+        @posts.map { |post| post.id.to_s }
+      search.hits.first.score.should > search.hits.last.score
+    end
+  end
+
+  describe 'with document boost' do
+    before :all do
+      Sunspot.remove_all
+      @posts = [4.0, 2.0].map do |rating|
+        Post.new(:title => 'Test', :ratings_average => rating)
+      end
+      Sunspot.index!(*@posts)
+    end
+
+    it 'should assign a higher score to the higher-boosted document' do
+      search = Sunspot.search(Post) { keywords 'test' }
+      search.hits.map { |hit| hit.primary_key }.should ==
+        @posts.map { |post| post.id.to_s }
+      search.hits.first.score.should > search.hits.last.score
+    end
+  end
+
+  describe 'with search-time boost' do
+    before :each do
+      Sunspot.remove_all
+      @comments = [
+        Namespaced::Comment.new(:body => 'test text'),
+        Namespaced::Comment.new(:author_name => 'test text')
+      ]
+      Sunspot.index!(@comments)
+    end
+
+    it 'assigns a higher score to documents in which all words appear in the phrase field' do
+      hits = Sunspot.search(Namespaced::Comment) do
+        keywords 'test text' do
+          phrase_fields :body => 2.0
+        end
+      end.hits
+      hits.first.instance.should == @comments.first
+      hits.first.score.should > hits.last.score
+    end
+
+    it 'assigns a higher score to documents in which the search terms appear in a boosted field' do
+      hits = Sunspot.search(Namespaced::Comment) do
+        keywords 'test' do
+          fields :body => 2.0, :author_name => 0.75
+        end
+      end.hits
+      hits.first.instance.should == @comments.first
+      hits.first.score.should > hits.last.score
+    end
+
+    it 'assigns a higher score to documents in which the search terms appear in a higher boosted phrase field' do
+      hits = Sunspot.search(Namespaced::Comment) do
+        keywords 'test text' do
+          phrase_fields :body => 2.0, :author_name => 0.75
+        end
+      end.hits
+      hits.first.instance.should == @comments.first
+      hits.first.score.should > hits.last.score
+    end
+  end
+
+  describe 'boost query' do
+    before :all do
+      Sunspot.remove_all
+      Sunspot.index!(
+        @posts = [
+          Post.new(:title => 'Rhino', :featured => true),
+          Post.new(:title => 'Rhino', :ratings_average => 3.3),
+          Post.new(:title => 'Rhino')
+        ]
+      )
+    end
+
+    it 'should assign a higher score to the document matching the boost query' do
+      search = Sunspot.search(Post) do |query|
+        query.keywords('rhino') do
+          boost(2.0) do
+            with(:featured, true)
+          end
+        end
+        query.without(@posts[1])
+      end
+      search.results.should == [@posts[0], @posts[2]]
+      search.hits[0].score.should > search.hits[1].score
+    end
+
+    it 'should assign scores in order of multiple boost query match' do
+      search = Sunspot.search(Post) do
+        keywords 'rhino' do
+          boost(2.0) { with(:featured, true) }
+          boost(1.5) { with(:average_rating).greater_than(3.0) }
+        end
+      end
+      search.results.should == @posts
+      search.hits[0].score.should > search.hits[1].score
+      search.hits[1].score.should > search.hits[2].score
+    end
+  end
+
+  describe 'minimum match' do
+    before do
+      Sunspot.remove_all
+      @posts = [
+        Post.new(:title => 'Pepperoni Sausage Anchovies'),
+        Post.new(:title => 'Pepperoni Tomatoes Mushrooms')
+      ]
+      Sunspot.index!(@posts)
+      @search = Sunspot.search(Post) do
+        keywords 'pepperoni sausage extra cheese', :minimum_match => 2
+      end
+    end
+
+    it 'should match documents that contain the minimum_match number of search terms' do
+      @search.results.should include(@posts[0])
+    end
+
+    it 'should not match documents that do not contain the minimum_match number of search terms' do
+      @search.results.should_not include(@posts[1])
+    end
+  end
+
+  describe 'query phrase slop' do
+    before do
+      Sunspot.remove_all
+      @posts = [
+        Post.new(:title => 'One four'),
+        Post.new(:title => 'One three four'),
+        Post.new(:title => 'One two three four')
+      ]
+      Sunspot.index!(@posts)
+      @search = Sunspot.search(Post) do
+        keywords '"one four"', :query_phrase_slop => 1
+      end
+    end
+
+    it 'should match exact phrase' do
+      @search.results.should include(@posts[0])
+    end
+
+    it 'should match phrase divided by query phrase slop terms' do
+      @search.results.should include(@posts[1])
+    end
+
+    it 'should not match phrase divided by more than query phrase slop terms' do
+      @search.results.should_not include(@posts[2])
+    end
+  end
+
+  describe 'phrase field slop' do
+    before do
+      Sunspot.remove_all
+      @comments = [
+        Namespaced::Comment.new(:author_name => 'one four'),
+        Namespaced::Comment.new(:body => 'one four'),
+        Namespaced::Comment.new(:author_name => 'one three four'),
+        Namespaced::Comment.new(:body => 'one three four'),
+        Namespaced::Comment.new(:author_name => 'one two three four'),
+        Namespaced::Comment.new(:body => 'one two three four')
+      ]
+      Sunspot.index!(@comments)
+      @search = Sunspot.search(Namespaced::Comment) do
+        keywords 'one four' do
+          phrase_fields :author_name => 3.0
+          phrase_slop 1
+        end
+      end
+      @sorted_hits = @search.hits.sort_by { |hit| @comments.index(hit.instance) }
+    end
+
+    it 'should give phrase field boost to exact match' do
+      @sorted_hits[0].score.should > @sorted_hits[1].score
+    end
+
+    it 'should give phrase field boost to match within slop' do
+      @sorted_hits[2].score.should > @sorted_hits[3].score
+    end
+
+    it 'should not give phrase field boost to match beyond slop' do
+      @sorted_hits[4].score.should == @sorted_hits[5].score
+    end
+  end
+
+  describe 'with function queries' do
+    before :each do
+      Sunspot.remove_all
+    end
+
+    after :each do
+      @search.results.should == @posts
+      @search.hits.first.score.should > @search.hits.last.score
+    end
+
+    it 'boosts via function query with float' do
+      @posts = [Post.new(:title => 'test', :ratings_average => 4.0),
+                Post.new(:title => 'test', :ratings_average => 2.0)]
+      Sunspot.index!(@posts)
+      @search = Sunspot.search(Post) do
+        keywords('test') do
+          boost function { :average_rating }
+        end
+      end
+    end
+
+    it 'boosts via function query with date' do
+      @posts = [Post.new(:title => 'test', :published_at => Time.now),
+                Post.new(:title => 'test', :published_at => Time.now - 60*60*24*31*6)] # roughly six months ago
+      Sunspot.index!(@posts)
+      @search = Sunspot.search(Post) do
+        keywords('test') do
+          boost function { recip(ms(Time.now, :published_at), 3.16e-11, 1, 1) }
+        end
+      end
+    end
+  end
+end

--- a/sunspot_rails/spec/model_spec.rb
+++ b/sunspot_rails/spec/model_spec.rb
@@ -114,12 +114,19 @@ describe 'ActiveRecord mixin' do
       end.results.should == [@post]
     end
 
+    it 'should use the given active record scope' do
+      Post.search do
+        with :title, 'Test Post'
+        store_options :activerecord_scope => Post.no_test_in_title
+      end.results.should == []
+    end
+
     it 'should not return results excluded by search' do
       Post.search do
         with :title, 'Bogus Post'
       end.results.should be_empty
     end
-    
+
     it 'should use the include option on the data accessor when specified' do
       Post.should_receive(:all).with(hash_including(:include => [:blog])).and_return([@post])
       Post.search do
@@ -134,7 +141,7 @@ describe 'ActiveRecord mixin' do
         with :title, 'Test Post'
       end.results.should == [@post]
     end
-    
+
     it 'should use the select option from search call to data accessor' do
       Post.should_receive(:all).with(hash_including(:select => 'title, published_at')).and_return([@post])
       Post.search(:select => 'title, published_at') do
@@ -145,7 +152,7 @@ describe 'ActiveRecord mixin' do
     it 'should not allow bogus options to search' do
       lambda { Post.search(:bogus => :option) }.should raise_error(ArgumentError)
     end
-    
+
     it 'should use the select option on the data accessor when specified' do
       Post.should_receive(:all).with(hash_including(:select => 'title, published_at')).and_return([@post])
       Post.search do
@@ -153,7 +160,7 @@ describe 'ActiveRecord mixin' do
         data_accessor_for(Post).select = [:title, :published_at]
       end.results.should == [@post]
     end
-    
+
     it 'should not use the select option on the data accessor when not specified' do
       Post.should_receive(:all).with(hash_not_including(:select)).and_return([@post])
       Post.search do
@@ -190,7 +197,7 @@ describe 'ActiveRecord mixin' do
       Post.search_ids.to_set.should == @posts.map { |post| post.id }.to_set
     end
   end
-  
+
   describe 'searchable?()' do
     it 'should not be true for models that have not been configured for search' do
       Location.should_not be_searchable
@@ -246,7 +253,7 @@ describe 'ActiveRecord mixin' do
       Sunspot.commit
       Post.search.results.to_set.should == @posts.to_set
     end
-    
+
   end
 
   describe 'reindex() with real data' do
@@ -268,7 +275,7 @@ describe 'ActiveRecord mixin' do
       Sunspot.commit
       Post.search.results.to_set.should == @posts.to_set
     end
-    
+
     describe "using batch sizes" do
       it 'should index with a specified batch size' do
         Post.reindex(:batch_size => 1)
@@ -279,15 +286,15 @@ describe 'ActiveRecord mixin' do
   end
 
 
-  
+
   describe "reindex()" do
-  
+
     before(:each) do
       @posts = Array.new(2) { Post.create }
     end
 
     describe "when not using batches" do
-      
+
       it "should select all if the batch_size is nil" do
         Post.should_receive(:all).with(:include => []).and_return([])
         Post.reindex(:batch_size => nil)
@@ -313,7 +320,7 @@ describe 'ActiveRecord mixin' do
           Post.search.results.should_not include(@posts.first)
         end
       end
-    
+
     end
 
     describe "when using batches" do
@@ -344,7 +351,7 @@ describe 'ActiveRecord mixin' do
       end
     end
   end
-  
+
   describe "more_like_this()" do
     before(:each) do
       @posts = [

--- a/sunspot_rails/spec/rails_template/app/models/post.rb
+++ b/sunspot_rails/spec/rails_template/app/models/post.rb
@@ -3,6 +3,8 @@ class Post < ActiveRecord::Base
   belongs_to :author
   has_many :comments
 
+  named_scope :no_test_in_title, :conditions => "title NOT LIKE '%Test%'"
+
   searchable :auto_index => false, :auto_remove => false do
     string :title
     text :body, :more_like_this => true


### PR DESCRIPTION
This patch adds a parameter `store_options` to `search`, which takes a hash. Here's an example:

```
Post.search do
  store_options :activerecord_scope => Post.published
end
```

Where `published` is a (named) scope on `Post`.This will result in only published posts being returned from the search.

I'm not sure if the API is ideal and if I put everything in its right place. Let me know if I should move things around.

After implementing the whole thing I realized it would be nice to be able to just say `Post.published.search` but haven't investigated it that's feasible.
