### PR TITLE
Allow stopping sunspot-solr service

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -1,4 +1,3 @@
-require 'shellwords'
 require 'set'
 require 'tempfile'
 require 'sunspot/solr/java'
@@ -101,7 +100,7 @@ module Sunspot
         command << "-Djava.util.logging.config.file=#{logging_config_path}" if logging_config_path
         command << '-jar' << File.basename(solr_jar)
         FileUtils.cd(File.dirname(solr_jar)) do
-          exec(Shellwords.shelljoin(command))
+          exec(*command)
         end
       end
 


### PR DESCRIPTION
The use of Shellwords caused the sunspot-solr stop command to stop
working, because the exec call first created an intermediate system
shell, to handle escaped parameters. The registered pid is that of the
shell, terminating the shell does not terminate the java command.

Instead of trying to escape arguments it's possible to pass in arguments
explicitly to exec (and related calls such as system), this avoids the
possibility of an intermediate shell and any problems with escaping
