### PR TITLE
Add CompositeSetup#more_like_this_fields

### DIFF
--- a/sunspot/lib/sunspot/composite_setup.rb
+++ b/sunspot/lib/sunspot/composite_setup.rb
@@ -116,6 +116,14 @@ module Sunspot
       @more_like_this_fields ||= more_like_this_fields_hash.values.map { |set| set.to_a }.flatten
     end
 
+    #
+    # Return one or more more_like_this fields (can be either attribute or text fields)
+    # for the given name.
+    #
+    def more_like_this_fields(field_name)
+      more_like_this_fields_hash[field_name].to_a
+    end
+
     private
 
     # 

--- a/sunspot/spec/integration/more_like_this_spec.rb
+++ b/sunspot/spec/integration/more_like_this_spec.rb
@@ -40,4 +40,17 @@ describe 'more_like_this' do
       @mlt.total.should == 0
     end
   end
+
+  context 'when the query is across multiple types' do
+    before(:all) do
+      @comment = Namespaced::Comment.new(:body => 'there are no numbers here')
+      Sunspot.index!(@comment)
+    end
+
+    it 'should return results for the specified text field' do
+      Sunspot.more_like_this(@posts.first, Post, Namespaced::Comment) do
+        fields :body
+      end.results.to_set.should == @posts[2..3].to_set
+    end
+  end
 end


### PR DESCRIPTION
Sunspot#more_like_this searches were failing if multiple types were provided
to run the search over. This is because a Sunspot::CompositeSetup object is
used to extract the fields in this case, instead of the usual
Sunspot::Setup object. The CompositeSetup class was missing the required
more_like_this_fields method, which is added by this commit.

A test is also added to the more_like_this integration tests.

<!---
@huboard:{"order":415.69140625}
-->
