### PR TITLE
Fixed greater_than and lower_than behaviour

### DIFF
--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -185,6 +185,23 @@ module Sunspot
         end
 
         def to_solr_conditional
+          "{* TO #{solr_value}}"
+        end
+      end
+
+      # 
+      # Results must have field with value less or equal to than given value
+      #
+      class LessThanOrEqualTo < Base
+        private
+
+        def solr_value(value = @value)
+          solr_value = super
+          solr_value = "\"#{solr_value}\"" if solr_value.index(' ')
+          solr_value
+        end
+
+        def to_solr_conditional
           "[* TO #{solr_value}]"
         end
       end
@@ -193,6 +210,23 @@ module Sunspot
       # Results must have field with value greater than given value
       #
       class GreaterThan < Base
+        private
+
+        def solr_value(value = @value)
+          solr_value = super
+          solr_value = "\"#{solr_value}\"" if solr_value.index(' ')
+          solr_value
+        end
+
+        def to_solr_conditional
+          "{#{solr_value} TO *}"
+        end
+      end
+
+      # 
+      # Results must have field with value greater than or equal to given value
+      #
+      class GreaterThanOrEqualTo < Base
         private
 
         def solr_value(value = @value)

--- a/sunspot/spec/api/query/connectives_examples.rb
+++ b/sunspot/spec/api/query/connectives_examples.rb
@@ -23,7 +23,7 @@ shared_examples_for "query with connective scope" do
     end
     connection.should have_last_search_including(
       :fq,
-      '(blog_id_i:2 OR (category_ids_im:1 AND average_rating_ft:[3\.0 TO *]))'
+      '(blog_id_i:2 OR (category_ids_im:1 AND average_rating_ft:{3\.0 TO *}))'
     )
   end
 
@@ -38,7 +38,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     connection.should have_last_search_including(
-      :fq, '(category_ids_im:1 OR (-average_rating_ft:[3\.0 TO *] AND blog_id_i:1))'
+      :fq, '(category_ids_im:1 OR (-average_rating_ft:{3\.0 TO *} AND blog_id_i:1))'
     )
   end
 
@@ -62,7 +62,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     connection.should have_last_search_including(
-      :fq, '-(-category_ids_im:1 AND average_rating_ft:[3\.0 TO *])'
+      :fq, '-(-category_ids_im:1 AND average_rating_ft:{3\.0 TO *})'
     )
   end
 
@@ -149,7 +149,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     connection.should have_last_search_including(
-      :fq, '-(average_rating_ft:[* TO *] AND -average_rating_ft:[3\.0 TO *])'
+      :fq, '-(average_rating_ft:[* TO *] AND -average_rating_ft:{3\.0 TO *})'
     )
   end
 
@@ -162,7 +162,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     connection.should have_last_search_including(
-      :fq, "(id:(Post\\ #{post.id}) OR average_rating_ft:[3\\.0 TO *])"
+      :fq, "(id:(Post\\ #{post.id}) OR average_rating_ft:{3\\.0 TO *})"
     )
   end
 

--- a/sunspot/spec/api/query/dynamic_fields_examples.rb
+++ b/sunspot/spec/api/query/dynamic_fields_examples.rb
@@ -14,7 +14,7 @@ shared_examples_for "query with dynamic field support" do
         with(:test).less_than(1)
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_integer\:test_i:[* TO 1]')
+    connection.should have_last_search_including(:fq, 'custom_integer\:test_i:{* TO 1}')
   end
 
   it 'restricts by dynamic float field with between restriction' do

--- a/sunspot/spec/api/query/fulltext_examples.rb
+++ b/sunspot/spec/api/query/fulltext_examples.rb
@@ -224,7 +224,7 @@ shared_examples_for 'fulltext query' do
         end
       end
     end
-    connection.should have_last_search_with(:bq => ['average_rating_ft:[2\.0 TO *]^2.0'])
+    connection.should have_last_search_with(:bq => ['average_rating_ft:{2\.0 TO *}^2.0'])
   end
 
   it 'creates multiple boost queries' do
@@ -240,7 +240,7 @@ shared_examples_for 'fulltext query' do
     end
     connection.should have_last_search_with(
       :bq => [
-        'average_rating_ft:[2\.0 TO *]^2.0',
+        'average_rating_ft:{2\.0 TO *}^2.0',
         'featured_bs:true^1.5'
       ]
     )

