### PR TITLE
Allow symlinks for solr_data_dir and pid_dir

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -189,7 +189,7 @@ module Sunspot
       #
       def create_solr_directories
         [solr_data_dir, pid_dir].each do |path|
-          FileUtils.mkdir_p(path) unless File.exists?(path)
+          FileUtils.mkdir_p(path) unless File.exists?(path) || File.symlink?(path)
         end
       end
 


### PR DESCRIPTION
My deploys keep failing because I symlink these directories. No reason to disallow them that I know of.
