### PR TITLE
removing some warnings in ruby's verbose mode.

### DIFF
--- a/sunspot/lib/sunspot/dsl/field_query.rb
+++ b/sunspot/lib/sunspot/dsl/field_query.rb
@@ -70,8 +70,6 @@ module Sunspot
       #
       # field_name<Symbol>:: the field to use for grouping
       def group(*field_names, &block)
-        options = Sunspot::Util.extract_options_from(field_names)
-
         field_names.each do |field_name|
           field = @setup.field(field_name)
           group = @query.add_group(Sunspot::Query::FieldGroup.new(field))

--- a/sunspot/lib/sunspot/dsl/fulltext.rb
+++ b/sunspot/lib/sunspot/dsl/fulltext.rb
@@ -5,8 +5,6 @@ module Sunspot
     # handler.
     #
     class Fulltext
-      attr_reader :exclude_fields #:nodoc:
-
       # accept function in boost
       include Functional
 

--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -12,6 +12,7 @@ module Sunspot
       @name, @type = name.to_sym, type
       @stored = !!options.delete(:stored)
       @more_like_this = !!options.delete(:more_like_this)
+      @multiple ||= false
       set_indexed_name(options)
       raise ArgumentError, "Field of type #{type} cannot be used for more_like_this" unless type.accepts_more_like_this? or !@more_like_this
     end
@@ -34,7 +35,7 @@ module Sunspot
     #
     def to_indexed(value)
       if value.is_a? Array
-        if @multiple
+        if multiple?
           value.map { |val| to_indexed(val) }
         else
           raise ArgumentError, "#{name} is not a multiple-value field, so it cannot index values #{value.inspect}"
@@ -106,7 +107,7 @@ module Sunspot
         if options[:as]
           options.delete(:as).to_s
         else
-          "#{@type.indexed_name(@name).to_s}#{'m' if @multiple }#{'s' if @stored}#{'v' if more_like_this?}"
+          "#{@type.indexed_name(@name).to_s}#{'m' if multiple? }#{'s' if @stored}#{'v' if more_like_this?}"
         end
     end
 

--- a/sunspot/lib/sunspot/query/common_query.rb
+++ b/sunspot/lib/sunspot/query/common_query.rb
@@ -10,6 +10,9 @@ module Sunspot
         else
           @scope.add_positive_restriction(TypeField.instance, Restriction::AnyOf, types)
         end
+
+        @pagination = nil
+        @parameter_adjustment = nil
       end
 
       def solr_parameter_adjustment=(block)

--- a/sunspot/lib/sunspot/query/dismax.rb
+++ b/sunspot/lib/sunspot/query/dismax.rb
@@ -15,6 +15,12 @@ module Sunspot
         @boost_queries = []
         @boost_functions = []
         @highlights = []
+
+        @minimum_match = nil
+        @phrase_fields = nil
+        @phrase_slop = nil
+        @query_phrase_slop = nil
+        @tie = nil
       end
 
       #

--- a/sunspot/lib/sunspot/query/filter.rb
+++ b/sunspot/lib/sunspot/query/filter.rb
@@ -31,7 +31,7 @@ module Sunspot
       # to include a tag in the local params.
       #
       def tagged?
-        !!@tag
+        defined?(@tag) && !!@tag
       end
     end
   end

--- a/sunspot/lib/sunspot/query/geo.rb
+++ b/sunspot/lib/sunspot/query/geo.rb
@@ -1,6 +1,6 @@
 begin
   require 'geohash'
-rescue LoadError => e
+rescue LoadError
   require 'pr_geohash'
 end
 

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -14,6 +14,7 @@ module Sunspot
       @stored_field_factories_cache = Hash.new { |h, k| h[k] = [] }
       @more_like_this_field_factories_cache = Hash.new { |h, k| h[k] = [] }
       @dsl = DSL::Fields.new(self)
+      @document_boost_extractor = nil
       add_field_factory(:class, Type::ClassType.instance)
     end
 

--- a/sunspot/lib/sunspot/type.rb
+++ b/sunspot/lib/sunspot/type.rb
@@ -1,7 +1,7 @@
 require 'singleton'
 begin
   require 'geohash'
-rescue LoadError => e
+rescue LoadError
   require 'pr_geohash'
 end
 

--- a/sunspot/lib/sunspot/util.rb
+++ b/sunspot/lib/sunspot/util.rb
@@ -202,7 +202,7 @@ module Sunspot
       class <<self
         def instance_eval_with_context(receiver, &block)
           calling_context = eval('self', block.binding)
-          if parent_calling_context = calling_context.instance_eval{@__calling_context__}
+          if parent_calling_context = calling_context.instance_eval{@__calling_context__ if defined?(@__calling_context__)}
             calling_context = parent_calling_context
           end
           new(receiver, calling_context).instance_eval(&block)

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -11,7 +11,7 @@ module Sunspot #:nodoc:
     begin
       require 'sunspot_solr'
       autoload :Server, File.join(File.dirname(__FILE__), 'rails', 'server')
-    rescue LoadError => e
+    rescue LoadError
       # We're fine
     end
 

--- a/sunspot_rails/lib/sunspot/rails/adapters.rb
+++ b/sunspot_rails/lib/sunspot/rails/adapters.rb
@@ -20,7 +20,8 @@ module Sunspot #:nodoc:
 
       class ActiveRecordDataAccessor < Sunspot::Adapters::DataAccessor
         # options for the find
-        attr_accessor :include, :select
+        attr_accessor :include
+        attr_reader :select
 
         def initialize(clazz)
           super(clazz)
@@ -78,8 +79,8 @@ module Sunspot #:nodoc:
         
         def options_for_find
           options = {}
-          options[:include] = @include unless @include.blank?
-          options[:select]  =  @select unless  @select.blank?
+          options[:include] = @include unless !defined?(@include) || @include.blank?
+          options[:select]  =  @select unless !defined?(@select)  || @select.blank?
           options
         end
       end

--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -19,7 +19,7 @@ module Sunspot
       end
       
       def self.logger
-        @logger
+        @logger if defined?(@logger)
       end
       
       def logger

--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -19,8 +19,9 @@ module Sunspot
 
       LOG_LEVELS = Set['SEVERE', 'WARNING', 'INFO', 'CONFIG', 'FINE', 'FINER', 'FINEST']
 
-      attr_accessor :min_memory, :max_memory, :bind_address, :port, :solr_data_dir, :solr_home, :log_file
-      attr_writer :pid_dir, :pid_file, :log_level, :solr_data_dir, :solr_home, :solr_jar
+      attr_accessor :min_memory, :max_memory, :bind_address, :port, :log_file
+
+      attr_writer :pid_dir, :pid_file, :solr_data_dir, :solr_home, :solr_jar
 
       def initialize(*args)
         ensure_java_installed


### PR DESCRIPTION
Thanks for the great library. In running my tests in verbose mode, I noticed a lot of warnings being thrown by sunspot (hundreds and hundreds of lines over my suite).

I cleaned those up, mostly by just deleting some unnecessary assignment and accessors and occasionally having to check if an ivar is defined.

I'm happy to make revisions if necessary. It'd be great for this library to be less noisy in verbose mode.

Thanks
