### PR TITLE
Forward port changes from PR #249 to the 2-0-stable branch

### DIFF
--- a/sunspot_rails/dev_tasks/spec.rake
+++ b/sunspot_rails/dev_tasks/spec.rake
@@ -52,6 +52,10 @@ namespace :spec do
     app_path = rails_app_path(version)
 
     FileUtils.cp_r File.join(rails_template_path, "."), app_path
+    rails_major_version = version.split(".").first
+
+    FileUtils.cp File.join(app_path, "config", "sunspot_rails#{rails_major_version}.yml"),
+                 File.join(app_path, "config", "sunspot.yml")
   end
 
   task :run do

--- a/sunspot_rails/gemfiles/rails-2.3.16
+++ b/sunspot_rails/gemfiles/rails-2.3.16
@@ -9,5 +9,6 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 1.3.4'
+  gem 'database_cleaner', '~> 0.9.1'
   gem 'test-unit', '~> 1.2.3', :platform => :mri_19
 end

--- a/sunspot_rails/gemfiles/rails-3.0.20
+++ b/sunspot_rails/gemfiles/rails-3.0.20
@@ -9,4 +9,5 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 2.8.1'
+  gem 'database_cleaner', '~> 0.9.1'
 end

--- a/sunspot_rails/gemfiles/rails-3.1.10
+++ b/sunspot_rails/gemfiles/rails-3.1.10
@@ -9,4 +9,5 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 2.8.1'
+  gem 'database_cleaner', '~> 0.9.1'
 end

--- a/sunspot_rails/gemfiles/rails-3.2.11
+++ b/sunspot_rails/gemfiles/rails-3.2.11
@@ -9,4 +9,5 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 2.8.1'
+  gem 'database_cleaner', '~> 0.9.1'
 end

--- a/sunspot_rails/generators/sunspot/templates/sunspot.yml
+++ b/sunspot_rails/generators/sunspot/templates/sunspot.yml
@@ -1,3 +1,19 @@
+development:
+  solr:
+    hostname: localhost
+    port: 8982
+    log_level: INFO
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit
+
+test:
+  solr:
+    hostname: localhost
+    port: 8981
+    log_level: WARNING
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit
+
 production:
   solr:
     hostname: localhost
@@ -5,16 +21,5 @@ production:
     log_level: WARNING
     # read_timeout: 2
     # open_timeout: 0.5
-
-development:
-  solr:
-    hostname: localhost
-    port: 8982
-    log_level: INFO
-
-test:
-  solr:
-    hostname: localhost
-    port: 8981
-    log_level: WARNING
-    
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -36,6 +36,8 @@ module Sunspot #:nodoc:
     #       hostname: localhost
     #       port: 8982
     #       path: /solr
+    #     auto_index_callback: after_commit
+    #     auto_remove_callback: after_commit
     #     auto_commit_after_request: true
     #
     # Sunspot::Rails uses the configuration to set up the Solr connection, as
@@ -259,13 +261,13 @@ module Sunspot #:nodoc:
       def bind_address
         @bind_address ||= user_configuration_from_key('solr', 'bind_address')
       end
-      
+
       def read_timeout
-        @read_timeout ||= user_configuration_from_key('solr', 'read_timeout')
+        @read_timeout ||= (user_configuration_from_key('solr', 'read_timeout') || 2)
       end
 
       def open_timeout
-        @open_timeout ||= user_configuration_from_key('solr', 'open_timeout')
+        @open_timeout ||= (user_configuration_from_key('solr', 'open_timeout') || 0.5)
       end
 
       #
@@ -274,6 +276,28 @@ module Sunspot #:nodoc:
       #
       def disabled?
         @disabled ||= (user_configuration_from_key('disabled') || false)
+      end
+
+      #
+      # The callback to use when automatically indexing records. The default is
+      # after_save for backwards compatibility, but after_commit is highly
+      # recommended on Rails 3 as the record will have been fully committed
+      # and won't rolled back by other callbacks.
+      #
+      def auto_index_callback
+        @auto_index_callback ||=
+          (user_configuration_from_key('auto_index_callback') || 'after_save')
+      end
+
+      #
+      # The callback to use when automatically removing records after deletion.
+      # The default is after_destroy for backwards compatibility, but
+      # after_commit is highly recommended on Rails 3 as the record will have
+      # been fully removed and won't rolled back by other callbacks.
+      #
+      def auto_remove_callback
+        @auto_remove_callback ||=
+          (user_configuration_from_key('auto_remove_callback') || 'after_destroy')
       end
 
       private

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -90,13 +90,18 @@ module Sunspot #:nodoc:
 
             unless options[:auto_index] == false
               before_save :mark_for_auto_indexing_or_removal
-              after_save :perform_index_tasks
+
+              # after_commit :perform_index_tasks, :unless => :new_record?
+              __send__ Sunspot::Rails.configuration.auto_index_callback,
+                       :perform_index_tasks,
+                       :unless => :new_record?
             end
 
             unless options[:auto_remove] == false
-              after_destroy do |searchable|
-                searchable.remove_from_index
-              end
+              # after_commit { |searchable| searchable.remove_from_index }, :on => :destroy
+              __send__ Sunspot::Rails.configuration.auto_remove_callback,
+                       proc { |searchable| searchable.remove_from_index },
+                       :on => :destroy
             end
             options[:include] = Util::Array(options[:include])
             

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -84,6 +84,14 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   it "should handle the 'disabled' property when not set" do
     @config.disabled?.should be_false
   end
