### PR TITLE
Requires YAML to read the configuration

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'yaml'
 
 module Sunspot #:nodoc:
   module Rails #:nodoc:


### PR DESCRIPTION
In Ruby 2.1.2 with Rails 4.1.4 yaml wasn't being required and I was seeing the following error:

    gems/sunspot_rails-2.1.1/lib/sunspot/rails/configuration.rb:360:in `block in user_configuration': uninitialized constant Sunspot::Rails::Configuration::YAML (NameError)

Just had to require YAML, and everything works well :)