### PR TITLE
Don't escape facet prefix

### DIFF
--- a/sunspot/lib/sunspot/query/abstract_field_facet.rb
+++ b/sunspot/lib/sunspot/query/abstract_field_facet.rb
@@ -30,7 +30,7 @@ module Sunspot
           params[qualified_param('offset')] = @options[:offset].to_i
         end
         if @options[:prefix]
-          params[qualified_param('prefix')] = escape(@options[:prefix].to_s)
+          params[qualified_param('prefix')] = @options[:prefix].to_s
         end
         params[qualified_param('mincount')] = 
           case

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -89,14 +89,7 @@ shared_examples_for "facetable query" do
       end
       connection.should have_last_search_with(:"f.title_ss.facet.prefix" => 'Test')
     end
-
-    it 'escapes the facet prefix' do
-      search do
-        facet :title, :prefix => 'Test Title'
-      end
-      connection.should have_last_search_with(:"f.title_ss.facet.prefix" => 'Test\ Title')
-    end
-
+    
     it 'sends a query facet for :any extra' do
       search do
         facet :category_ids, :extra => :any

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -156,6 +156,32 @@ describe 'search faceting' do
     end
   end
 
+  context 'prefix escaping' do
+    before do
+      Sunspot.remove_all
+      ["title1", "title2", "title with spaces 1", "title with spaces 2", "title/with/slashes/1", "title/with/slashes/2"].each do |value|
+        Sunspot.index(Post.new(:title => value, :blog_id => 1))
+      end
+      Sunspot.commit
+    end
+
+    it 'should limit facet values by a prefix with spaces' do
+      search = Sunspot.search(Post) do
+        with :blog_id, 1
+        facet :title, :prefix => 'title '
+      end
+      search.facet(:title).rows.map { |row| row.value }.sort.should == ["title with spaces 1", "title with spaces 2"]
+    end
+
+    it 'should limit facet values by a prefix with slashes' do
+      search = Sunspot.search(Post) do
+        with :blog_id, 1
+        facet :title, :prefix => 'title/'
+      end
+      search.facet(:title).rows.map { |row| row.value }.sort.should == ["title/with/slashes/1", "title/with/slashes/2"]
+    end
+  end
+
   context 'multiselect faceting' do
     before do
       Sunspot.remove_all


### PR DESCRIPTION
Although query params require escaping, facet prefix params do not, and will prevent matching in situations where characters do get escaped. Adds the regression specs that #169 was missing.

Prefix escaping was added in [this commit](https://github.com/sunspot/sunspot/commit/17b94682e99746f0e74a56ecad5145692ba4c6ee) 2 years ago. I'm not sure why it was added but the tests demonstrate that it is broken. Maybe an older version of solr worked this way?
