### PR TITLE
Search requests should set UTF-8 encoding

### DIFF
--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -35,7 +35,7 @@ module Sunspot
       def execute
         reset
         params = @query.to_params
-        @solr_result = @connection.post "#{request_handler}", :data => params
+        @solr_result = @connection.post "#{request_handler}", :data => params, :headers => {'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8'}
         self
       end
 


### PR DESCRIPTION
I have been running Solr on Tomcat 6.
When I upgraded sunspot from 1.3.0.rc4 to 1.3.0.rc6, the search that includes multibyte characters in the query returned empty results. I think it is because rc6 does not set UTF-8 encoding for a search request.
