### PR TITLE
Test against ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
+  - 2.0.0
   # - rbx-2.0
   # - jruby
 
@@ -30,6 +31,10 @@ matrix:
       env: GEM=sunspot_rails RAILS=3.2.8
     - rvm: 1.9.3
       env: GEM=sunspot_rails RAILS=2.3.14
+
+  allow_failures:
+    - rvm: 2.0.0
+
 
 script:
   - ci/travis.sh


### PR DESCRIPTION
It's good to test against ruby 2.0. Please note, by setting `allow_features`, the failure testing against ruby 2.0 won't affect the overall build result
