### PR TITLE
Retry failed updates at least once after a 500ms delay.

### DIFF
--- a/sunspot/lib/sunspot/session_proxy/retry_fail_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/retry_fail_session_proxy.rb
@@ -1,0 +1,45 @@
+require File.join(File.dirname(__FILE__), 'abstract_session_proxy')
+
+module Sunspot
+  module SessionProxy
+    class RetryFailSessionProxy < AbstractSessionProxy
+
+      attr_reader :search_session
+
+      delegate :new_search, :search, :config,
+                :new_more_like_this, :more_like_this,
+                :delete_dirty, :delete_dirty?,
+                :to => :search_session
+
+      def initialize(search_session = Sunspot.session)
+        @search_session = search_session
+      end
+
+      def rescued_exception(method, e)
+        $stderr.puts("Exception in #{method}: #{e.message}")
+      end
+
+      SUPPORTED_METHODS = [
+        :batch, :commit, :commit_if_dirty, :commit_if_delete_dirty, :dirty?,
+        :index!, :index, :optimize, :remove!, :remove, :remove_all!, :remove_all,
+        :remove_by_id!, :remove_by_id
+      ]
+
+      SUPPORTED_METHODS.each do |method|
+        module_eval(<<-RUBY)
+          def #{method}(*args, &block)
+            retry_count = 1
+            begin
+              search_session.#{method}(*args, &block)
+            rescue => e
+              sleep 0.5
+              self.rescued_exception(:#{method}, e)
+              retry if (retry_count -= 1) >= 0
+            end
+          end
+        RUBY
+      end
+      
+    end
+  end
+end


### PR DESCRIPTION
So, sometimes Solr sends a 503 because it needs a breather. Let's just retry those.

TODO:
- Target 503 errors differently than the rest — what exception is RSolr sending? No sense retrying a 40x.
- Tests
- Wrap this into the default session, because what's the point if nobody uses it?
