### PR TITLE
Fix test pollution, on Travis, sorta

### DIFF
--- a/sunspot/spec/api/sunspot_spec.rb
+++ b/sunspot/spec/api/sunspot_spec.rb
@@ -4,11 +4,11 @@ describe Sunspot do
 
   describe "setup" do
     it "should register the class in Sunspot.searchable" do
-      Sunspot.setup(Blog) do
+      Sunspot.setup(User) do
         text :name
       end
       Sunspot.searchable.should_not be_empty
-      Sunspot.searchable.should include(Blog)
+      Sunspot.searchable.should include(User)
     end
   end
 


### PR DESCRIPTION
Switching to 'User' here instead of 'Blog' fixes [sunspot/spec/api/indexer/fixed_fields_spec.rb:45](https://github.com/sunspot/sunspot/blob/master/sunspot/spec/api/indexer/fixed_fields_spec.rb#L45) on Travis. It was failing because this sunspot_spec was being run first, setting up the Blog class, and thus somehow making the future test fail. :cry:

This was only failing on Jenkins, mysteriously.
