### PR TITLE
Updating documentation to show how to use the silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,9 @@ bundle exec rake sunspot:solr:reindex
 
 # or, to be specific to a certain model with a certain batch size:
 bundle exec rake sunspot:solr:reindex[500,Post] # some shells will require escaping [ with \[ and ] with \]
+
+# to skip the prompt asking you if you want to proceed with the reindexing:
+bundle exec rake sunspot:solr:reindex[,,true] # some shells will require escaping [ with \[ and ] with \]
 ```
 
 ## Use Without Rails


### PR DESCRIPTION
The reindexing rake task has been changed to allow you to bypass the warning prompt (and merged in this commit - https://github.com/sunspot/sunspot/pull/370).  I updated the documentation to reflect this change.
