### PR TITLE
Only reindex changes of

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -46,6 +46,11 @@ module Sunspot #:nodoc:
         # :ignore_attribute_changes_of<Array>::
         #   Define attributes, that should not trigger a reindex of that
         #   object. Usual suspects are updated_at or counters.
+        # :only_reindex_attribute_changes_of<Array>::
+        #   Define attributes, that are the only attributes that should
+        #   trigger a reindex of that object. Useful if there are a small
+        #   number of searchable attributes and a large number of attributes
+        #   to ignore.
         # :include<Mixed>::
         #   Define default ActiveRecord includes, set this to allow ActiveRecord
         #   to load required associations when indexing. See ActiveRecord's 
@@ -465,6 +470,8 @@ module Sunspot #:nodoc:
             @marked_for_auto_indexing =
               if !new_record? && ignore_attributes = self.class.sunspot_options[:ignore_attribute_changes_of]
                 !(changed.map { |attr| attr.to_sym } - ignore_attributes).blank?
+              elsif !new_record? && only_attributes = self.class.sunspot_options[:only_reindex_attribute_changes_of]
+                !(changed.map { |attr| attr.to_sym } & only_attributes).blank?
               else
                 true
               end

--- a/sunspot_rails/spec/model_lifecycle_spec.rb
+++ b/sunspot_rails/spec/model_lifecycle_spec.rb
@@ -60,5 +60,22 @@ describe 'searchable with lifecycle' do
       @post.update_attribute :updated_at, 123.seconds.from_now
     end
   end
+
+  describe 'only paying attention to specific attributes' do
+    before(:each) do
+      @post = PostWithOnlySomeAttributesTriggeringReindex.create
+    end
+
+    it "should not reindex the object on an update_at change, because it is not in the whitelist" do
+      Sunspot.should_not_receive(:index).with(@post)
+      @post.update_attribute :updated_at, 123.seconds.from_now
+    end
+
+    it "should reindex the object on a title change, because it is in the whitelist" do
+      Sunspot.should_receive(:index).with(@post)
+      @post.update_attribute :title, "brand new title"
+    end
+
+  end
 end
 

--- a/sunspot_rails/spec/rails_template/app/models/post_with_only_some_attributes_triggering_reindex.rb
+++ b/sunspot_rails/spec/rails_template/app/models/post_with_only_some_attributes_triggering_reindex.rb
@@ -1,0 +1,12 @@
+class PostWithOnlySomeAttributesTriggeringReindex < ActiveRecord::Base
+  def self.table_name
+    'posts'
+  end
+
+  attr_accessible :title, :type, :location_id, :body, :blog
+
+  searchable :only_reindex_attribute_changes_of => [ :title, :body ] do
+    string :title
+    text :body, :more_like_this => true
+  end
+end


### PR DESCRIPTION
This adds an option that is the opposite of :ignore_attribute_changes_of. I've named it :only_reindex_attribute_changes_of but I will gladly rename it to whatever best fits in the project.

Instead of a blacklist of changing attributes to ignore, this is a whitelist of attributes that are the only ones that should trigger a reindex.

My use case is in a model with many attributes that only have a few that are searchable, and we'd rather list the positive set than the negative set. The set of searchable attributes is also less likely to change or be added to than the set of attributes that should be ignored.
