### PR TITLE
Fix Sunspot Rails not using sunspot.yml log_level setting

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -47,6 +47,10 @@ module Sunspot #:nodoc:
     # configured under <code>solr</code> for all read operations.
     #
     class Configuration
+      # ActiveSupport log levels are integers; this array maps them to the
+      # appropriate java.util.logging.Level constant
+      LOG_LEVELS = %w(FINE INFO WARNING SEVERE SEVERE INFO)
+
       attr_writer :user_configuration
       #
       # The host name at which to connect to Solr. Default 'localhost'.
@@ -146,17 +150,21 @@ module Sunspot #:nodoc:
         @has_master = !!user_configuration_from_key('master_solr')
       end
 
-      # 
+      #
       # The default log_level that should be passed to solr. You can
       # change the individual log_levels in the solr admin interface.
-      # Default 'INFO'.
+      # If no level is specified in the sunspot configuration file, 
+      # use a level similar to Rails own logging level.
       #
       # ==== Returns
       #
       # String:: log_level
       #
       def log_level
-        @log_level ||= (user_configuration_from_key('solr', 'log_level') || 'INFO')
+        @log_level ||= (
+          user_configuration_from_key('solr', 'log_level') ||
+          LOG_LEVELS[::Rails.logger.level]
+        )
       end
       
       #

--- a/sunspot_rails/lib/sunspot/rails/server.rb
+++ b/sunspot_rails/lib/sunspot/rails/server.rb
@@ -1,9 +1,6 @@
 module Sunspot
   module Rails
     class Server < Sunspot::Solr::Server
-      # ActiveSupport log levels are integers; this array maps them to the
-      # appropriate java.util.logging.Level constant
-      LOG_LEVELS = %w(FINE INFO WARNING SEVERE SEVERE INFO)
 
       # 
       # Directory in which to store PID files
@@ -58,12 +55,8 @@ module Sunspot
         configuration.port
       end
 
-      #
-      # Severity level for logging. This is based on the severity level for the
-      # Rails logger.
-      #
       def log_level
-        LOG_LEVELS[::Rails.logger.level]
+        configuration.log_level
       end
 
       # 

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -45,8 +45,9 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
     @config.open_timeout == nil
   end
 
-  it "should handle the 'log_level' property when not set" do
-    @config.log_level.should == 'INFO'
+  it "should set 'log_level' property using Rails log level when not set" do
+    ::Rails.logger.stub(:level){ 3 }
+    @config.log_level.should == 'SEVERE'
   end
   
   it "should handle the 'log_file' property" do

--- a/sunspot_rails/spec/server_spec.rb
+++ b/sunspot_rails/spec/server_spec.rb
@@ -4,6 +4,7 @@ describe Sunspot::Rails::Server do
   before :each do
     @server = Sunspot::Rails::Server.new
     @config = Sunspot::Rails::Configuration.new
+    @server.stub(:configuration){ @config }
     @solr_home = File.join(@config.solr_home)
   end
 
@@ -23,8 +24,9 @@ describe Sunspot::Rails::Server do
     @server.port.should == 8983
   end
 
-  it "sets the correct log level" do
-    @server.log_level.should == "FINE"
+  it "sets the log level using configuration" do
+    @config.stub(:log_level){ 'WARNING' }
+    @server.log_level.should == "WARNING"
   end
 
   it "sets the correct log file" do


### PR DESCRIPTION
Sunspot will now use the configuration class to obtain the log_level
setting. The configuration class will get the log_level from sunspot.yml
settings file. If it is not present, the configuration class will use
Rails' log level setting instead.

Fixed Rails server class spec of not associating the @config instance
with the @server instance.
