### PR TITLE
Make InRadius restriciton use GeoFilt class

### DIFF
--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -145,14 +145,15 @@ module Sunspot
       end
 
       class InRadius < Base
-        def initialize(negated, field, lat, lon, radius)
-          @lat, @lon, @radius = lat, lon, radius
+        def initialize(negated, field, lat, lon, radius, options = {})
+          @lat, @lon, @radius, @options = lat, lon, radius, options
           super negated, field, [lat, lon, radius]
         end
 
         private
           def to_positive_boolean_phrase
-            "_query_:\"{!geofilt sfield=#{@field.indexed_name} pt=#{@lat},#{@lon} d=#{@radius}}\""
+            geofilt = Geofilt.new(@field, @lat, @lon, @radius, @options).to_params[:fq]
+            "_query_:\"#{geofilt}\""
           end
       end
 


### PR DESCRIPTION
This is mainly to allow `q.without(:geo).in_radius(32, -68, 10, bbox: true)` functionality. That is, the use of `bbox` on `without` queries.

Also, since the `Sunspot::Query::Geofilt` already has the responsibility of generating the `geofilt` function for other types of queries, it makes sense to have `InRadius` use the same code and logic.
