### PR TITLE
Accept non-string literals when ordering by function.

### DIFF
--- a/sunspot/lib/sunspot/query/sort.rb
+++ b/sunspot/lib/sunspot/query/sort.rb
@@ -140,7 +140,7 @@ module Sunspot
               @fields<< FunctionComp.new(setup,argument)
             when "Symbol"
               @fields<< setup.field(argument).indexed_name
-            when "String"
+            else
               @fields<< argument
             end
           end

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -476,5 +476,15 @@ describe 'scoped_search' do
       search = Sunspot.search(Post) { order_by_function :product, :blog_id, [:sum,:blog_id,:primary_category_id], :desc}
       search.results.first.should == @p2
     end
+    it 'should accept string literals' do
+      # (1 * -2) > (2 * -2)
+      search = Sunspot.search(Post) {order_by_function :product, :blog_id, '-2', :desc}
+      search.results.first.should == @p1
+    end
+    it 'should accept non-string literals' do
+      # (1 * -2) > (2 * -2)
+      search = Sunspot.search(Post) {order_by_function :product, :blog_id, -2, :desc}
+      search.results.first.should == @p1
+    end
   end
 end


### PR DESCRIPTION
Currently order_by_function only accepts arguments of type Array, Symbol, or String. Since the functions often deal with math, it is natural to want to use numeric types as well. FunctionComp already does the work of converting fields to_s, so this PR changes it to more liberally accept non-string literals.
