### PR TITLE
Fixing rails 3.0.x compatibility in Optimized memory usage when calling solr_index_orphans

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -289,13 +289,17 @@ module Sunspot #:nodoc:
         #
         # Array:: Collection of IDs that exist in Solr but not in the database
         def solr_index_orphans(opts={})
-          batch_size = opts[:batch_size] || Sunspot.config.indexing.default_batch_size
-          count = self.count
-          indexed_ids = solr_search_ids { paginate(:page => 1, :per_page => count) }.to_set
-          find_each(:select => 'id', :batch_size => batch_size) do |object|
-            indexed_ids.delete(object.id)
+          batch_size = opts[:batch_size] || Sunspot.config.indexing.default_batch_size          
+
+          solr_page = 0
+          solr_ids = []
+          while (solr_page = solr_page.next)
+            ids = solr_search_ids { paginate(:page => solr_page, :per_page => 1000) }.to_a
+            break if ids.empty?
+            solr_ids.concat ids
           end
-          indexed_ids.to_a
+
+          return solr_ids - self.connection.select_values("SELECT id FROM #{quoted_table_name}").collect(&:to_i)
         end
 
         # 


### PR DESCRIPTION
See https://github.com/sunspot/sunspot/pull/282
