### PR TITLE
Improved model loading in sunspot:reindex Rake task

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -27,7 +27,11 @@ namespace :sunspot do
 
     # Load all the application's models. Models which invoke 'searchable' will register themselves
     # in Sunspot.searchable.
-    Dir.glob(Rails.root.join('app/models/**/*.rb')).each { |path| require path }
+    Rails.root.join('app', 'models').tap do |models_path|
+      Dir.glob(models_path.join('**', '*.rb')).map do |path| 
+        ActiveSupport::Dependencies.require_or_load path.sub(models_path.to_s+'/', '')[0..-4] rescue nil
+      end.compact
+    end
 
     # By default, reindex all searchable models
     sunspot_models = Sunspot.searchable


### PR DESCRIPTION
This patch solves problems running `rake sunspot:reindex` in development mode for models that use STI and alias_method (e.g. models including `ActiveSupport::Memoization`).

In our case we had problems with an indexed model that has two sub-models (via STI) and uses `ActiveSupport::Memoization`. Running `rake sunspot:reindex` threw an `Already memoized foobar` error as class-level code got executed twice.

My solution uses `ActiveSupport::Dependencies` to load models, which keeps track of already loaded models, even in Rails development mode.
