### PR TITLE
index_orphans batch_size fix, and deleted_at tweak

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -278,23 +278,28 @@ module Sunspot #:nodoc:
         # ==== Options (passed as a hash)
         #
         # batch_size<Integer>:: Batch size with which to load records. Passing
-        #                       Default is 1000 (from ActiveRecord).
+        #                       Default is 50
+        #
+        # use_deleted_at<Boolean>:: Uses the ActiveRecord's deleted_at column to
+        #                           treat soft/paranoid deleted records in the 
+        #                           database as deleted.
         # 
         # ==== Returns
         #
         # Array:: Collection of IDs that exist in Solr but not in the database
         def solr_index_orphans(opts={})
           batch_size = opts[:batch_size] || Sunspot.config.indexing.default_batch_size          
+          deleted_filter = opts[:use_deleted_at] ? "WHERE deleted_at IS NULL" : ""
 
           solr_page = 0
           solr_ids = []
           while (solr_page = solr_page.next)
-            ids = solr_search_ids { paginate(:page => solr_page, :per_page => 1000) }.to_a
+            ids = solr_search_ids { paginate(:page => solr_page, :per_page => batch_size) }.to_a
             break if ids.empty?
             solr_ids.concat ids
           end
 
-          return solr_ids - self.connection.select_values("SELECT id FROM #{quoted_table_name}").collect(&:to_i)
+          return solr_ids - self.connection.select_values("SELECT id FROM #{quoted_table_name} #{deleted_filter}").collect(&:to_i)
         end
 
         # 
@@ -307,6 +312,10 @@ module Sunspot #:nodoc:
         #
         # batch_size<Integer>:: Batch size with which to load records
         #                       Default is 50
+        #
+        # use_deleted_at<Boolean>:: Uses the ActiveRecord's deleted_at column to
+        #                           treat soft/paranoid deleted records in the 
+        #                           database as deleted.
         # 
         def solr_clean_index_orphans(opts={})
           solr_index_orphans(opts).each do |id|


### PR DESCRIPTION
- Fixed `batch_size` so the option is respected
- Added support for soft/paranoid deleted objects, something which lots of Rails projects use

Examples against real data, with `batch_size`:

```
irb(main):002:0> Job.index_orphans(batch_size: 100000)
D, [2014-07-21T18:03:58.456963 #27407] DEBUG -- :   SOLR Request (167.9ms)  [ path=select parameters={fq: ["type:Job"], start: 0, rows: 100000, q: "*:*"} ]
D, [2014-07-21T18:03:58.460621 #27407] DEBUG -- :   SOLR Request (3.1ms)  [ path=select parameters={fq: ["type:Job"], start: 100000, rows: 100000, q: "*:*"} ]
   (2424.6ms)  SELECT id FROM "jobs"
=> []
```

And with `use_deleted_at`:

```
irb(main):003:0> Job.index_orphans(batch_size: 100000, use_deleted_at: true)
D, [2014-07-21T18:04:14.702333 #27407] DEBUG -- :   SOLR Request (4.9ms)  [ path=select parameters={fq: ["type:Job"], start: 0, rows: 100000, q: "*:*"} ]
D, [2014-07-21T18:04:14.706563 #27407] DEBUG -- :   SOLR Request (3.2ms)  [ path=select parameters={fq: ["type:Job"], start: 100000, rows: 100000, q: "*:*"} ]
   (2092.9ms)  SELECT id FROM "jobs" WHERE deleted_at IS NULL
=> []
```
