### PR TITLE
Added support for multi-select facets to Sunspot::Query::Geofilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,34 @@ Sunspot.search(Post) do
 end
 ```
 
+#### Multi Select Facets
+
+In some cases you may want your facets to include the results that would be available
+if the user had not filtered by some of the current filters. In order to build such facets
+you can name your filters then build a facet which excludes the given filter, like so:
+
+```ruby
+# Filter the highest rated Posts but still build a facet for each average rating.
+search = Post.search do
+  rating_filter = with(:average_rating, 4.0..5.0)
+
+  facet(:average_rating, :exclude => rating_filter) do
+    row(1.0..2.0) do
+      with(:average_rating, 1.0..2.0)
+    end
+    row(2.0..3.0) do
+      with(:average_rating, 2.0..3.0)
+    end
+    row(3.0..4.0) do
+      with(:average_rating, 3.0..4.0)
+    end
+    row(4.0..5.0) do
+      with(:average_rating, 4.0..5.0)
+    end
+  end
+end
+```
+
 ### Ordering
 
 By default, Sunspot orders results by "score": the Solr-determined

--- a/sunspot/lib/sunspot/query/geofilt.rb
+++ b/sunspot/lib/sunspot/query/geofilt.rb
@@ -1,15 +1,25 @@
 module Sunspot
   module Query
-    class Geofilt
+    class Geofilt < Restriction::Base
       def initialize(field, lat, lon, radius, options = {})
         @field, @lat, @lon, @radius, @options = field, lat, lon, radius, options
       end
 
       def to_params
-        func = @options[:bbox] ? "bbox" : "geofilt"
+        {:fq => to_solr_conditional}
+      end
 
-        filter = "{!#{func} sfield=#{@field.indexed_name} pt=#{@lat},#{@lon} d=#{@radius}}"
-        {:fq => filter}
+      def to_solr_conditional
+        if tagged?
+          "{!tag=#{tag}}_query_:\"#{geo_phrase}\""
+        else
+          geo_phrase
+        end
+      end
+
+      def geo_phrase
+        func = @options[:bbox] ? "bbox" : "geofilt"
+        "{!#{func} sfield=#{@field.indexed_name} pt=#{@lat},#{@lon} d=#{@radius}}"
       end
     end
   end

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -477,6 +477,21 @@ shared_examples_for "facetable query" do
       )
     end
 
+    it 'tags and excludes a geo filter in a query facet' do
+      search do
+        geo_filter = with(:coordinates_new).in_radius(23, -46, 100)
+        facet :foo, :exclude => geo_filter do
+          row(:bar) do
+            with(:coordinates_new).in_radius(23, -46, 50)
+          end
+        end
+      end
+      filter_tag = get_filter_tag('_query_:"{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}"')
+      connection.should have_last_search_with(
+        :"facet.query" => "{!ex=#{filter_tag}}_query_:\"{!geofilt sfield=coordinates_new_ll pt=23,-46 d=50}\""
+      )
+    end
+
 
     it 'ignores facet query with only empty rows' do
       search do


### PR DESCRIPTION
Trying to exclude a geo filter from a facet currently results in an error, because geospatial queries do not have a 'tag' method. Furthermore, the exclusion tags required for excluding a geofilt query are not being generated at all.

Here's an example of what I want to do, filter anything within 100 miles but also always build a facet for things closer than that.

``` ruby
location_filter = with(:location).in_radius(*coords, 100)
facet(:distance, exclude: location_filter) do
  row('1') do
    with(:location).in_radius(*coords, 1)
  end
  row('5') do
    with(:location).in_radius(*coords, 5)
  end
  row('15') do
    with(:location).in_radius(*coords, 15)
  end
  row('50') do
    with(:location).in_radius(*coords, 50)
  end
end
```

This patch addresses those issues, I tried to inherit everything from Restriction::Base but I guess there may be some slight duplication in the to_solr_conditional method of Sunspot::Query::Geofilt, someone more familiar with this codebase should be able to remove the duplication.

cheers

----nubis 

<!---
@huboard:{"order":337.0}
-->