+
+  it "should handle the 'auto_index_callback' property when not set" do
+    @config.auto_index_callback.should == "after_save"
+  end
+
+  it "should handle the 'auto_remove_callback' property when not set" do
+    @config.auto_remove_callback.should == "after_destroy"
+  end
 end
 
 describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
@@ -140,6 +148,21 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
   end
   it "should handle the 'open_timeout' property when set" do
     @config.open_timeout.should == 0.5
+  end
+end
+
+describe Sunspot::Rails::Configuration, "with auto_index_callback and auto_remove_callback set" do
+  before do
+    ::Rails.stub!(:env => 'config_commit_test')
+    @config = Sunspot::Rails::Configuration.new
+  end
+
+  it "should handle the 'auto_index_callback' property when set" do
+    @config.auto_index_callback.should == "after_commit"
+  end
+
+  it "should handle the 'auto_remove_callback' property when set" do
+    @config.auto_remove_callback.should == "after_commit"
   end
 end
 

--- a/sunspot_rails/spec/model_lifecycle_spec.rb
+++ b/sunspot_rails/spec/model_lifecycle_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path('spec_helper', File.dirname(__FILE__))
 
-describe 'searchable with lifecycle' do
+describe 'searchable with lifecycle', :truncate => true do
   describe 'on create' do
     before :each do
       @post = PostWithAuto.create
@@ -12,7 +12,7 @@ describe 'searchable with lifecycle' do
     end
   end
 
-  describe 'on update' do
+  describe 'on update', :truncate => true do
     before :each do
       @post = PostWithAuto.create
       @post.update_attributes(:title => 'Test 1')

--- a/sunspot_rails/spec/model_spec.rb
+++ b/sunspot_rails/spec/model_spec.rb
@@ -345,7 +345,7 @@ describe 'ActiveRecord mixin' do
     end
   end
   
-  describe "more_like_this()" do
+  describe "more_like_this()", :truncate => true do
     before(:each) do
       @posts = [
         Post.create!(:title => 'Post123', :body => "one two three"),
@@ -386,7 +386,7 @@ describe 'ActiveRecord mixin' do
     end
   end
 
-  describe ':if constraint' do
+  describe ':if constraint', :truncate => true do
     subject do
       PostWithAuto.new(:title => 'Post123')
     end
@@ -440,7 +440,7 @@ describe 'ActiveRecord mixin' do
     end
 
     context 'Proc' do
-      context 'constraint returns true' do
+      context 'constraint returns true', :truncate => true do
         # searchable :if => proc { true }
         before do
           subject.class.sunspot_options[:if] = proc { true }
@@ -483,7 +483,7 @@ describe 'ActiveRecord mixin' do
       end
     end
 
-    it 'removes the model from the index if the constraint does not match' do
+    it 'removes the model from the index if the constraint does not match', :truncate => true do
       subject.save!
       Sunspot.commit
       subject.class.search.results.should include(subject)
@@ -495,7 +495,7 @@ describe 'ActiveRecord mixin' do
     end
   end
 
-  describe ':unless constraint' do
+  describe ':unless constraint', :truncate => true do
     subject do
       PostWithAuto.new(:title => 'Post123')
     end

--- a/sunspot_rails/spec/rails_template/config/sunspot_rails2.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot_rails2.yml
@@ -1,0 +1,29 @@
+test:
+  solr:
+    hostname: localhost
+    port: 8983
+  auto_index_callback: after_save
+  auto_remove_callback: after_destroy
+development:
+  solr:
+    hostname: localhost
+    port: 8981
+config_test:
+  solr:
+    hostname: some.host
+    port: 1234
+    path: /solr/idx
+    log_level: WARNING
+    data_path: /my_superior_path/data
+    pid_dir: /my_superior_path/pids
+    solr_home: /my_superior_path
+    bind_address: 127.0.0.1
+    read_timeout: 2
+    open_timeout: 0.5
+  auto_commit_after_request: false
+  auto_commit_after_delete_request: true
+config_disabled_test:
+  disabled: true
+config_commit_test:
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit

--- a/sunspot_rails/spec/rails_template/config/sunspot_rails3.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot_rails3.yml
@@ -2,6 +2,8 @@ test:
   solr:
     hostname: localhost
     port: 8983
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit
 development:
   solr:
     hostname: localhost
@@ -22,3 +24,6 @@ config_test:
   auto_commit_after_delete_request: true
 config_disabled_test:
   disabled: true
+config_commit_test:
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit

--- a/sunspot_rails/spec/spec_helper.rb
+++ b/sunspot_rails/spec/spec_helper.rb
@@ -41,8 +41,31 @@ rspec =
 Dir[File.expand_path("shared_examples/*.rb", File.dirname(__FILE__))].each {|f| require f}
 
 rspec.configure do |config|
+  config.use_transactional_fixtures = false
+
   config.before(:each) do
     load_schema
     Sunspot.remove_all!
+  end
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each, :truncate => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.after(:each, :truncate => true) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before do
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
This is a forward port of the changes in pull request #249 to the 2-0-stable branch.  PR #249 enabled sunspot_rails users to replace the after_save and after_destroy hooks for Sunspot actions with after_commit actions via configuration.

Failure to forward port this functionality appears to have been an oversight.

<!---
@huboard:{"order":290.625}
-->
