### PR TITLE
Allow indexing of all records, even those outside of a Rails default_scope

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -251,8 +251,8 @@ module Sunspot #:nodoc:
 
           if options[:batch_size].to_i > 0
             batch_counter = 0
-            self.includes(options[:include]).find_in_batches(options.slice(:batch_size, :start)) do |records|
-              
+            self.includes(options[:include]).unscoped.find_in_batches(options.slice(:batch_size, :start)) do |records|
+
               solr_benchmark(options[:batch_size], batch_counter += 1) do
                 Sunspot.index(records.select { |model| model.indexable? })
                 Sunspot.commit if options[:batch_commit]
@@ -261,7 +261,7 @@ module Sunspot #:nodoc:
               options[:progress_bar].increment!(records.length) if options[:progress_bar]
             end
           else
-            Sunspot.index! self.includes(options[:include]).select(&:indexable?)
+            Sunspot.index! self.includes(options[:include]).unscoped.select(&:indexable?)
           end
 
           # perform a final commit if not committing in batches

--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -55,7 +55,7 @@ namespace :sunspot do
       # Set up progress_bar to, ah, report progress unless the user has chosen to silence output
       begin
         require 'progress_bar'
-        total_documents = sunspot_models.map { | m | m.count }.sum
+        total_documents = sunspot_models.map { | m | m.unscoped.count }.sum
         reindex_options[:progress_bar] = ProgressBar.new(total_documents)
       rescue LoadError => e
         $stdout.puts "Skipping progress bar: for progress reporting, add gem 'progress_bar' to your Gemfile"


### PR DESCRIPTION
Currently the `sunspot:reindex` task will only index models after any default_scopes specified have been applied. This adds some `unscoped` calls to make sure _all_ records get indexed, even those excluded by any default_scopes.
