### PR TITLE
Rails 4: replaced deprecated finder option "include" from find_in_batches options

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -252,10 +252,13 @@ module Sunspot #:nodoc:
             :batch_size => options[:batch_size],
             :start => options[:start]
           }
+          find_in_batch_options[:include] = options[:include] unless ::Rails.version >= '3'
           progress_bar = options[:progress_bar]
+
           if options[:batch_size]
             batch_counter = 0
-            includes(options[:include]).find_in_batches(find_in_batch_options) do |records|
+
+            batch_block = Proc.new do |records|
               solr_benchmark options[:batch_size], batch_counter do
                 Sunspot.index(records.select { |model| model.indexable? })
                 Sunspot.commit if options[:batch_commit]
@@ -264,10 +267,17 @@ module Sunspot #:nodoc:
               progress_bar.increment!(records.length) if progress_bar
               batch_counter += 1
             end
+
+            if ::Rails.version >= '3'
+              includes(options[:include]).find_in_batches(find_in_batch_options, &batch_block)
+            else
+              find_in_batches(find_in_batch_options, &batch_block)
+            end
           else
             records = all(:include => options[:include]).select { |model| model.indexable? }
             Sunspot.index!(records)
           end
+
           # perform a final commit if not committing in batches
           Sunspot.commit unless options[:batch_commit]
         end


### PR DESCRIPTION
As you can see in the official gem rails/activerecord-deprecated_finders, using finder options in find_in_batches, namely "include" in that case, has been deprecated.

Warning message:

```
Relation#find_in_batches with finder options is deprecated. Please build a scope and then call find_in_batches on it instead.
```

This fixes the problem using Rails 3 and Rails 4 Relation#includes method. The behaviour stays the same for Rails 2.3.
