### PR TITLE
Add config to StubSessionProxy in order to fix error when scope is used.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -44,6 +44,10 @@ module Sunspot
       def optimize
       end
 
+      def config
+        Sunspot::Configuration.build
+      end
+
       def dirty?
         false
       end

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -118,6 +118,10 @@ describe 'specs with Sunspot stubbed' do
     Sunspot.more_like_this(@post)
   end
 
+  it 'should not raise error when reindexing scope' do
+    expect{ Post.solr_index }.to_not raise_error
+  end
+
   describe 'stub search' do
     before :each do
       @search = Post.search


### PR DESCRIPTION
Fix #247, where Sunspot is trying to access StubSessionProxy's config, but it does not exist. Add accessor to a default config to fix this.

<!---
@huboard:{"order":298.828125}
-->
