### PR TITLE
Remove rake reindex prompt.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -14,18 +14,7 @@ namespace :sunspot do
   # $ rake sunspot:reindex[1000,Post]     # reindex only the Post model in
   #                                       # batchs of 1000
   # $ rake sunspot:reindex[,Post+Author]  # reindex Post and Author model
-  # $ rake sunspot:reindex[,,true]        # reindex silencing/skipping the boolean prompt
   task :reindex, [:batch_size, :models, :silence] => [:environment] do |t, args|
-    args.with_defaults(:silence => false)
-    if args[:silence] == false
-      puts "*Note: the reindex task will remove your current indexes and start from scratch."
-      puts "If you have a large dataset, reindexing can take a very long time, possibly weeks."
-      puts "This is not encouraged if you have anywhere near or over 1 million rows."
-      puts "Are you sure you want to drop your indexes and completely reindex? (y/n)"
-      answer = STDIN.gets.chomp
-      return false unless answer.match(/^y/)
-    end
-
     # Retry once or gracefully fail for a 5xx error so we don't break reindexing
     with_session(Sunspot::SessionProxy::Retry5xxSessionProxy.new(Sunspot.session)) do
 


### PR DESCRIPTION
This prompt causes too many problems with automated scripts for little benefit. The description now states that this task will drop your models first. I've removed it unless we can come up with a more unobtrusive solution.
