### PR TITLE
Added note to README.md regarding threading and ThreadLocalSessionProxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,16 @@ bundle exec rake sunspot:solr:reindex[500,Post] # some shells will require escap
 
 TODO
 
+## Threading
+
+The default Sunspot Session is not thread-safe. If used in a multi-threaded
+environment (such as sidekiq), you should configure Sunspot to use the
+[ThreadLocalSessionProxy](http://sunspot.github.io/sunspot/docs/Sunspot/SessionProxy/ThreadLocalSessionProxy.html):
+
+```ruby
+Sunspot.session = Sunspot::SessionProxy::ThreadLocalSessionProxy.new
+```
+
 ## Manually Adjusting Solr Parameters
 
 To add or modify parameters sent to Solr, use `adjust_solr_params`:


### PR DESCRIPTION
The current README doesn't include any information about thread-safety, which was a challenge for us recently as we were working with sunspot in sidekiq (a multi-threaded environment). Once we found the ThreadLocalSessionProxy API docs, it was trivial to fix but I thought it would be good to include this info clearly in the README in order to avoid others going through the same troubleshooting pains that we did. 
