### PR TITLE
Fix rails rake tasks under spring

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -72,7 +72,7 @@ namespace :sunspot do
 
   def sunspot_solr_in_load_path?
     # http://www.rubular.com/r/rJGDh7eOSc
-    $:.any? { |path| path =~ %r{sunspot_solr(-[^/]+)?/lib$} }
+    $:.any? { |path| path.to_s =~ %r{sunspot_solr(-[^/]+)?/lib$} }
   end
 
   unless sunspot_solr_in_load_path?


### PR DESCRIPTION
I have a rails app with sunspot_rails and I use the [spring](https://github.com/rails/spring) rails preloader to make running rake, rails and rspec quicker.

Since adding the sunspot_rails gem to the Gemfile, I get this error when running any rake task under spring:

```
$ spring rake db:migrate --trace
undefined method `=~' for #<Pathname:/Users/daniel/work/myapp/app/services>
/Users/daniel/work/myapp/Rakefile:6:in `<top (required)>'
/Users/daniel/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sunspot_rails-2.1.0/lib/sunspot/rails/tasks.rb:75:in `block in sunspot_solr_in_load_path?'
```

Strangely it only happens under spring (running `rake db:migrate` normally works fine).

Thanks! :heart:
