### PR TITLE
fixed models loading in "rake sunspot:reindex"

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -27,15 +27,15 @@ namespace :sunspot do
 
     # Load all the application's models. Models which invoke 'searchable' will register themselves
     # in Sunspot.searchable.
-    Dir.glob(Rails.root.join('app/models/**/*.rb')).each { |path| require path }
+    Rails.application.eager_load!
 
-    # By default, reindex all searchable models
-    sunspot_models = Sunspot.searchable
-
-    # Choose a specific subset of models, if requested
     if args[:models]
+      # Choose a specific subset of models, if requested
       model_names = args[:models].split('+')
       sunspot_models = model_names.map{ |m| m.constantize }
+    else
+      # By default, reindex all searchable models
+      sunspot_models = Sunspot.searchable
     end
     
     # Set up progress_bar to, ah, report progress


### PR DESCRIPTION
rake sunspot:reindex does not work in production environment if you include namespaced modules in your models:

```
$ RAILS_ENV=production rake sunspot:reindex --trace
** Invoke sunspot:reindex (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute sunspot:reindex
rake aborted!
Expected /path/to/project/releases/20120317160302/app/models/ontology/import.rb to define Ontology::Import
```

Content of `app/models/ontology/import.rb`:

```
module Ontology::Import
  extend ActiveSupport::Concern
end
```

Content of `app/models/ontology.rb`:

```
class Ontology < ActiveRecord::Base
  include Ontology::Import
end
```
