### PR TITLE
Allows sunspot:solr:run to be executed on Windows platforms.

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/tasks.rb
+++ b/sunspot_solr/lib/sunspot/solr/tasks.rb
@@ -27,12 +27,6 @@ namespace :sunspot do
     task reindex: :"sunspot:reindex"
 
     def server
-      case RUBY_PLATFORM
-      when /w(in)?32$/, /java$/
-        abort("This command is not supported on #{RUBY_PLATFORM}. " +
-              "Use rake sunspot:solr:run to run Solr in the foreground.")
-      end
-
       if defined?(Sunspot::Rails::Server)
         Sunspot::Rails::Server.new
       else


### PR DESCRIPTION
Since I couldn't get sunspot working on Windows, I debugged trying to figure out what was preventing it from activating when using the sunspot:solr:run command. Removing this line lets me use the sunspot:solr:run command, the solr server boots up, and my search system works again.

What is the idea behind preventing win32 & mingw32 platforms from executing the 'server' function? The rake tasks won't execute at all without it. Should this check be put somewhere else? Without understanding the system, those would be my questions. Otherwise, it seems to have had no negative effects, and only positive ones (I can run the application now, woooo!!).

Please merge if this is deemed an ok fix, as this is an issue for a number of Windows developers.