### PR TITLE
Fix the case when using order_by_function with Solr strdist

### DIFF
--- a/sunspot/lib/sunspot/query/sort.rb
+++ b/sunspot/lib/sunspot/query/sort.rb
@@ -134,6 +134,23 @@ module Sunspot
         def initialize(setup,args)
           @function=args.shift
           @fields = []
+          @extras = []
+
+          case @function.to_s
+          when "strdist"
+            # Reference: http://wiki.apache.org/solr/FunctionQuery#strdist
+            valid_measures = [:jw, :edit, :ngram]
+            extra = args.pop
+            if valid_measures.include? extra.to_sym
+              @extras.push(extra)
+            else
+              raise(
+                UnrecognizedRestrictionError,
+                "Use only valid measure options with strdist (#{valid_measures.to_s})"
+              )
+            end
+          end
+
           args.each do |argument|
             case argument.class.name
             when "Array"
@@ -146,7 +163,9 @@ module Sunspot
           end
         end
         def to_s
-          "#{function}(#{fields.map(&:to_s).join(",")})"
+          mapped_fields = fields
+          mapped_fields = mapped_fields + @extras if not @extras.empty?
+          "#{function}(#{mapped_fields.map(&:to_s).join(",")})"
         end
       end
     end


### PR DESCRIPTION
When using the [Solr strdist](http://wiki.apache.org/solr/FunctionQuery#strdist) FunctionQuery with the new `order_by_function` it is required to include a distance measure to use, but sunspot consider each param as it were fields, this pull request fixes that situation.

```
valid_measures = [:jw, :edit, :ngram]
```
