### PR TITLE
Let Rails handle defaults for custom primary keys

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -246,7 +246,7 @@ module Sunspot #:nodoc:
             :batch_size => Sunspot.config.indexing.default_batch_size,
             :batch_commit => true,
             :include => self.sunspot_options[:include],
-            :start => opts.delete(:first_id) || 0
+            :start => opts.delete(:first_id)
           }.merge(opts)
           find_in_batch_options = {
             :include => options[:include],


### PR DESCRIPTION
Rails offers support for custom primary_keys, e.g. UUID.
See https://github.com/rails/rails/pull/7987

Here's the fix for the `start` option default, which in Sunspot always expected an _integer_ primary key,
causing `find_in_batches` to crash.

Rails handles the correct default.
