### PR TITLE
Fix for GH-132

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -48,15 +48,20 @@ namespace :sunspot do
     rescue Exception => e
       $stderr.puts "Error using progress bar: #{e.message}"
     end
-    
+
     # Finally, invoke the class-level solr_reindex on each model
     sunspot_models.each do |model|
       model.solr_reindex(reindex_options)
     end
   end
 
+  # Assume that if the sunspot_solr gem is in the load path that this deprication warning is
+  # redundant.
+  def sunspot_solr_in_load_path
+    $:.any? { |path| path =~ %r{sunspot_solr/lib$} }
+  end
 
-  unless defined?(Sunspot::Solr)
+  unless sunspot_solr_in_load_path
     namespace :solr do
   		task :moved_to_sunspot_solr do
   	    abort %(


### PR DESCRIPTION
Hi,

A fix for GH-132. Instead of checking the loaded modules in the rake task, check the
load path for sunspot_solr (bundler will have added all Gems there
at boot).

Cheers,
Chris
