### PR TITLE
enabeled sunspot task when running with Rails 4

### DIFF
--- a/sunspot_solr/lib/sunspot_solr.rb
+++ b/sunspot_solr/lib/sunspot_solr.rb
@@ -1,5 +1,5 @@
 require 'sunspot/solr/server'
 
-if defined?(Rails) && Rails::VERSION::MAJOR == 3
+if defined?(Rails::Railtie)
   require 'sunspot/solr/railtie'
 end


### PR DESCRIPTION
sunspot_solr can't run with Rails 4. fixed Railtie detect condition.
