### PR TITLE
Passing :silence => true to sunspot:reindex will no longer show the Progress Bar

### DIFF
--- a/sunspot_rails/History.txt
+++ b/sunspot_rails/History.txt
@@ -1,5 +1,6 @@
 == 2.1.0
 * Dropped Rails 2 support in favour of supporting Rails 4
+* Passing :silence => true while invoking the rake sunspot:reindex will no longer show the Progress Bar
 
 == 2.0.0
 * Finds orphaned objects in batches to avoid excessive memory use (Peer Allan)
@@ -70,7 +71,7 @@
 == 0.10.6
 * Added script/generate sunspot support to generate the required sunspot.yml
   file [Brandon Keepers]
-  
+
 == 0.10.5
 * Added a auto_commit_after_request option to sunspot.yml. Sunspot will not
   automatically commit any changes in solr if you set this value to false.

--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -52,7 +52,7 @@ namespace :sunspot do
         sunspot_models = Sunspot.searchable
       end
 
-      # Set up progress_bar to, ah, report progress
+      # Set up progress_bar to, ah, report progress unless the user has chosen to silence output
       begin
         require 'progress_bar'
         total_documents = sunspot_models.map { | m | m.count }.sum
@@ -61,7 +61,7 @@ namespace :sunspot do
         $stdout.puts "Skipping progress bar: for progress reporting, add gem 'progress_bar' to your Gemfile"
       rescue Exception => e
         $stderr.puts "Error using progress bar: #{e.message}"
-      end
+      end unless args[:silence]
 
       # Finally, invoke the class-level solr_reindex on each model
       sunspot_models.each do |model|


### PR DESCRIPTION
This cleans up spec test output and makes sense in headless operation situations where the :silence option is meant to be used.
