### PR TITLE
Unnecessarily raises JavaMissing.new("You need a Java Runtime Environmen...

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/java.rb
+++ b/sunspot_solr/lib/sunspot/solr/java.rb
@@ -2,7 +2,8 @@ module Sunspot
   module Solr
     module Java
       def self.installed?
-        `java -version &> /dev/null`
+        java_cmd = RUBY_PLATFORM =~ /i386/ ? 'java -version' : 'java -version &> /dev/null'
+        system(java_cmd)
         $?.success?
       end
     end


### PR DESCRIPTION
...t to run the Solr server") on windows 7.
