### PR TITLE
Redirect progress_bar logging to stdout rather than stderr

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -44,7 +44,7 @@ namespace :sunspot do
       total_documents = sunspot_models.map { | m | m.count }.sum
       reindex_options[:progress_bar] = ProgressBar.new(total_documents)
     rescue LoadError => e
-      $stderr.puts "Skipping progress bar: for progress reporting, add gem 'progress_bar' to your Gemfile"
+      $stdout.puts "Skipping progress bar: for progress reporting, add gem 'progress_bar' to your Gemfile"
     rescue Exception => e
       $stderr.puts "Error using progress bar: #{e.message}"
     end


### PR DESCRIPTION
If you run reindex as a cron job (and receive email notifications of errors) then the progress_bar gem should be optional.  I modified the logging to write to stdout instead.
