### PR TITLE
Fix warning about InstanceMethods included from ActiveSupport::Concern

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -7,12 +7,11 @@ module Sunspot
         alias_method_chain :execute, :as_instrumentation
       end
 
-      module InstanceMethods
-        def execute_with_as_instrumentation(path, params={}, *extra)
-          ActiveSupport::Notifications.instrument("request.rsolr",
-                                                  {:path => path, :parameters => params}) do
-            execute_without_as_instrumentation(path, params, *extra)
-          end
+
+      def execute_with_as_instrumentation(path, params={}, *extra)
+        ActiveSupport::Notifications.instrument("request.rsolr",
+                                                {:path => path, :parameters => params}) do
+          execute_without_as_instrumentation(path, params, *extra)
         end
       end
     end


### PR DESCRIPTION
Auto inclusion for InstanceMethods module was deprecated and is throwing a warning when ActiveSupport::Concern was extented.
