### PR TITLE
Allow symbol or string in :as declaration inside a model's searchable block (or Sunspot.setup)

### DIFF
--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -104,7 +104,7 @@ module Sunspot
     def set_indexed_name(options)
       @indexed_name =
         if options[:as]
-          options.delete(:as)
+          options.delete(:as).to_s
         else
           "#{@type.indexed_name(@name).to_s}#{'m' if @multiple }#{'s' if @stored}#{'v' if more_like_this?}"
         end

--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -89,7 +89,7 @@ module Sunspot
         # String:: Boolean phrase for restriction in the positive
         #
         def to_positive_boolean_phrase
-          "#{escape(@field.indexed_name.to_s)}:#{to_solr_conditional}"
+          "#{escape(@field.indexed_name)}:#{to_solr_conditional}"
         end
 
         # 

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -147,7 +147,7 @@ describe 'scoped_search' do
     it "allows for using symbols in defining static field names" do
       Sunspot.remove_all
       Sunspot.index!(Post.new)
-      expect { Sunspot.search(Post) { with(:legacy, "doesn't matter") } }.to_not raise_error
+      expect { Sunspot.search(Post) { with(:legacy, "doesn't matter") } }.to_not raise_error(NoMethodError, /undefined method.*gsub.*Symbol/)
     end
   end
 


### PR DESCRIPTION
When specifying a legacy field with :as, like:

```
searchable do
  string :legacy, :as => :legacy_field
end
```

Subsequent searches with fielded search:

```
MyModel.search do
  with :legacy, "some value"
end
```

raise this error: NoMethodError: undefined method `gsub' for :legacy:Symbol

This makes it so a symbol or a string can be used, interchangeably.
