### PR TITLE
Mark selected facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,40 @@ Sunspot.search(Post) do
 end
 ```
 
+#### Facet Inclusion in Response
+```ruby
+# Posts tagged with 'pizza' and any of 'Marcel Proust' or 'James Beard'.
+# Response includes counts for each :cuisine_id and :author_id, a FacetRow
+# for each of 'pizza', 'Marcel Proust', and 'James Beard'.
+@search = Post.search do
+  with(:cuisine_id).all_of(['pizza'])
+  with(:author_id).any_of(['Marcel Proust', 'James Beard'])
+  facet :author_id
+  facet :cuisine_id
+end
+
+# Example using the FacetRow.selected method to:
+# 1) succinctly render an "undo" link for facet 'pizza'
+# 2) show the state of 'Marcel Proust' and 'James Beard' checkboxes as
+#    selected in the user interface.
+# This example assumes a link_to_undo helper as well as other
+# implementation details left out as there are many solutions and this is
+# meant only to illustrate the FacetRow "selected" method.
+    <% for row in @search.facet('cuisine_id').rows %>
+      <% if row.selected %>
+        <%= link_to_undo('cuisine_id', row.value.to_s, row.instance.name) %>
+        <%= hidden_field_tag ('cuisine_id[]').to_sym, row.value %>
+      <% else %>
+        <%= link_to(row.instance.name, request.fullpath, %{#{facet}_id[]=#{row.value}} %> (<%= row.count %>)
+      <% end %>
+    <% end %>
+
+    <% for row in @search_response.facet('author_id').rows %>
+      <%= check_box_tag(facet + '[]', row.value.to_s, row.selected, id: row.value.to_s.parameterize) %>
+      <%= label_tag(row.value.to_s.parameterize, %{#{row.value} (#{row.count})}) %></li>
+    <% end %>
+```
+
 ### Ordering
 
 By default, Sunspot orders results by "score": the Solr-determined

--- a/sunspot/lib/sunspot/search/facet_row.rb
+++ b/sunspot/lib/sunspot/search/facet_row.rb
@@ -1,11 +1,11 @@
 module Sunspot
   module Search
     class FacetRow
-      attr_reader :value, :count
+      attr_reader :value, :count, :selected
       attr_writer :instance #:nodoc:
 
-      def initialize(value, count, facet) #:nodoc:
-        @value, @count, @facet = value, count, facet
+      def initialize(value, count, facet, selected=nil) #:nodoc:
+        @value, @count, @facet, @selected = value, count, facet, selected
       end
 
       # 

--- a/sunspot/lib/sunspot/search/field_facet.rb
+++ b/sunspot/lib/sunspot/search/field_facet.rb
@@ -39,7 +39,8 @@ module Sunspot
               if @search.facet_response['facet_fields']
                 if data = @search.facet_response['facet_fields'][key]
                   data.each_slice(2) do |value, count|
-                    row = FacetRow.new(@field.cast(value), count, self)
+                    selected = ! (@search.fq_response_header.nil? || @search.fq_response_header[key].nil?) && @search.fq_response_header[key].include?(value)
+                    row = FacetRow.new(@field.cast(value), count, self, selected)
                     rows << row
                   end
                 end

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -212,6 +212,18 @@ describe 'search faceting' do
         search.facet(:category_ids).rows.map { |row| row.value }.should == [1]
         search.facet(:all_category_ids).rows.map { |row| row.value }.to_set.should == Set[1, 2]
       end
+
+      it 'marks all facet values specified in search as selected' do
+        search = Sunspot.search(Post) do
+          facet(:category_ids)
+          with(:category_ids).any_of([1])
+        end
+        search.facet(:category_ids).rows.each do |row|
+          row.selected.should == true if row.value == 1
+          row.selected.should == false if row.value != 1
+        end
+      end
+
     end
 
     context 'query faceting' do


### PR DESCRIPTION
The is a re-request of a closed pull request (https://github.com/sunspot/sunspot/pull/41). I made changes per comments from @nz. 

I added a "selected" method on the FacetRow. I determine which facets are selected by inspecting the solr responseHeader in AbstractSearch, called from FieldFacet. In AbstractSearch I created the fq_response method which exposes all the values in responseHeader.params.fq as a Hash. If the hash key ends in '_im' or '_s', then I further split the hash value into an array.

For example:
fq: [
"type:VenueOffering"
"amenities_ids_im:(9 AND 12)"
"neighborhood_s:(East\ Village OR Chelsea)"
"capacity_max_is:[30 TO *]"
]

becomes
fq_response: ["type" => "VenueOffering", "amenties_ids_im" => ["9", "12"], "neighborhood_s" => ["East Village", "Chelsea"], "capacity_max_is" => "[30 TO *]"]

<!---
@huboard:{"order":0.3828125}
-->
