### PR TITLE
Fix request error when using empty arrays with query.with/without

### DIFF
--- a/sunspot/lib/sunspot/dsl/scope.rb
+++ b/sunspot/lib/sunspot/dsl/scope.rb
@@ -201,6 +201,7 @@ module Sunspot
             @scope.add_shorthand_restriction(negated, @setup.field(field_name.to_sym), value)
           end
         else
+          return if args.empty?
           instances = args.flatten
           @scope.add_restriction(
             negated,


### PR DESCRIPTION
Hi,

We've been having troubles passing empty arrays to `.with` and `.without`. Those were generating request conditions of the form: `-foo_ss:()` which, in turn, raised the error pasted below.

This is a quick fix that I have not tested in the hope that this report can be useful to you guys.

```
11:31:38 solr.1       | GRAVE: org.apache.solr.common.SolrException: org.apache.lucene.queryParser.ParseException: Cannot parse '-foo_ss:()': Encountered " ")" ") "" at line 1, column 11.
11:31:38 solr.1       | Was expecting one of:
11:31:38 solr.1       |     <NOT> ...
11:31:38 solr.1       |     "+" ...
11:31:38 solr.1       |     "-" ...
11:31:38 solr.1       |     "(" ...
11:31:38 solr.1       |     "*" ...
11:31:38 solr.1       |     <QUOTED> ...
11:31:38 solr.1       |     <TERM> ...
11:31:38 solr.1       |     <PREFIXTERM> ...
11:31:38 solr.1       |     <WILDTERM> ...
11:31:38 solr.1       |     "[" ...
11:31:38 solr.1       |     "{" ...
11:31:38 solr.1       |     <NUMBER> ...
11:31:38 solr.1       |     <TERM> ...
11:31:38 solr.1       |     "*" ...
11:31:38 solr.1       |     
11:31:38 solr.1       |     at org.apache.solr.handler.component.QueryComponent.prepare(QueryComponent.java:108)
11:31:38 solr.1       |     at org.apache.solr.handler.component.SearchHandler.handleRequestBody(SearchHandler.java:174)
11:31:38 solr.1       |     at org.apache.solr.handler.RequestHandlerBase.handleRequest(RequestHandlerBase.java:131)
11:31:38 solr.1       |     at org.apache.solr.core.SolrCore.execute(SolrCore.java:1316)
11:31:38 solr.1       |     at org.apache.solr.servlet.SolrDispatchFilter.execute(SolrDispatchFilter.java:338)
11:31:38 solr.1       |     at org.apache.solr.servlet.SolrDispatchFilter.doFilter(SolrDispatchFilter.java:241)
11:31:38 solr.1       |     at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1089)
11:31:38 solr.1       |     at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:365)
11:31:38 solr.1       |     at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
11:31:38 solr.1       |     at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:181)
11:31:38 solr.1       |     at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:712)
11:31:38 solr.1       |     at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:405)
11:31:38 solr.1       |     at org.mortbay.jetty.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:211)
11:31:38 solr.1       |     at org.mortbay.jetty.handler.HandlerCollection.handle(HandlerCollection.java:114)
11:31:38 solr.1       |     at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:139)
11:31:38 solr.1       |     at org.mortbay.jetty.Server.handle(Server.java:285)
11:31:38 solr.1       |     at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:502)
11:31:38 solr.1       |     at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:821)
11:31:38 solr.1       |     at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:513)
11:31:38 solr.1       |     at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:208)
11:31:38 solr.1       |     at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:378)
11:31:38 solr.1       |     at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:226)
11:31:38 solr.1       |     at org.mortbay.thread.BoundedThreadPool$PoolThread.run(BoundedThreadPool.java:442)
11:31:38 solr.1       | Caused by: org.apache.lucene.queryParser.ParseException: Cannot parse '-foo_ss:()': Encountered " ")" ") "" at line 1, column 11.
11:31:38 solr.1       | Was expecting one of:
11:31:38 solr.1       |     <NOT> ...
11:31:38 solr.1       |     "+" ...
11:31:38 solr.1       |     "-" ...
11:31:38 solr.1       |     "(" ...
11:31:38 solr.1       |     "*" ...
11:31:38 solr.1       |     <QUOTED> ...
11:31:38 solr.1       |     <TERM> ...
11:31:38 solr.1       |     <PREFIXTERM> ...
11:31:38 solr.1       |     <WILDTERM> ...
11:31:38 solr.1       |     "[" ...
11:31:38 solr.1       |     "{" ...
11:31:38 solr.1       |     <NUMBER> ...
11:31:38 solr.1       |     <TERM> ...
11:31:38 solr.1       |     "*" ...
11:31:38 solr.1       |     
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.parse(QueryParser.java:205)
11:31:38 solr.1       |     at org.apache.solr.search.LuceneQParser.parse(LuceneQParserPlugin.java:78)
11:31:38 solr.1       |     at org.apache.solr.search.QParser.getQuery(QParser.java:131)
11:31:38 solr.1       |     at org.apache.solr.handler.component.QueryComponent.prepare(QueryComponent.java:103)
11:31:38 solr.1       |     ... 22 more
11:31:38 solr.1       | Caused by: org.apache.lucene.queryParser.ParseException: Encountered " ")" ") "" at line 1, column 11.
11:31:38 solr.1       | Was expecting one of:
11:31:38 solr.1       |     <NOT> ...
11:31:38 solr.1       |     "+" ...
11:31:38 solr.1       |     "-" ...
11:31:38 solr.1       |     "(" ...
11:31:38 solr.1       |     "*" ...
11:31:38 solr.1       |     <QUOTED> ...
11:31:38 solr.1       |     <TERM> ...
11:31:38 solr.1       |     <PREFIXTERM> ...
11:31:38 solr.1       |     <WILDTERM> ...
11:31:38 solr.1       |     "[" ...
11:31:38 solr.1       |     "{" ...
11:31:38 solr.1       |     <NUMBER> ...
11:31:38 solr.1       |     <TERM> ...
11:31:38 solr.1       |     "*" ...
11:31:38 solr.1       |     
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.generateParseException(QueryParser.java:1846)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.jj_consume_token(QueryParser.java:1728)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.Clause(QueryParser.java:1355)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.Query(QueryParser.java:1265)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.Clause(QueryParser.java:1341)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.Query(QueryParser.java:1265)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.TopLevelQuery(QueryParser.java:1254)
11:31:38 solr.1       |     at org.apache.lucene.queryParser.QueryParser.parse(QueryParser.java:200)
11:31:38 solr.1       |     ... 25 more
11:31:38 solr.1       | 
```
