### PR TITLE
STI models include and select option fix

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -320,9 +320,11 @@ module Sunspot #:nodoc:
             search.build do |query|
               if options[:include]
                 query.data_accessor_for(self).include = options[:include]
+                self.descendants.each{|sub| query.data_accessor_for(sub).include = options[:include]}
               end
               if options[:select]
                 query.data_accessor_for(self).select = options[:select]
+                self.descendants.each{|sub| query.data_accessor_for(sub).include = options[:select]}
               end
             end
           end


### PR DESCRIPTION
When you search the top of an STI model in rails, the select and include parameters were not being passed down the chain in the data_accessor method. I added a fix to this so that these methods are passed to its descendants. The fix only works when "cache_classes" is set to true in the environment file. 
