### PR TITLE
Fix ActiveSupport instrumentation

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -32,9 +32,14 @@ module Sunspot
 
         name = '%s (%.1fms)' % ["SOLR Request", event.duration]
 
-        # produces: path=/select parameters={fq: ["type:Tag"], q: rossi, fl: * score, qf: tag_name_text, defType: dismax, start: 0, rows: 20}
-        parameters = event.payload[:parameters].map { |k, v| "#{k}: #{color(v, BOLD, true)}" }.join(', ')
-        request = "path=#{event.payload[:path]} parameters={#{parameters}}"
+        # produces: path=select parameters={fq: ["type:Tag"], q: "rossi", fl: "* score", qf: "tag_name_text", defType: "dismax", start: 0, rows: 20}
+        path = color(event.payload[:path], BOLD, true)
+        parameters = event.payload[:parameters].map { |k, v|
+          v = "\"#{v}\"" if v.is_a? String
+          v = v.to_s.gsub(/\\/,'') # unescape
+          "#{k}: #{color(v, BOLD, true)}"
+        }.join(', ')
+        request = "path=#{path} parameters={#{parameters}}"
 
         debug "  #{color(name, GREEN, true)}  [ #{request} ]"
       end

--- a/sunspot_rails/lib/sunspot/rails/railtie.rb
+++ b/sunspot_rails/lib/sunspot/rails/railtie.rb
@@ -12,7 +12,7 @@ module Sunspot
           include(Sunspot::Rails::RequestLifecycle)
         end
         require 'sunspot/rails/log_subscriber'
-        RSolr::Connection.module_eval{ include Sunspot::Rails::SolrInstrumentation }
+        RSolr::Client.class_eval{ include Sunspot::Rails::SolrInstrumentation }
       end
 
       # Expose database runtime to controller for logging.

--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -4,14 +4,16 @@ module Sunspot
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :execute, :as_instrumentation
+        alias_method_chain :send_and_receive, :as_instrumentation
       end
 
 
-      def execute_with_as_instrumentation(path, params={}, *extra)
-        ActiveSupport::Notifications.instrument("request.rsolr",
-                                                {:path => path, :parameters => params}) do
-          execute_without_as_instrumentation(path, params, *extra)
+      def send_and_receive_with_as_instrumentation(path, opts)
+        parameters = (opts[:params] || {})
+        parameters.merge!(opts[:data]) if opts[:data].is_a? Hash
+        payload = {:path => path, :parameters => parameters}
+        ActiveSupport::Notifications.instrument("request.rsolr", payload) do
+          send_and_receive_without_as_instrumentation(path, opts)
         end
       end
     end


### PR DESCRIPTION
This fixes the ActiveSupport::Instrumentation hooks, that have been broken since upgrading Sunspot to RSolr 1.0.0 in commit 1575981dee two years ago.

I've also slightly changed the log output to quote string fields and remove `\\` escaping like in  `type:Spree\\:Product` to improve legibility.
