### PR TITLE
Throw exception on index unpersisted object

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -7,6 +7,7 @@ module Sunspot #:nodoc:
     # created and destroyed.
     #
     module Searchable
+      UnpersistedObjectError = Class.new(RuntimeError)
       class <<self
         def included(base) #:nodoc:
           base.module_eval do
@@ -384,6 +385,7 @@ module Sunspot #:nodoc:
         # manually.
         #
         def solr_index
+          raise UnpersistedObjectError if self.new_record?
           Sunspot.index(self)
         end
 
@@ -391,6 +393,7 @@ module Sunspot #:nodoc:
         # Index the model in Solr and immediately commit. See #index
         #
         def solr_index!
+          raise UnpersistedObjectError if self.new_record?
           Sunspot.index!(self)
         end
         

--- a/sunspot_rails/spec/model_spec.rb
+++ b/sunspot_rails/spec/model_spec.rb
@@ -20,6 +20,11 @@ describe 'ActiveRecord mixin' do
       posts = Array.new(2) { |j| PostWithDefaultScope.create! :title => (10-j).to_s }
       lambda { PostWithDefaultScope.index(:batch_size => 1) }.should_not raise_error
     end
+
+    it "should blow up if the record isn't persisted" do
+      post = Post.new
+      expect { post.index}.to raise_error
+    end
   end
 
   describe 'single table inheritence' do
@@ -41,6 +46,11 @@ describe 'ActiveRecord mixin' do
 
     it 'should immediately index and commit' do
       Post.search.results.should == [@post]
+    end
+
+    it "should blow up if the record isn't persisted" do
+      post = Post.new
+      expect { post.index!}.to raise_error
     end
   end
 


### PR DESCRIPTION
In response to - https://github.com/sunspot/sunspot/issues/477

ActiveRecord objects shouldn't be indexed in they aren't persisted.
