### PR TITLE
Don't use InstanceMethods when not needed.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -7,12 +7,11 @@ module Sunspot
         alias_method_chain :execute, :as_instrumentation
       end
 
-      module InstanceMethods
-        def execute_with_as_instrumentation(path, params={}, *extra)
-          ActiveSupport::Notifications.instrument("request.rsolr",
-                                                  {:path => path, :parameters => params}) do
-            execute_without_as_instrumentation(path, params, *extra)
-          end
+
+      def execute_with_as_instrumentation(path, params={}, *extra)
+        ActiveSupport::Notifications.instrument("request.rsolr",
+                                                {:path => path, :parameters => params}) do
+          execute_without_as_instrumentation(path, params, *extra)
         end
       end
     end


### PR DESCRIPTION
Rails 3.2 deprecates it, so this fixes warnings being logged.
