### PR TITLE
Update config_installer.rb

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/installer/config_installer.rb
+++ b/sunspot_solr/lib/sunspot/solr/installer/config_installer.rb
@@ -42,7 +42,7 @@ module Sunspot
 
           # Also copy the solr.xml file for multi core support
           file = File.expand_path('../solr.xml', sunspot_config_path)
-          dest = File.expand_path(File.join(@config_path, ".."), File.basename(file))
+          dest = File.expand_path(File.join(@config_path, "..", File.basename(file)))
           say("Copying #{file} => #{dest}")
           FileUtils.cp(file, dest)
 


### PR DESCRIPTION
Due to a misplaced paren, the installer attempts to copy solr.xml to [...]/solr.xml/solr

Thus the installer fails, and if it was invoked by, say, rake sunspot:solr:start, then the daemon will not start either.