### PR TITLE
Set Init order

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/railtie.rb
+++ b/sunspot_rails/lib/sunspot/rails/railtie.rb
@@ -1,7 +1,7 @@
 module Sunspot
   module Rails
     class Railtie < ::Rails::Railtie
-      initializer 'sunspot_rails.init', :after=> "active_record.initialize_database" do
+      initializer 'sunspot_rails.init', :before=> :load_config_initializers do
         Sunspot.session = Sunspot::Rails.build_session
         ActiveSupport.on_load(:active_record) do
           Sunspot::Adapters::InstanceAdapter.register(Sunspot::Rails::Adapters::ActiveRecordInstanceAdapter, ActiveRecord::Base)


### PR DESCRIPTION
I've set the order (there was no order) of the `sunspot_rails.init` Initializer to run just before any application Initializers are loaded. This way Engines and Railties like rails_admin that make use of a Model's code will work correctly. See https://github.com/sferik/rails_admin/issues/1018

The alternative to this is to run the contents of the `init.rb` file in a different Initilializer just before the one that uses any Model Class.
