### PR TITLE
Fixed speed decrease if not uniq tables defined

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -245,7 +245,7 @@ module Sunspot #:nodoc:
           options = {
             :batch_size => Sunspot.config.indexing.default_batch_size,
             :batch_commit => true,
-            :include => self.sunspot_options[:include],
+            :include => Array.wrap(self.sunspot_options[:include]).uniq,
             :start => opts.delete(:first_id) || 0
           }.merge(opts)
           find_in_batch_options = {


### PR DESCRIPTION
This commit removes duplicated tables from options[:include] to prevent degrade of reindex speed
