### PR TITLE
Group's data accessor from its search object

### DIFF
--- a/sunspot/lib/sunspot/search/group.rb
+++ b/sunspot/lib/sunspot/search/group.rb
@@ -35,6 +35,10 @@ module Sunspot
         @doclist['docs']
       end
       
+      def data_accessor_for(clazz)
+        @search.data_accessor_for(clazz)
+      end      
+      
       #
       # The total number of documents matching the query for this group
       #


### PR DESCRIPTION
The group should use same data accessor that its `@search` uses. 
This way it will use the options passed in into the search: Eg :include

```
@s = Post.search(:include => :comments) do
  group(:categories_id_str)
end
```

So when loading the `categories_id_str` group each Post loaded will include its `:comments`
