### PR TITLE
Log complete solr request data, including inserts

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -10,7 +10,7 @@ module Sunspot
 
       def send_and_receive_with_as_instrumentation(path, opts)
         parameters = (opts[:params] || {})
-        parameters.merge!(opts[:data]) if opts[:data].is_a? Hash
+        parameters[:data] = opts[:data]
         payload = {:path => path, :parameters => parameters}
         ActiveSupport::Notifications.instrument("request.rsolr", payload) do
           send_and_receive_without_as_instrumentation(path, opts)


### PR DESCRIPTION
I found it greatly helped in my debugging of solr to be able to see the full data that was being submitted to solr, but 994fd5c8ed474992c3360b3b1ce2d7c37acc0c77 removed it (because inserts/updates are done with an XML string, not a hash). This puts it back in.
