### PR TITLE
Added ability to change PaginatedCollection's total_count/total_entries

### DIFF
--- a/sunspot/lib/sunspot/search/paginated_collection.rb
+++ b/sunspot/lib/sunspot/search/paginated_collection.rb
@@ -4,8 +4,10 @@ module Sunspot
     class PaginatedCollection
       instance_methods.each { |m| undef_method m unless m =~ /^__|instance_eval|object_id/ }
 
-      attr_reader :total_count, :current_page, :per_page
+      attr_reader :current_page, :per_page
+      attr_accessor :total_count
       alias :total_entries :total_count
+      alias :total_entries= :total_count=
       alias :limit_value :per_page
 
       def initialize(collection, page, per_page, total)
@@ -34,12 +36,12 @@ module Sunspot
 
       def next_page
         current_page < total_pages ? (current_page + 1) : nil
-      end  
+      end
 
       def out_of_bounds?
         current_page > total_pages
       end
-      
+
       def offset
         (current_page - 1) * per_page
       end

--- a/sunspot/spec/api/search/paginated_collection_spec.rb
+++ b/sunspot/spec/api/search/paginated_collection_spec.rb
@@ -14,6 +14,16 @@ describe "PaginatedCollection" do
     it { subject.next_page.should eql(2) }
     it { subject.out_of_bounds?.should_not be_true }
     it { subject.offset.should eql(0) }
+
+    it 'should allow setting total_count' do
+      subject.total_count = 1
+      subject.total_count.should eql(1)
+    end
+
+    it 'should allow setting total_entries' do
+      subject.total_entries = 1
+      subject.total_entries.should eql(1)
+    end
   end
 
   context "behaves like Kaminari" do


### PR DESCRIPTION
In sunspot_rails 1.2.1 we had the ability to change the result collection's total_entries amount.  This allowed us to limit the number of returned results so our users didn't get overwhelmed seeing 65K pages.

The ability to do this was removed in 1.3.  This patch returns that ability.  A couple of simple tests were added and all the tests pass with this change.

Thank you.
