### PR TITLE
Add group.results and group.total

### DIFF
--- a/sunspot/lib/sunspot/search/group.rb
+++ b/sunspot/lib/sunspot/search/group.rb
@@ -23,6 +23,10 @@ module Sunspot
         @verified_hits ||= super
       end
 
+      def results
+        @results ||= verified_hits.map { |hit| hit.instance }
+      end
+
       def highlights_for(doc)
         @search.highlights_for(doc)
       end
@@ -30,6 +34,17 @@ module Sunspot
       def solr_docs
         @doclist['docs']
       end
+      
+      #
+      # The total number of documents matching the query for this group
+      #
+      # ==== Returns
+      #
+      # Integer:: Total matching documents
+      # 
+      def total
+        @doclist['numFound']
+      end      
     end
   end
 end


### PR DESCRIPTION
The readme was wrong (at least mine...). There were no results collection in the group object, so I added that and a total method to get the total number of docs that matched the query for the instance group.
