### PR TITLE
Add DSL for group.facet=true solr functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,23 @@ Sunspot.search(Post) do
 end
 ```
 
+#### Grouped Facets
+
+**Solr 4.0 and above**
+
+When grouping documents, it is often desirable to have facets by unique occurences within
+groups, rather than the occurences in document. Grouped facets are computed based on the first
+specified group. More information about result grouping/field collapsing is available
+on the [Solr Wiki](http://wiki.apache.org/solr/FieldCollapsing) - see `group.facet`.
+
+```ruby
+Post.search do
+  group :title
+    facet
+  end
+end
+```
+
 ### Ordering
 
 By default, Sunspot orders results by "score": the Solr-determined
@@ -543,6 +560,14 @@ Post.search do
   end
 
   facet :blog_id_str, :extra => :any
+end
+
+# Facet count is based on unique occurences in all documents of each
+# group matching the query (>= Solr 4)
+Post.search do
+  group :blog_id_str do
+    facet
+  end
 end
 ```
 

--- a/sunspot/lib/sunspot/dsl/field_group.rb
+++ b/sunspot/lib/sunspot/dsl/field_group.rb
@@ -33,6 +33,27 @@ module Sunspot
         @group.truncate = true
       end
 
+      # Computes grouped facets for the field facets specified in facet
+      # parameters. Grouped facets are computed based on the first specified
+      # group. Default for Solr is false.  Solr4.0
+      #
+      # Supported in Solr 4.0 and above.
+      #
+      # ==== Example
+      #
+      #     Sunspot.search(Post) do
+      #       group :title do
+      #         facet
+      #       end
+      #
+      #       facet :title
+      #     end
+      #
+      def facet
+        @group.facet = true
+      end
+
+
       # Specify the order that results should be returned in. This method can
       # be called multiple times; precedence will be in the order given.
       #

--- a/sunspot/lib/sunspot/query/field_group.rb
+++ b/sunspot/lib/sunspot/query/field_group.rb
@@ -4,7 +4,7 @@ module Sunspot
     # A FieldGroup groups by the unique values of a given field.
     #
     class FieldGroup
-      attr_accessor :limit, :truncate
+      attr_accessor :limit, :truncate, :facet
 
       def initialize(field)
         if field.multiple?
@@ -29,6 +29,7 @@ module Sunspot
         params.merge!(@sort.to_params("group."))
         params[:"group.limit"] = @limit if @limit
         params[:"group.truncate"] = @truncate if @truncate
+        params[:"group.facet"] = @facet if @facet
 
         params
       end

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -154,6 +154,18 @@ describe 'search faceting' do
       # Should be 5 instead of 11
       search.facet(:title).rows.first.count.should == 5
     end
+
+    it 'gives correct facet count when group == true and facet == true' do
+      search = Sunspot.search(Post) do
+        group :blog_id do
+          facet
+        end
+
+        facet :title
+      end
+
+      search.facet(:title).rows.count.should == 5
+    end
   end
 
   context 'prefix escaping' do


### PR DESCRIPTION
This PR adds Solr's [group.facet](http://wiki.apache.org/solr/FieldCollapsing#line-147) functionality for the FieldGroup dsl class.
