### PR TITLE
Add support for boost amounts on functions.

### DIFF
--- a/sunspot/lib/sunspot/query/function_query.rb
+++ b/sunspot/lib/sunspot/query/function_query.rb
@@ -5,6 +5,11 @@ module Sunspot
     #
     class FunctionQuery 
       include RSolr::Char
+
+      def ^(y)
+        @boost_amount = y
+        self
+      end
     end
 
     #
@@ -16,7 +21,7 @@ module Sunspot
       end
 
       def to_s
-        Type.to_literal(@constant)
+        Type.to_literal(@constant) << (@boost_amount ? "^#{@boost_amount}" : "")
       end
     end
 
@@ -29,7 +34,7 @@ module Sunspot
       end
 
       def to_s
-        "#{escape(@field.indexed_name)}"
+        "#{escape(@field.indexed_name)}" << (@boost_amount ? "^#{@boost_amount}" : "")
       end
     end
 
@@ -45,7 +50,7 @@ module Sunspot
 
       def to_s
         params = @function_args.map { |arg| arg.to_s }.join(",")
-        "#{@function_name}(#{params})"
+        "#{@function_name}(#{params})" << (@boost_amount ? "^#{@boost_amount}" : "")
       end
     end
   end

--- a/sunspot/spec/api/query/function_spec.rb
+++ b/sunspot/spec/api/query/function_spec.rb
@@ -10,6 +10,15 @@ describe 'function query' do
     connection.should have_last_search_including(:bf, 'average_rating_ft')
   end
 
+  it "should send query to solr with boost function and boost amount" do
+    session.search Post do
+      keywords('pizza') do
+        boost(function { :average_rating }^5)
+      end
+    end
+    connection.should have_last_search_including(:bf, 'average_rating_ft^5')
+  end
+
   it "should handle boost function with constant float" do
     session.search Post do
       keywords('pizza') do
@@ -17,6 +26,15 @@ describe 'function query' do
       end
     end
     connection.should have_last_search_including(:bf, '10.5')
+  end
+
+  it "should handle boost function with constant float and boost amount" do
+    session.search Post do
+      keywords('pizza') do
+        boost(function { 10.5 }^5)
+      end
+    end
+    connection.should have_last_search_including(:bf, '10.5^5')
   end
 
   it "should handle boost function with time literal" do
@@ -44,6 +62,15 @@ describe 'function query' do
       end
     end
     connection.should have_last_search_including(:bf, 'sub(average_rating_ft,10)')
+  end
+
+  it "should handle boost amounts on function query block" do
+    session.search Post do
+      keywords('pizza') do
+        boost(function { sub(:average_rating, 10)^5 })
+      end
+    end
+    connection.should have_last_search_including(:bf, 'sub(average_rating_ft,10)^5')
   end
  
   it "should handle nested functions in a function query block" do


### PR DESCRIPTION
This pull request enables use of the `^` operator to indicate the boost amount on a particular function.

I've added a couple of tests that should properly illustrate how it's used.

Hopefully this is merge-worthy. I'm open to feedback on how this could be improved!
