### PR TITLE
updates stub session proxy to add raw_results

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -81,6 +81,7 @@ module Sunspot
         def hits(options = {})
           PaginatedCollection.new
         end
+        alias_method :raw_results, :hits
 
         def total
           0

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -116,6 +116,10 @@ describe 'specs with Sunspot stubbed' do
       @search.hits.should == []
     end
 
+    it 'should return the same for raw_results as hits' do
+      @search.raw_results.should == @search.hits
+    end
+
     it 'should return zero total' do
       @search.total.should == 0
     end


### PR DESCRIPTION
`Sunspot::Rails::Searchable` depends on a `raw_results` method that wasn't included in `Sunspot::Rails::StubSessionProxy`. `raw_results` is an alias for `hits`, so I added that alias for the `StubSessionProxy`.

This fixes the undefined method error caused by testing `search_ids` in rails.

Thanks.
