### PR TITLE
Load models before their concerns

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -41,7 +41,7 @@ namespace :sunspot do
 
     # Load all the application's models. Models which invoke 'searchable' will register themselves
     # in Sunspot.searchable.
-    Dir.glob(Rails.root.join('app/models/**/*.rb')).each { |path| require path }
+    Dir.glob(Rails.root.join('app/models/**/*.rb')).sort_by { |path| path.length }.each { |path| require path }
 
     # By default, reindex all searchable models
     sunspot_models = Sunspot.searchable


### PR DESCRIPTION
If app/model/foo.rb and app/model/foo/bar.rb both exist, it is sometimes desirable to require foo.rb first, since the latter may refer to things defined in the former. Sorting the paths makes sure that happens.

<!---
@huboard:{"order":281.25}
-->
