### PR TITLE
[Fix] Failure with StubSessionProxy on Object.search_ids with use of raw_results

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -342,7 +342,7 @@ module Sunspot #:nodoc:
 
         def solr_execute_search_ids(options = {})
           search = yield
-          search.raw_results.map { |raw_result| raw_result.primary_key.to_i }
+          search.hits.map { |hit| hit.primary_key.to_i }
         end
         
         protected


### PR DESCRIPTION
Method 'raw_results' is now an alias of 'hits'
https://github.com/sunspot/sunspot/blob/master/sunspot/lib/sunspot/search/abstract_search.rb#L93

But the core searchable uses it when firing Object.search_ids requests :

https://github.com/sunspot/sunspot/blob/master/sunspot_rails/lib/sunspot/rails/searchable.rb#L345

This causes a fail when using StubSessionProxy as it doesn't have a mock for raw_results on the returned object. 

We could either add raw_results to StubSessionProxy, or IMHO the better fix is to use the correct (unaliased) method.

I had some trouble getting the sunspot_rails spec suite to run, so I haven't been able to write a test. But its pretty straight forward as there is no 'Post.search_ids' check, which explodes without this fix.

<!---
@huboard:{"order":14.0625}
-->
