### PR TITLE
 Require Forwardable in sunspot/adapters.

### DIFF
--- a/sunspot/lib/sunspot/adapters.rb
+++ b/sunspot/lib/sunspot/adapters.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Sunspot
   #
   # Sunspot works by saving references to the primary key (or natural ID) of


### PR DESCRIPTION
I received an error: uninitialized constant Sunspot::Adapters::Registry::Forwardable. Requiring it explicitly fixed the error.

Cheers,

Strika

<!---
@huboard:{"order":465.0}
-->
