### PR TITLE
Fix class reference in FileAdapter code example

### DIFF
--- a/sunspot/lib/sunspot/adapters.rb
+++ b/sunspot/lib/sunspot/adapters.rb
@@ -46,7 +46,7 @@ module Sunspot
     #   end
     #
     #   # then in your initializer
-    #   Sunspot::Adapters::InstanceAdapter.register(MyAdapter, File)
+    #   Sunspot::Adapters::InstanceAdapter.register(FileAdapter, File)
     #
     class InstanceAdapter
       def initialize(instance) #:nodoc:


### PR DESCRIPTION
Shouldn't it be "FileAdapter" instead of "MyAdapter" on line 49?
