### PR TITLE
Fixing rails 3.0.x compatibility in Optimized memory usage when calling solr_index_orphans

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -294,7 +294,7 @@ module Sunspot #:nodoc:
             solr_ids.concat ids
           end
 
-          return solr_ids - self.connection.select_values(select(:id).arel).collect(&:to_i)
+          return solr_ids - self.connection.select_values(select(:id).to_sql).collect(&:to_i)
         end
 
         # 


### PR DESCRIPTION
See https://github.com/sunspot/sunspot/pull/282
