### PR TITLE
Silence Java detection by redirecting STDERR

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/java.rb
+++ b/sunspot_solr/lib/sunspot/solr/java.rb
@@ -1,9 +1,12 @@
+require 'rbconfig'
+
 module Sunspot
   module Solr
     module Java
+      NULL_DEVICE = RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL' : '/dev/null'
+
       def self.installed?
-        `java -version`
-        $?.success?
+        system "java -version >#{NULL_DEVICE} 2>&1"
       end
     end
   end


### PR DESCRIPTION
This supresses the output form `java -version` everytime `installed?` is run.

It adds a line for os detection, because Windows names it's null device differently. Cygwin emulates /dev/null, so it's excluded from the list of Windows OSes.

Tested on MRI 1.8.7, 1.9.3, 2.0.0.