--- a/sunspot/spec/api/query/scope_examples.rb
+++ b/sunspot/spec/api/query/scope_examples.rb
@@ -46,21 +46,21 @@ shared_examples_for "scoped query" do
     search do
       with(:average_rating).less_than 3.0
     end
-    connection.should have_last_search_including(:fq, 'average_rating_ft:[* TO 3\.0]')
+    connection.should have_last_search_including(:fq, 'average_rating_ft:{* TO 3\.0}')
   end
 
   it 'should quote string with space in a less than match' do
     search do
       with(:title).less_than('test value')
     end
-    connection.should have_last_search_including(:fq, 'title_ss:[* TO "test\ value"]')
+    connection.should have_last_search_including(:fq, 'title_ss:{* TO "test\ value"}')
   end
 
   it 'scopes by greater than match with float' do
     search do
       with(:average_rating).greater_than 3.0
     end
-    connection.should have_last_search_including(:fq, 'average_rating_ft:[3\.0 TO *]')
+    connection.should have_last_search_including(:fq, 'average_rating_ft:{3\.0 TO *}')
   end
 
   it 'scopes by short-form between match with integers' do
@@ -116,14 +116,14 @@ shared_examples_for "scoped query" do
     search do
       without(:average_rating).less_than 3.0
     end
-    connection.should have_last_search_including(:fq, '-average_rating_ft:[* TO 3\.0]')
+    connection.should have_last_search_including(:fq, '-average_rating_ft:{* TO 3\.0}')
   end
 
   it 'scopes by not greater than match with float' do
     search do
       without(:average_rating).greater_than 3.0
     end
-    connection.should have_last_search_including(:fq, '-average_rating_ft:[3\.0 TO *]')
+    connection.should have_last_search_including(:fq, '-average_rating_ft:{3\.0 TO *}')
   end
   
   it 'scopes by not between match with shorthand' do

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -33,24 +33,48 @@ describe 'scoped_search' do
 
       it 'should filter by less than' do
         results = Sunspot.search(clazz) { with(field).less_than values[2] }.results
-        (0..2).each { |i| results.should include(@objects[i]) }
-        (3..4).each { |i| results.should_not include(@objects[i]) }
+        (0..1).each { |i| results.should include(@objects[i]) }
+        (2..4).each { |i| results.should_not include(@objects[i]) }
       end
 
       it 'should reject by less than' do
         results = Sunspot.search(clazz) { without(field).less_than values[2] }.results
+        (0..1).each { |i| results.should_not include(@objects[i]) }
+        (2..4).each { |i| results.should include(@objects[i]) }
+      end
+
+      it 'should filter by less than or equal to' do
+        results = Sunspot.search(clazz) { with(field).less_than_or_equal_to values[2] }.results
+        (0..2).each { |i| results.should include(@objects[i]) }
+        (3..4).each { |i| results.should_not include(@objects[i]) }
+      end
+
+      it 'should reject by less than or equal to' do
+        results = Sunspot.search(clazz) { without(field).less_than_or_equal_to values[2] }.results
         (0..2).each { |i| results.should_not include(@objects[i]) }
         (3..4).each { |i| results.should include(@objects[i]) }
       end
 
       it 'should filter by greater than' do
         results = Sunspot.search(clazz) { with(field).greater_than values[2] }.results
+        (3..4).each { |i| results.should include(@objects[i]) }
+        (0..2).each { |i| results.should_not include(@objects[i]) }
+      end
+
+      it 'should reject by greater than' do
+        results = Sunspot.search(clazz) { without(field).greater_than values[2] }.results
+        (3..4).each { |i| results.should_not include(@objects[i]) }
+        (0..2).each { |i| results.should include(@objects[i]) }
+      end
+
+      it 'should filter by greater than or equal to' do
+        results = Sunspot.search(clazz) { with(field).greater_than_or_equal_to values[2] }.results
         (2..4).each { |i| results.should include(@objects[i]) }
         (0..1).each { |i| results.should_not include(@objects[i]) }
       end
 
       it 'should reject by greater than' do
-        results = Sunspot.search(clazz) { without(field).greater_than values[2] }.results
+        results = Sunspot.search(clazz) { without(field).greater_than_or_equal_to values[2] }.results
         (2..4).each { |i| results.should_not include(@objects[i]) }
         (0..1).each { |i| results.should include(@objects[i]) }
       end


### PR DESCRIPTION
This patch solves problems with `greater_than` and `lower_than` methods, which used to work like `greater_than_or_equal_to` and `lower_than_or_equal_to`. I've fixed that, plus added those missing methods.
