### PR TITLE
implement conjunctions for in_radius queries

### DIFF
--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -144,6 +144,18 @@ module Sunspot
         end
       end
 
+      class InRadius < Base
+        def initialize(negated, field, lat, lon, radius)
+          @lat, @lon, @radius = lat, lon, radius
+          super negated, field, [lat, lon, radius]
+        end
+
+        private
+          def to_positive_boolean_phrase
+            "_query_:\"{!geofilt sfield=#{@field.indexed_name} pt=#{@lat},#{@lon} d=#{@radius}}\""
+          end
+      end
+
       # 
       # Results must have field with value equal to given value. If the value
       # is nil, results must have no value for the given field.

--- a/sunspot/spec/api/query/connectives_examples.rb
+++ b/sunspot/spec/api/query/connectives_examples.rb
@@ -186,4 +186,16 @@ shared_examples_for "query with connective scope" do
     end
     connection.should_not have_last_search_including(:fq, '')
   end
+
+  it 'creates a conjunction of in_radius queries' do
+    search do
+      any_of do
+        with(:coordinates_new).in_radius(23, -46, 100)
+        with(:coordinates_new).in_radius(42, 56, 50)
+      end
+    end
+    connection.should have_last_search_including(
+      :fq, '(_query_:"{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}" OR _query_:"{!geofilt sfield=coordinates_new_ll pt=42,56 d=50}")'
+    )
+  end
 end

--- a/sunspot/spec/integration/geospatial_spec.rb
+++ b/sunspot/spec/integration/geospatial_spec.rb
@@ -25,6 +25,17 @@ describe "geospatial search" do
 
       results.should_not include(@post)
     end
+
+    it "allows conjunction queries" do
+      results = Sunspot.search(Post) {
+        any_of do
+          with(:coordinates_new).in_radius(32, -68, 1)
+          with(:coordinates_new).in_radius(35, 68, 1)
+        end
+      }.results
+
+      results.should include(@post)
+    end
   end
 
   describe "filtering by bounding box" do


### PR DESCRIPTION
This pull request implements conjunctions for in_radius queries. This limitation is also referenced in https://github.com/sunspot/sunspot/issues/227. Therefore one can now do:

``` ruby
    search do
      any_of do
        with(:coordinates_new).in_radius(23, -46, 100)
        with(:coordinates_new).in_radius(42, 56, 50)
      end
    end
```

This is my first patch to sunspot, so maybe you can point out improvements. 
