### PR TITLE
ThreadLocalSessionProxy.new shouldn't call Sunspot::Configuration.new

### DIFF
--- a/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
@@ -24,7 +24,7 @@ module Sunspot
       # passed, a default configuration is used; it can then be modified using
       # the #config attribute.
       #
-      def initialize(config = Sunspot::Configuration.new)
+      def initialize(config = Sunspot::Configuration.build)
         @config = config
         ObjectSpace.define_finalizer(self, FINALIZER)
       end


### PR DESCRIPTION
Looks like it should use Sunspot::Configuration.build instead?
