### PR TITLE
Return an Enumerator from each_hit_with_result if no block is given

### DIFF
--- a/sunspot/lib/sunspot/search/hit_enumerable.rb
+++ b/sunspot/lib/sunspot/search/hit_enumerable.rb
@@ -46,9 +46,7 @@ module Sunspot
       # for more information).
       #
       def each_hit_with_result
-        verified_hits.each do |hit|
-          yield(hit, hit.result)
-        end
+        verified_hits.map { |h| [h, h.result] }.each
       end
 
       # 

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -49,6 +49,18 @@ describe 'hits', :type => :search do
     end
   end
 
+  it 'should provide an Enumerator over hits with instances' do
+    posts = Array.new(2) { Post.new }
+    stub_results(*posts)
+    search = session.search(Post)
+    hits, results = [], []
+    search.each_hit_with_result.with_index do |(hit, result), index|
+      hit.should be_kind_of(Sunspot::Search::Hit)
+      result.should be_kind_of(Post)
+      index.should be_kind_of(Integer)
+    end
+  end
+
   it 'should hydrate all hits when an instance is requested from a hit' do
     posts = Array.new(2) { Post.new }
     stub_results(*posts)


### PR DESCRIPTION
This is standard enumerable behavior from the stdlib. When not given a block, enumerables return an Enumerator so that further enumerator methods like with_index or with_object can be chained on. I recently had a use case where we needed to add an index to the iteration and we had to do it manually rather than being able to chain a with_index.
