### PR TITLE
Updates indexing to use batch processing with a config variable

### DIFF
--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -8,6 +8,8 @@ module Sunspot
   # Sunspot.config.pagination.default_per_page::
   #   Solr always paginates its results. This sets Sunspot's default result
   #   count per page if it is not explicitly specified in the query.
+  # Sunspot.config.indexing.default_batch_size::
+  #   This sets the batch size for indexing, default is 50
   #
   module Configuration
     class <<self
@@ -27,6 +29,9 @@ module Sunspot
           end
           pagination do
             default_per_page 30
+          end
+          indexing do
+            default_batch_size 50
           end
         end
       end

--- a/sunspot_rails/spec/model_spec.rb
+++ b/sunspot_rails/spec/model_spec.rb
@@ -211,6 +211,12 @@ describe 'ActiveRecord mixin' do
     it 'should return IDs of objects that are in the index but not the database' do
       Post.index_orphans.should == [@posts.first.id]
     end
+
+    it 'should find the orphans in batches to improve performance' do
+      Post.should_receive(:find_each).with(hash_including(:batch_size => 10)).and_return([])
+      Post.index_orphans(:batch_size => 10)
+    end
+
   end
 
   describe 'clean_index_orphans()' do


### PR DESCRIPTION
This commit updates the indexing system to use ActiveRecord's batch selection option, find_each.  This would force a minimum requirement of Rails 2.3.x, which does not seem unreasonable now.  Additionally it adds the config variable "Sunspot.config.indexing.default_batch_size" to allow users to set their batch size globally.
