### PR TITLE
Enabling soft commits for Solr4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,12 +1005,12 @@ There are a number of ways to index manually within Ruby:
 ```ruby
 # On a class itself
 Person.reindex
-Sunspot.commit
+Sunspot.commit # or commit(true) for a soft commit (Solr4)
 
 # On mixed objects
 Sunspot.index [post1, item2]
 Sunspot.index person3
-Sunspot.commit
+Sunspot.commit # or commit(true) for a soft commit (Solr4)
 
 # With autocommit
 Sunspot.index! [post1, item2, person3]

--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -196,23 +196,27 @@ module Sunspot
       session.index!(*objects)
     end
 
-    # Commits the singleton session
+    # Commits (soft or hard) the singleton session
     #
     # When documents are added to or removed from Solr, the changes are
     # initially stored in memory, and are not reflected in Solr's existing
-    # searcher instance. When a commit message is sent, the changes are written
+    # searcher instance. When a hard commit message is sent, the changes are written
     # to disk, and a new searcher is spawned. Commits are thus fairly
     # expensive, so if your application needs to index several documents as part
     # of a single operation, it is advisable to index them all and then call
     # commit at the end of the operation.
+    # Solr 4 introduced the concept of a soft commit which is much faster
+    # since it only makes index changes visible while not writing changes to disk.
+    # If Solr crashes or there is a loss of power, changes that occurred after
+    # the last hard commit will be lost.
     #
     # Note that Solr can also be configured to automatically perform a commit
     # after either a specified interval after the last change, or after a
     # specified number of documents are added. See
     # http://wiki.apache.org/solr/SolrConfigXml
     #
-    def commit
-      session.commit
+    def commit(softCommit = false)
+      session.commit softCommit
     end
 
     # Optimizes the index on the singletion session.
@@ -510,10 +514,10 @@ module Sunspot
     end
 
     # 
-    # Sends a commit if the session is dirty (see #dirty?).
+    # Sends a commit (soft or hard) if the session is dirty (see #dirty?).
     #
-    def commit_if_dirty
-      session.commit_if_dirty
+    def commit_if_dirty(softCommit = false)
+      session.commit_if_dirty softCommit
     end
     
     #
@@ -530,8 +534,8 @@ module Sunspot
     # 
     # Sends a commit if the session has deletes since the last commit (see #delete_dirty?).
     #
-    def commit_if_delete_dirty
-      session.commit_if_delete_dirty
+    def commit_if_delete_dirty(softCommit = false)
+      session.commit_if_delete_dirty softCommit
     end
     
     # Returns the configuration associated with the singleton session. See

--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -215,8 +215,8 @@ module Sunspot
     # specified number of documents are added. See
     # http://wiki.apache.org/solr/SolrConfigXml
     #
-    def commit(softCommit = false)
-      session.commit softCommit
+    def commit(soft_commit = false)
+      session.commit soft_commit
     end
 
     # Optimizes the index on the singletion session.
@@ -516,8 +516,8 @@ module Sunspot
     # 
     # Sends a commit (soft or hard) if the session is dirty (see #dirty?).
     #
-    def commit_if_dirty(softCommit = false)
-      session.commit_if_dirty softCommit
+    def commit_if_dirty(soft_commit = false)
+      session.commit_if_dirty soft_commit
     end
     
     #
@@ -534,8 +534,8 @@ module Sunspot
     # 
     # Sends a commit if the session has deletes since the last commit (see #delete_dirty?).
     #
-    def commit_if_delete_dirty(softCommit = false)
-      session.commit_if_delete_dirty softCommit
+    def commit_if_delete_dirty(soft_commit = false)
+      session.commit_if_delete_dirty soft_commit
     end
     
     # Returns the configuration associated with the singleton session. See

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -102,9 +102,9 @@ module Sunspot
     #
     # See Sunspot.commit
     #
-    def commit(softCommit = false)
+    def commit(soft_commit = false)
       @adds = @deletes = 0
-      connection.commit :commit_attributes => {:softCommit => softCommit}
+      connection.commit :commit_attributes => {:softCommit => soft_commit}
     end
 
     #
@@ -200,8 +200,8 @@ module Sunspot
     # 
     # See Sunspot.commit_if_dirty
     #
-    def commit_if_dirty(softCommit = false)
-      commit softCommit if dirty?
+    def commit_if_dirty(soft_commit = false)
+      commit soft_commit if dirty?
     end
     
     # 
@@ -214,8 +214,8 @@ module Sunspot
     # 
     # See Sunspot.commit_if_delete_dirty
     #
-    def commit_if_delete_dirty(softCommit = false)
-      commit softCommit if delete_dirty?
+    def commit_if_delete_dirty(soft_commit = false)
+      commit soft_commit if delete_dirty?
     end
     
     # 

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -102,9 +102,9 @@ module Sunspot
     #
     # See Sunspot.commit
     #
-    def commit
+    def commit(softCommit = false)
       @adds = @deletes = 0
-      connection.commit
+      connection.commit :commit_attributes => {softCommit: softCommit}
     end
 
     #
@@ -200,8 +200,8 @@ module Sunspot
     # 
     # See Sunspot.commit_if_dirty
     #
-    def commit_if_dirty
-      commit if dirty?
+    def commit_if_dirty(softCommit = false)
+      commit softCommit if dirty?
     end
     
     # 
@@ -214,8 +214,8 @@ module Sunspot
     # 
     # See Sunspot.commit_if_delete_dirty
     #
-    def commit_if_delete_dirty
-      commit if delete_dirty?
+    def commit_if_delete_dirty(softCommit = false)
+      commit softCommit if delete_dirty?
     end
     
     # 

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -104,7 +104,7 @@ module Sunspot
     #
     def commit(softCommit = false)
       @adds = @deletes = 0
-      connection.commit :commit_attributes => {softCommit: softCommit}
+      connection.commit :commit_attributes => {:softCommit => softCommit}
     end
 
     #

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -35,6 +35,26 @@ shared_examples_for 'all sessions' do
     end
   end
 
+  context '#commit(bool)' do
+    it 'should soft-commit if bool=true' do
+      @session.commit(true)
+      connection.should have(1).commits
+      connection.should have(1).softCommits
+    end
+
+    it 'should hard-commit if bool=false' do
+      @session.commit(false)
+      connection.should have(1).commits
+      connection.should have(0).softCommits
+    end
+
+    it 'should hard-commit if bool is not specified' do
+      @session.commit
+      connection.should have(1).commits
+      connection.should have(0).softCommits
+    end
+  end
+
   context '#optimize()' do
     before :each do
       @session.optimize
@@ -202,16 +222,30 @@ describe 'Session' do
       connection.should have(0).commits
     end
 
-    it 'should commit when commit_if_dirty called on dirty session' do
+    it 'should hard commit when commit_if_dirty called on dirty session' do
       @session.index(Post.new)
       @session.commit_if_dirty
       connection.should have(1).commits
     end
     
-    it 'should commit when commit_if_delete_dirty called on delete_dirty session' do
+    it 'should soft commit when commit_if_dirty called on dirty session' do
+      @session.index(Post.new)
+      @session.commit_if_dirty(true)
+      connection.should have(1).commits
+      connection.should have(1).softCommits
+    end
+    
+    it 'should hard commit when commit_if_delete_dirty called on delete_dirty session' do
       @session.remove(Post.new)
       @session.commit_if_delete_dirty
       connection.should have(1).commits
+    end
+
+    it 'should soft commit when commit_if_delete_dirty called on delete_dirty session' do
+      @session.remove(Post.new)
+      @session.commit_if_delete_dirty(true)
+      connection.should have(1).commits
+      connection.should have(1).softCommits
     end
   end
 

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -39,19 +39,19 @@ shared_examples_for 'all sessions' do
     it 'should soft-commit if bool=true' do
       @session.commit(true)
       connection.should have(1).commits
-      connection.should have(1).softCommits
+      connection.should have(1).soft_commits
     end
 
     it 'should hard-commit if bool=false' do
       @session.commit(false)
       connection.should have(1).commits
-      connection.should have(0).softCommits
+      connection.should have(0).soft_commits
     end
 
     it 'should hard-commit if bool is not specified' do
       @session.commit
       connection.should have(1).commits
-      connection.should have(0).softCommits
+      connection.should have(0).soft_commits
     end
   end
 
@@ -232,7 +232,7 @@ describe 'Session' do
       @session.index(Post.new)
       @session.commit_if_dirty(true)
       connection.should have(1).commits
-      connection.should have(1).softCommits
+      connection.should have(1).soft_commits
     end
     
     it 'should hard commit when commit_if_delete_dirty called on delete_dirty session' do
@@ -245,7 +245,7 @@ describe 'Session' do
       @session.remove(Post.new)
       @session.commit_if_delete_dirty(true)
       connection.should have(1).commits
-      connection.should have(1).softCommits
+      connection.should have(1).soft_commits
     end
   end
 

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -22,7 +22,7 @@ module Mock
   end
 
   class Connection
-    attr_reader :adds, :commits, :optims, :searches, :message, :opts, :deletes_by_query
+    attr_reader :adds, :commits, :softCommits, :optims, :searches, :message, :opts, :deletes_by_query
     attr_accessor :response
     attr_writer :expected_handler
     undef_method :select # annoyingly defined on Object
@@ -30,7 +30,7 @@ module Mock
     def initialize(opts = {})
       @opts = opts
       @message = OpenStruct.new
-      @adds, @deletes, @deletes_by_query, @commits, @optims, @searches = Array.new(6) { [] }
+      @adds, @deletes, @deletes_by_query, @commits, @softCommits, @optims, @searches = Array.new(7) { [] }
       @expected_handler = :select
     end
 
@@ -46,8 +46,10 @@ module Mock
       @deletes_by_query << query
     end
 
-    def commit
+    def commit(opts = {})
+      commit_attrs = opts.delete(:commit_attributes) || {}
       @commits << Time.now
+      @softCommits << Time.now if commit_attrs[:softCommit]
     end
 
     def optimize

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -22,7 +22,7 @@ module Mock
   end
 
   class Connection
-    attr_reader :adds, :commits, :softCommits, :optims, :searches, :message, :opts, :deletes_by_query
+    attr_reader :adds, :commits, :soft_commits, :optims, :searches, :message, :opts, :deletes_by_query
     attr_accessor :response
     attr_writer :expected_handler
     undef_method :select # annoyingly defined on Object
@@ -30,7 +30,7 @@ module Mock
     def initialize(opts = {})
       @opts = opts
       @message = OpenStruct.new
-      @adds, @deletes, @deletes_by_query, @commits, @softCommits, @optims, @searches = Array.new(7) { [] }
+      @adds, @deletes, @deletes_by_query, @commits, @soft_commits, @optims, @searches = Array.new(7) { [] }
       @expected_handler = :select
     end
 
@@ -49,7 +49,7 @@ module Mock
     def commit(opts = {})
       commit_attrs = opts.delete(:commit_attributes) || {}
       @commits << Time.now
-      @softCommits << Time.now if commit_attrs[:softCommit]
+      @soft_commits << Time.now if commit_attrs[:softCommit]
     end
 
     def optimize

--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -46,13 +46,13 @@ module Sunspot
         false
       end
 
-      def commit_if_dirty
+      def commit_if_dirty(softCommit = false)
       end
 
-      def commit_if_delete_dirty
+      def commit_if_delete_dirty(softCommit = false)
       end
 
-      def commit
+      def commit(softCommit = false)
       end
 
       def search(*types)

--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -46,13 +46,13 @@ module Sunspot
         false
       end
 
-      def commit_if_dirty(softCommit = false)
+      def commit_if_dirty(soft_commit = false)
       end
 
-      def commit_if_delete_dirty(softCommit = false)
+      def commit_if_delete_dirty(soft_commit = false)
       end
 
-      def commit(softCommit = false)
+      def commit(soft_commit = false)
       end
 
       def search(*types)


### PR DESCRIPTION
This pull request adds the ability to do soft commits in Solr4. Three function pairs were patched: commit, commit_if_dirty and commit_if_delete_dirty in Sunspot and Session classes. An optional boolean parameter denotes a soft commit if true. New tests are added and all tests are passing. Documentation is also updated to explain hard and soft commits.