### PR TITLE
Add ability for an ActiveRecord to automatically index associations.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -3,6 +3,7 @@ require File.join(File.dirname(__FILE__), 'rails', 'configuration')
 require File.join(File.dirname(__FILE__), 'rails', 'adapters')
 require File.join(File.dirname(__FILE__), 'rails', 'request_lifecycle')
 require File.join(File.dirname(__FILE__), 'rails', 'searchable')
+require File.join(File.dirname(__FILE__), 'rails', 'index_related')
 
 module Sunspot #:nodoc:
   module Rails #:nodoc:

--- a/sunspot_rails/lib/sunspot/rails/index_related.rb
+++ b/sunspot_rails/lib/sunspot/rails/index_related.rb
@@ -1,0 +1,76 @@
+module Sunspot #:nodoc:
+  module Rails #:nodoc:
+    #
+    # This module adds the ability for an ActiveRecord to trigger Solr indexing
+    # of associated ActiveRecord models. The associated models are indexed
+    # after the base model is saved or destroyed.
+    #
+    # Note that the trigging model does not need to be Searchable, but
+    # the associatd model(s) do need to be Searchable.
+    #
+    module IndexRelated
+      class <<self
+        def included(base) #:nodoc:
+          base.module_eval do
+            extend(ActsAsMethods)
+          end
+        end
+      end
+
+      module ActsAsMethods
+        #
+        # Configures the ActiveRecord to trigger indexing of the specified
+        # associated models when this models is saved or destroyed.
+        #
+        # ==== Options (+options+)
+        # All options are passed to after_save and after_destroy. For example:
+        #
+        # :if<Mixed>::
+        #   Only index associated models if the method, proc or string evaluates
+        #   to true (e.g. <code>:if => :should_index?</code> or <code>:if =>
+        #   proc { |model| model.foo > 2 }</code>). Multiple constraints can be
+        #   specified by passing an array (e.g. <code>:if => [:method1, :method2]
+        #   </code>).
+        # :unless<Mixed>::
+        #   Only index associated models if the method, proc or string evaluates
+        #   to false (e.g. <code>:unless => :should_index?</code> or <code>:unless =>
+        #   proc { |model| model.foo > 2 }</code>). Multiple constraints can be
+        #   specified by passing an array (e.g. <code>:unless => [:method1, :method2]
+        #   </code>).
+        #
+        # ==== Example
+        #
+        #   class Post < ActiveRecord::Base
+        #     belongs_to :blog
+        #     belongs_to :author
+        #
+        #     index_related :blog, :author, if: :published?
+        #   end
+        #
+        #
+
+        def index_related(*args)
+          include InstanceMethods
+
+          callback_options = args.last.is_a?(::Hash) ? args.pop : {}
+
+          class_attribute :indexable
+          self.indexable = *args
+
+          after_save :index_related, callback_options
+          after_destroy :index_related, callback_options
+        end
+      end
+
+      module InstanceMethods
+        private
+        def index_related
+          indexable.each do |related_attribute|
+            related_model = send(related_attribute)
+            Sunspot.index!(related_model) if related_model
+          end
+        end
+      end
+    end
+  end
+end

--- a/sunspot_rails/lib/sunspot/rails/init.rb
+++ b/sunspot_rails/lib/sunspot/rails/init.rb
@@ -2,4 +2,5 @@ Sunspot.session = Sunspot::Rails.build_session
 Sunspot::Adapters::InstanceAdapter.register(Sunspot::Rails::Adapters::ActiveRecordInstanceAdapter, ActiveRecord::Base)
 Sunspot::Adapters::DataAccessor.register(Sunspot::Rails::Adapters::ActiveRecordDataAccessor, ActiveRecord::Base)
 ActiveRecord::Base.module_eval { include(Sunspot::Rails::Searchable) }
+ActiveRecord::Base.module_eval { include(Sunspot::Rails::IndexRelated) }
 ActionController::Base.module_eval { include(Sunspot::Rails::RequestLifecycle) }

