### PR TITLE
Remove append mode from STDOUT.reopen

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -69,7 +69,7 @@ module Sunspot
           pid = fork do
             Process.setsid
             STDIN.reopen('/dev/null')
-            STDOUT.reopen('/dev/null', 'a')
+            STDOUT.reopen('/dev/null')
             STDERR.reopen(STDOUT)
             run
           end


### PR DESCRIPTION
This causes problems when used in conjunction with `zeus rake`

Is there a real need for it? If not, this makes it work. Thanks!
