### PR TITLE
Reference configuration instance instead of class

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ test:
 
 You may want to use SSL for production environments with a username and password. For example, set `SOLR_URL` to `https://username:password@production.solr.example.com/solr`.
 
-You can examine the value of `Sunspot::Rails::Configuration.solr_url` at runtime.
+You can examine the value of `Sunspot::Rails.configuration` at runtime.
 
 ## Development
 


### PR DESCRIPTION
The current `README.md` code is invalid:

```
> Sunspot::Rails::Configuration.solr_url
NoMethodError: undefined method `solr_url' for Sunspot::Rails::Configuration:Class
```

I think it's nicer to just see all the configuration:

```
> Sunspot::Rails.configuration
=> #<Sunspot::Rails::Configuration:0x007ff707ec8de8 @user_configuration={"solr"=>{"hostname"=>"localhost", "port"=>8983, "log_level"=>"WARNING", "path"=>"/solr/production"}}, @disabled=false, @has_master=false, @hostname="XXXXXXXX", @port=80, @path="XXXXXXXX", @read_timeout=nil, @open_timeout=nil>
```