--- a/sunspot_rails/lib/sunspot/rails/railtie.rb
+++ b/sunspot_rails/lib/sunspot/rails/railtie.rb
@@ -7,6 +7,7 @@ module Sunspot
           Sunspot::Adapters::InstanceAdapter.register(Sunspot::Rails::Adapters::ActiveRecordInstanceAdapter, ActiveRecord::Base)
           Sunspot::Adapters::DataAccessor.register(Sunspot::Rails::Adapters::ActiveRecordDataAccessor, ActiveRecord::Base)
           include(Sunspot::Rails::Searchable)
+          include(Sunspot::Rails::IndexRelated)
         end
         ActiveSupport.on_load(:action_controller) do
           include(Sunspot::Rails::RequestLifecycle)

--- a/sunspot_rails/spec/model_lifecycle_spec.rb
+++ b/sunspot_rails/spec/model_lifecycle_spec.rb
@@ -77,5 +77,55 @@ describe 'searchable with lifecycle' do
     end
 
   end
+
+  describe 'indexing associated model' do
+    before(:each) do
+      @post = PostThatIndexesAssociations.create(blog: Blog.create)
+    end
+
+    it 'should index the associated model when saved' do
+      Sunspot.should_receive(:index!).with(@post.blog)
+      @post.update_attribute :title, "brand new title"
+    end
+
+    it 'should index the associated model when destroyed' do
+      Sunspot.should_receive(:index!).with(@post.blog)
+      @post.destroy
+    end
+  end
+
+  describe 'conditionally index associated model' do
+    context "when the condition is true" do
+      before(:each) do
+        @post = PostThatConditionallyIndexesAssociations.create(blog: Blog.create, published: true)
+      end
+
+      it 'should index the associated model when saved' do
+        Sunspot.should_receive(:index!).with(@post.blog)
+        @post.update_attribute :title, "brand new title"
+      end
+
+      it 'should index the associated model when destroyed' do
+        Sunspot.should_receive(:index!).with(@post.blog)
+        @post.destroy
+      end
+    end
+
+    context "when the condition is false" do
+      before(:each) do
+        @post = PostThatConditionallyIndexesAssociations.create(blog: Blog.create, published: false)
+      end
+
+      it "should not index associations upon save" do
+        Sunspot.should_not_receive(:index!).with(@post.blog)
+        @post.update_attribute :title, "brand new title"
+      end
+
+      it 'should not index the associated model when destroyed' do
+        Sunspot.should_not_receive(:index!).with(@post.blog)
+        @post.destroy
+      end
+    end
+  end
 end
 

--- a/sunspot_rails/spec/rails_template/app/models/post_that_conditionally_indexes_associations.rb
+++ b/sunspot_rails/spec/rails_template/app/models/post_that_conditionally_indexes_associations.rb
@@ -1,0 +1,12 @@
+class PostThatConditionallyIndexesAssociations < ActiveRecord::Base
+  def self.table_name
+    'posts'
+  end
+
+  attr_accessor :published
+  attr_accessible :title, :blog, :published
+
+  belongs_to :blog
+
+  index_related :blog, if: :published
+end

--- a/sunspot_rails/spec/rails_template/app/models/post_that_indexes_associations.rb
+++ b/sunspot_rails/spec/rails_template/app/models/post_that_indexes_associations.rb
@@ -1,0 +1,11 @@
+class PostThatIndexesAssociations < ActiveRecord::Base
+  def self.table_name
+    'posts'
+  end
+
+  attr_accessible :title, :blog
+
+  belongs_to :blog
+
+  index_related :blog
+end


### PR DESCRIPTION
This module adds the ability for an ActiveRecord to trigger Solr indexing of associated ActiveRecord models. The associated models are indexed after the base model is saved or destroyed.

Note that the trigging model does not need to be Searchable, but the associated model(s) do need to be Searchable.

Example

```
 class Post < ActiveRecord::Base
   belongs_to :blog
   belongs_to :author

   index_related :blog, :author, if: :published?
 end
```

We needed this feature because we had to reindex parent objects when the child objects changed.
