### PR TITLE
Fixed deprecated (by ActiveSupport 4.1.0) require of "active_support/core_ext/object/to_json"

### DIFF
--- a/sunspot_rails/lib/sunspot_rails.rb
+++ b/sunspot_rails/lib/sunspot_rails.rb
@@ -1,7 +1,11 @@
 # This needs to be loaded before sunspot/search/paginated_collection
 # or #to_json gets defined in Object breaking delegation to Array via
 # method_missing
-require 'active_support/core_ext/object/to_json'
+if ::Rails.version >= '4.1'
+  require 'active_support/core_ext/object/json'
+elsif ::Rails.version >= '3'
+  require 'active_support/core_ext/object/to_json'
+end
 
 require 'sunspot/rails'
 require 'sunspot/rails/railtie'


### PR DESCRIPTION
Deprecated here: https://github.com/rails/rails/blob/64c88fb5d2caf3c34742a07394ac68b8377c4936/activesupport/lib/active_support/core_ext/object/to_json.rb