### PR TITLE
Add ability to tag Geofilt restrictions

### DIFF
--- a/sunspot/lib/sunspot/query/geofilt.rb
+++ b/sunspot/lib/sunspot/query/geofilt.rb
@@ -1,15 +1,20 @@
 module Sunspot
   module Query
     class Geofilt
+      include Filter
+      attr_reader :field
+
       def initialize(field, lat, lon, radius, options = {})
         @field, @lat, @lon, @radius, @options = field, lat, lon, radius, options
       end
 
-      def to_params
+      def to_boolean_phrase
         func = @options[:bbox] ? "bbox" : "geofilt"
+        "{!#{func} sfield=#{@field.indexed_name} pt=#{@lat},#{@lon} d=#{@radius}}"
+      end
 
-        filter = "{!#{func} sfield=#{@field.indexed_name} pt=#{@lat},#{@lon} d=#{@radius}}"
-        {:fq => filter}
+      def to_params
+        {:fq => to_filter_query}
       end
     end
   end


### PR DESCRIPTION
Includes `Sunspot::Query::Filter` inside of `Sunspot::Query::Geofilt` to allow geo restrictions to be excluded in a facet query.
