### PR TITLE
Add method to return the Solr query time for a response.

### DIFF
--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -119,6 +119,17 @@ module Sunspot
       end
   
       # 
+      # The time elapsed to generate the Solr response
+      #
+      # ==== Returns
+      #
+      # Integer:: Query runtime in milliseconds
+      #
+      def query_time
+        @query_time ||= solr_response_header['QTime']
+      end
+  
+      # 
       # Get the facet object for the given name. `name` can either be the name
       # given to a query facet, or the field name of a field facet. Returns a
       # Sunspot::Facet object.
@@ -263,6 +274,10 @@ module Sunspot
   
       def solr_response
         @solr_response ||= @solr_result['response'] || {}
+      end
+  
+      def solr_response_header
+        @solr_response_header ||= @solr_result['responseHeader'] || {}
       end
   
       def highlights_for(doc)

--- a/sunspot/spec/api/search/results_spec.rb
+++ b/sunspot/spec/api/search/results_spec.rb
@@ -42,6 +42,12 @@ describe 'search results', :type => :search do
     session.search(Post) { paginate(:page => 1) }.total.should == 4
   end
 
+  it 'returns query time' do
+    stub_nil_results
+    connection.response['responseHeader'] = { 'QTime' => 42 }
+    session.search(Post) { paginate(:page => 1) }.query_time.should == 42
+  end
+
   it 'returns total for nil search' do
     stub_nil_results
     session.search(Post).total.should == 0


### PR DESCRIPTION
This patch adds a query_time accessor to Sunspot::Search::AbstractSearch which can be used to tell how many milliseconds it took for Solr to generate a response.
