### PR TITLE
Added support for facet(name).rows in StubSessionProxy

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -83,9 +83,11 @@ module Sunspot
         end
 
         def facet(name)
+          FacetStub.new
         end
 
         def dynamic_facet(name)
+          FacetStub.new
         end
 
         def execute
@@ -139,6 +141,14 @@ module Sunspot
           0
         end
         
+      end
+
+      class FacetStub
+
+        def rows
+          []
+        end
+
       end
       
     end

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -111,12 +111,12 @@ describe 'specs with Sunspot stubbed' do
       @search.total.should == 0
     end
 
-    it 'should return nil for a given facet' do
-      @search.facet(:category_id).should be_nil
+    it 'should return empty results for a given facet' do
+      @search.facet(:category_id).rows.should == []
     end
 
-    it 'should return nil for a given dynamic facet' do
-      @search.dynamic_facet(:custom).should be_nil
+    it 'should return empty results for a given dynamic facet' do
+      @search.dynamic_facet(:custom).rows.should == []
     end
   end
 end


### PR DESCRIPTION
Currently, code such as what is shown in the README regarding facets fails in test environement when using `StubSessionProxy`. Example code (from the README):

```
search.facet(:average_rating).rows.each do |facet|
  puts "Number of posts with rating withing #{facet.value}: #{facet.count}"
end
```

This would fail using `StubSessionProxy` because `facet(:average_rating)` returns `nil`. Whis this PR, `facet(:average_rating)` would return a new instance of `FacetStub` that responds to `rows` with an empty array.
