### PR TITLE
Fix rake task sunspot:solr:reindex

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -100,7 +100,9 @@ namespace :sunspot do
       task :stop => :moved_to_sunspot_solr
 
       # for backwards compatibility
-      task :reindex => :"sunspot:reindex"
+      task :reindex, [:batch_size, :models, :silence] => [:environment] do |t, args|
+        Rake::Task['sunspot:reindex'].execute(args)
+      end
     end
   end
 end

--- a/sunspot_solr/lib/sunspot/solr/tasks.rb
+++ b/sunspot_solr/lib/sunspot/solr/tasks.rb
@@ -24,7 +24,9 @@ namespace :sunspot do
     end
 
     # for backwards compatibility
-    task reindex: :"sunspot:reindex"
+    task :reindex, [:batch_size, :models, :silence] => [:environment] do |t, args|
+      Rake::Task['sunspot:reindex'].execute(args)
+    end
 
     def server
       case RUBY_PLATFORM


### PR DESCRIPTION
`sunspot:solr:reindex` is the alias for `sunspot:reindex` . But it seems cut off arguments.
