### PR TITLE
User can choose to use get http method

### DIFF
--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -23,6 +23,7 @@ module Sunspot
         LightConfig.build do
           solr do
             url 'http://127.0.0.1:8983/solr'
+            http_method  'post'
             read_timeout nil
             open_timeout nil
           end

--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -23,7 +23,7 @@ module Sunspot
         LightConfig.build do
           solr do
             url 'http://127.0.0.1:8983/solr'
-            http_method  'post'
+            http_method  'get'
             read_timeout nil
             open_timeout nil
           end
@@ -38,7 +38,7 @@ module Sunspot
           end
         end
       end
-      
+
       # Location for the default solr configuration files,
       # required for bootstrapping a new solr installation
       #

--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -22,7 +22,7 @@ module Sunspot
       include HitEnumerable
   
       def initialize(connection, setup, query, configuration) #:nodoc:
-        @connection, @setup, @query = connection, setup, query
+        @connection, @setup, @query, @configuration = connection, setup, query, configuration
         @query.paginate(1, configuration.pagination.default_per_page)
 
         @facets = []
@@ -42,7 +42,7 @@ module Sunspot
       def execute
         reset
         params = @query.to_params
-        if configuration.solr.http_method.to_s == 'get'
+        if @configuration.solr.http_method.to_s == 'get'
           @solr_result = @connection.get "#{request_handler}", :params => params
         else
           @solr_result = @connection.post "#{request_handler}", :data => params

--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -42,7 +42,11 @@ module Sunspot
       def execute
         reset
         params = @query.to_params
-        @solr_result = @connection.post "#{request_handler}", :data => params
+        if configuration.solr.http_method.to_s == 'get'
+          @solr_result = @connection.get "#{request_handler}", :params => params
+        else
+          @solr_result = @connection.post "#{request_handler}", :data => params
+        end
         self
       end
 

--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -3,15 +3,15 @@ require 'sunspot/search/hit_enumerable'
 
 module Sunspot
   module Search #:nodoc:
-    
-    # 
+
+    #
     # This class encapsulates the results of a Solr search. It provides access
     # to search results, total result count, facets, and pagination information.
     # Instances of Search are returned by the Sunspot.search and
     # Sunspot.new_search methods.
     #
     class AbstractSearch
-      # 
+      #
       # Retrieve all facet objects defined for this search, in order they were
       # defined. To retrieve an individual facet by name, use #facet()
       #
@@ -20,7 +20,7 @@ module Sunspot
       attr_accessor :request_handler
 
       include HitEnumerable
-  
+
       def initialize(connection, setup, query, configuration) #:nodoc:
         @connection, @setup, @query, @configuration = connection, setup, query, configuration
         @query.paginate(1, configuration.pagination.default_per_page)
@@ -31,7 +31,7 @@ module Sunspot
         @groups_by_name = {}
         @groups = []
       end
-  
+
       #
       # Execute the search on the Solr instance and store the results. If you
       # use Sunspot#search() to construct your searches, there is no need to call
@@ -42,10 +42,10 @@ module Sunspot
       def execute
         reset
         params = @query.to_params
-        if @configuration.solr.http_method.to_s == 'get'
-          @solr_result = @connection.get "#{request_handler}", :params => params
-        else
+        if @configuration.solr.http_method.to_s == 'post'
           @solr_result = @connection.post "#{request_handler}", :data => params
+        else
+          @solr_result = @connection.get "#{request_handler}", :params => params
         end
         self
       end
@@ -53,8 +53,8 @@ module Sunspot
       def execute! #:nodoc: deprecated
         execute
       end
-  
-      # 
+
+      #
       # Get the collection of results as instantiated objects. If WillPaginate is
       # available, the results will be a WillPaginate::Collection instance; if
       # not, it will be a vanilla Array.
@@ -69,8 +69,8 @@ module Sunspot
       def results
         @results ||= paginate_collection(verified_hits.map { |hit| hit.instance })
       end
-  
-      # 
+
+      #
       # Access raw Solr result information. Returns a collection of Hit objects
       # that contain the class name, primary key, keyword relevance score (if
       # applicable), and any stored fields.
@@ -96,7 +96,7 @@ module Sunspot
       end
       alias_method :raw_results, :hits
 
