### PR TITLE
Move prepare out of private so that sunspot matchers has access to it

### DIFF
--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -82,12 +82,6 @@ module Sunspot
       add_documents(batcher.end_current)
     end
 
-    private
-
-    def batcher
-      @batcher ||= Batcher.new
-    end
-
     # 
     # Convert documents into hash of indexed properties
     #
@@ -101,6 +95,12 @@ module Sunspot
         field_factory.populate_document(document, model)
       end
       document
+    end
+
+    private
+
+    def batcher
+      @batcher ||= Batcher.new
     end
 
     def add_documents(documents)


### PR DESCRIPTION
I'm not sure of a better way

Github in the split view seems to think that I removed private altogether along with the batcher. This is not the case if you review the file itself.

Corresponding pull request for sunspot matchers to add have_indexed_field (https://github.com/pivotal/sunspot_matchers/pull/18)