### PR TITLE
add support for conjunctions with bounding box

### DIFF
--- a/sunspot/lib/sunspot/query/bbox.rb
+++ b/sunspot/lib/sunspot/query/bbox.rb
@@ -5,8 +5,12 @@ module Sunspot
         @field, @first_corner, @second_corner = field, first_corner, second_corner
       end
 
+      def to_solr_conditional
+        "[#{@first_corner.join(",")} TO #{@second_corner.join(",")}]"
+      end
+
       def to_params
-        filter = "#{@field.indexed_name}:[#{@first_corner.join(",")} TO #{@second_corner.join(",")}]"
+        filter = "#{@field.indexed_name}:#{to_solr_conditional}"
 
         {:fq => filter}
       end

--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -156,6 +156,17 @@ module Sunspot
           end
       end
 
+      class InBoundingBox < Base
+        def initialize(negated, field, first_corner, second_corner)
+          @bbox = Sunspot::Query::Bbox.new(field, first_corner, second_corner)
+          super negated, field, [first_corner, second_corner]
+        end
+
+        def to_solr_conditional
+          @bbox.to_solr_conditional
+        end
+      end
+
       # 
       # Results must have field with value equal to given value. If the value
       # is nil, results must have no value for the given field.

--- a/sunspot/spec/api/query/connectives_examples.rb
+++ b/sunspot/spec/api/query/connectives_examples.rb
@@ -198,4 +198,16 @@ shared_examples_for "query with connective scope" do
       :fq, '(_query_:"{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}" OR _query_:"{!geofilt sfield=coordinates_new_ll pt=42,56 d=50}")'
     )
   end
+  
+  it 'creates a conjunction of in_bounding_box queries' do
+    search do
+      any_of do
+        with(:coordinates_new).in_bounding_box([23, -46], [25, -44])
+        with(:coordinates_new).in_bounding_box([42, 56], [43, 58])
+      end
+    end
+    connection.should have_last_search_including(
+      :fq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])'
+    )
+  end
 end

--- a/sunspot/spec/integration/geospatial_spec.rb
+++ b/sunspot/spec/integration/geospatial_spec.rb
@@ -26,11 +26,22 @@ describe "geospatial search" do
       results.should_not include(@post)
     end
 
-    it "allows conjunction queries" do
+    it "allows conjunction queries with radius" do
       results = Sunspot.search(Post) {
         any_of do
           with(:coordinates_new).in_radius(32, -68, 1)
           with(:coordinates_new).in_radius(35, 68, 1)
+        end
+      }.results
+
+      results.should include(@post)
+    end
+
+    it "allows conjunction queries with bounding box" do
+      results = Sunspot.search(Post) {
+        any_of do
+          with(:coordinates_new).in_bounding_box([31, -69], [33, -67])
+          with(:coordinates_new).in_bounding_box([35, 68], [36, 69])
         end
       }.results
 


### PR DESCRIPTION
Allow `with().in_bounding_box()` restrictions to be added to conjunctions
such as `any_of`, e.g.

```
Model.search do
  any_of do
    with(:city, city)
    with(:location).in_bounding_box(se, nw)
  end
end
```

<!---
@huboard:{"order":99.875}
-->