-      # 
+      #
       # The total number of documents matching the query parameters
       #
       # ==== Returns
@@ -106,8 +106,8 @@ module Sunspot
       def total
         @total ||= solr_response['numFound'] || 0
       end
-  
-      # 
+
+      #
       # The time elapsed to generate the Solr response
       #
       # ==== Returns
@@ -117,8 +117,8 @@ module Sunspot
       def query_time
         @query_time ||= solr_response_header['QTime']
       end
-  
-      # 
+
+      #
       # Get the facet object for the given name. `name` can either be the name
       # given to a query facet, or the field name of a field facet. Returns a
       # Sunspot::Facet object.
@@ -173,14 +173,14 @@ module Sunspot
           @groups_by_name[name.to_sym]
         end
       end
-  
-      # 
+
+      #
       # Deprecated in favor of optional second argument to #facet
       #
       def dynamic_facet(base_name, dynamic_name) #:nodoc:
         facet(base_name, dynamic_name)
       end
-  
+
       def facet_response #:nodoc:
         @solr_result['facet_counts']
       end
@@ -188,8 +188,8 @@ module Sunspot
       def group_response #:nodoc:
         @solr_result['grouped']
       end
-  
-      # 
+
+      #
       # Build this search using a DSL block. This method can be called more than
       # once on an unexecuted search (e.g., Sunspot.new_search) in order to build
       # a search incrementally.
@@ -206,8 +206,8 @@ module Sunspot
         Util.instance_eval_or_call(dsl, &block)
         self
       end
-  
-  
+
+
       def inspect #:nodoc:
         "<Sunspot::Search:#{query.to_params.inspect}>"
       end
@@ -215,16 +215,16 @@ module Sunspot
       def add_field_group(field, options = {}) #:nodoc:
         add_group(field.name, FieldGroup.new(field, self, options))
       end
-  
+
       def add_field_facet(field, options = {}) #:nodoc:
         name = (options[:name] || field.name)
         add_facet(name, FieldFacet.new(field, self, options))
       end
-  
+
       def add_query_facet(name, options) #:nodoc:
         add_facet(name, QueryFacet.new(name, self, options))
       end
-  
+
       def add_date_facet(field, options) #:nodoc:
         name = (options[:name] || field.name)
         add_facet(name, DateFacet.new(field, self, options))
@@ -240,21 +240,21 @@ module Sunspot
           @solr_result['highlighting'][doc['id']]
         end
       end
-  
+
       private
-  
+
       def dsl
-        raise NotImplementedError 
+        raise NotImplementedError
       end
-  
+
       def execute_request(params)
         raise NotImplementedError
       end
-  
+
       def solr_response
         @solr_response ||= @solr_result['response'] || {}
       end
-  
+
       def solr_response_header
         @solr_response_header ||= @solr_result['responseHeader'] || {}
       end
@@ -262,15 +262,15 @@ module Sunspot
       def solr_docs
         solr_response['docs']
       end
-  
+
       def verified_hits
         @verified_hits ||= paginate_collection(super)
       end
-  
+
       def paginate_collection(collection)
         PaginatedCollection.new(collection, @query.page, @query.per_page, total)
       end
-  
+
       def add_facet(name, facet)
         @facets << facet
         @facets_by_name[name.to_sym] = facet
@@ -280,7 +280,7 @@ module Sunspot
         @groups << group
         @groups_by_name[name.to_sym] = group
       end
-      
+
       # Clear out all the cached ivars so the search can be called again.
       def reset
         @results = @hits = @verified_hits = @total = @solr_response = @doc_ids = nil

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -62,6 +62,14 @@ module Mock
       @response || {}
     end
 
+    def get(path, params)
+      unless path == "#{@expected_handler}"
+        raise ArgumentError, "Expected request to #{@expected_handler} request handler"
+      end
+      @searches << @last_search = params[:params]
+      @response || {}
+    end
+
     def method_missing(method, *args, &block)
       get("#{method}", *args)
     end


### PR DESCRIPTION
There are a lot of use cases where using `get` is acceptable.
Using `get` makes it easy for us to use http caching like varnish etc

<!---
@huboard:{"order":0.765625}
-->


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sunspot/sunspot/276)
<!-- Reviewable:end -->
