### PR TITLE
Remove explicit temp directory setting from solr.xml

### DIFF
--- a/sunspot_solr/solr/contexts/solr.xml
+++ b/sunspot_solr/solr/contexts/solr.xml
@@ -4,5 +4,4 @@
   <Set name="contextPath"><SystemProperty name="hostContext" default="/solr"/></Set>
   <Set name="war"><SystemProperty name="jetty.home"/>/webapps/solr.war</Set>
   <Set name="defaultsDescriptor"><SystemProperty name="jetty.home"/>/etc/webdefault.xml</Set>
-  <Set name="tempDirectory"><Property name="jetty.home" default="."/>/solr-webapp</Set>
 </Configure>


### PR DESCRIPTION
Removes explicit setting of temp directory in contexts/solr.xml, which
caused solr crash while starting on systems with bundled gems directory
not writeable by non-root. 

It took me quite a while to figure out this was the reason.
