### PR TITLE
Travis tests for sunspot_rails are failing but they look like they're passing because the build exit status is wrong

### DIFF
--- a/sunspot_rails/dev_tasks/spec.rake
+++ b/sunspot_rails/dev_tasks/spec.rake
@@ -27,7 +27,7 @@ namespace :spec do
 
     unless File.exist?(ENV['BUNDLE_PATH'])
       puts "Installing gems for Rails #{version} (this will only be done once)..."
-      system("bundle install #{ENV['BUNDLE_ARGS']}") || exit(1)
+      sh "bundle install #{ENV['BUNDLE_ARGS']}"
     end
   end
 
@@ -40,9 +40,9 @@ namespace :spec do
 
       puts "Generating Rails #{version} application..."
       if version.start_with?("2")
-        system("#{rails_cmd} \"#{app_path}\" --force") || exit(1)
+        sh "#{rails_cmd} \"#{app_path}\" --force"
       elsif version.start_with?("3")
-        system("#{rails_cmd} new \"#{app_path}\" --force --skip-git --skip-javascript --skip-gemfile --skip-sprockets") || exit(1)
+        sh "#{rails_cmd} new \"#{app_path}\" --force --skip-git --skip-javascript --skip-gemfile --skip-sprockets"
       end
     end
   end
@@ -66,7 +66,7 @@ namespace :spec do
                      "rspec"
                    end
 
-    system "bundle exec #{spec_command} #{ENV['SPEC'] || 'spec/*_spec.rb'} --color"
+    sh "bundle exec #{spec_command} #{ENV['SPEC'] || 'spec/*_spec.rb'} --color"
   end
 end
 


### PR DESCRIPTION
So all the sunspot_rails test commands have failures in them now (which you can see by looking at the output of e.g. https://travis-ci.org/#!/sunspot/sunspot/jobs/2890640) but the travis overview makes it look like they're all passing.

This is because the exit status of the rake task is not bubbling up correctly.

This can be fixed by using rake's `sh` instead of `system` as discussed here: http://muness.blogspot.com/2007/06/failing-rake-task-that-executes-shell_20.html

The travis commands on this PR now show the actual outcomes: https://travis-ci.org/#!/carols10cents/sunspot/builds/2893804 :(
