### PR TITLE
Add hook for custom auto-index action

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -465,12 +465,21 @@ module Sunspot #:nodoc:
           true
         end
 
+        def dispatch_index_task(option, default)
+          to_do = sunspot_options[option] || default
+          if to_do.is_a? Proc
+            to_do.call(self)
+          elsif to_do
+            send(to_do)
+          end
+        end
+
         def perform_index_tasks
           if @marked_for_auto_indexing
-            solr_index
+            dispatch_index_task(:auto_index_method, :solr_index)
             remove_instance_variable(:@marked_for_auto_indexing)
           elsif @marked_for_auto_removal
-            solr_remove_from_index
+            dispatch_index_task(:auto_remove_method, :solr_remove_from_index)
             remove_instance_variable(:@marked_for_auto_removal)
           end
         end


### PR DESCRIPTION
At Causes.com, we want to index into solr asynchronously. We like the tooling around auto_index, but wanted the call to solr_index to be done asynchronously.

If we could pass in a callable to use instead of the default solr_index, it would decouple the need to index from exactly how indexing is done.

We then are able to extend Sunspot to do the async indexing.

(This is a patch against 1.3, which I appreciate is now old - just offering upstream in case it's useful.)

<!---
@huboard:{"order":461.5}
-->
