### PR TITLE
Remove old finders syntax

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/adapters.rb
+++ b/sunspot_rails/lib/sunspot/rails/adapters.rb
@@ -1,16 +1,16 @@
 module Sunspot #:nodoc:
   module Rails #:nodoc:
-    # 
+    #
     # This module provides Sunspot Adapter implementations for ActiveRecord
     # models.
     #
     module Adapters
       class ActiveRecordInstanceAdapter < Sunspot::Adapters::InstanceAdapter
-        # 
+        #
         # Return the primary key for the adapted instance
         #
         # ==== Returns
-        # 
+        #
         # Integer:: Database ID of model
         #
         def id
@@ -40,8 +40,8 @@ module Sunspot #:nodoc:
           value = value.join(', ') if value.respond_to?(:join)
           @select = value
         end
-        
-        # 
+
+        #
         # Get one ActiveRecord instance out of the database by ID
         #
         # ==== Parameters
@@ -51,14 +51,15 @@ module Sunspot #:nodoc:
         # ==== Returns
         #
         # ActiveRecord::Base:: ActiveRecord model
-        # 
+        #
         def load(id)
-          @clazz.first(options_for_find.merge(
-            :conditions => { @clazz.primary_key => id}
-          ))
+          options = options_for_find
+          scope = @clazz.includes(options[:include]).where(@clazz.primary_key => id)
+          scope = scope.select(options[:select]) if options[:select]
+          scope
         end
 
-        # 
+        #
         # Get a collection of ActiveRecord instances out of the database by ID
         #
         # ==== Parameters
@@ -70,13 +71,14 @@ module Sunspot #:nodoc:
         # Array:: Collection of ActiveRecord models
         #
         def load_all(ids)
-          @clazz.all(options_for_find.merge(
-            :conditions => { @clazz.primary_key => ids.map { |id| id }}
-          ))
+          options = options_for_find
+          scope = @clazz.includes(options[:include]).where(@clazz.primary_key => ids).to_a
+          scope = scope.select(options[:select]) if options[:select]
+          scope
         end
-        
+
         private
-        
+
         def options_for_find
           options = {}
           options[:include] = @include unless !defined?(@include) || @include.blank?


### PR DESCRIPTION
Update finders in rails adapter to support the chaining api and stop producing deprecation warning with rails 4
