### PR TITLE
Propagate :first_id option to find_in_batches, before was always nil

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -246,7 +246,7 @@ module Sunspot #:nodoc:
           find_in_batch_options = {
             :include => options[:include],
             :batch_size => options[:batch_size],
-            :start => options[:first_id]
+            :start => options[:start]
           }
           progress_bar = options[:progress_bar]
           if options[:batch_size]


### PR DESCRIPTION
I'm working on a customized version of the `reindex_task` which uses the `solr_index` method and I've found out that the documented :first_id option is not correctly propagated to the `find_in_batches` AR method.

This commit should fix it.
