### PR TITLE
Fix: undefined method data_accessor_for for StubSessionProxy::Search

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -71,8 +71,12 @@ module Sunspot
         Search.new
       end
 
+      class DataAccessorStub
+        attr_accessor :include, :select
+      end
+
       class Search
-        
+
         def build
           self
         end
@@ -102,28 +106,32 @@ module Sunspot
           FacetStub.new
         end
 
+        def data_accessor_for(klass)
+          DataAccessorStub.new
+        end
+
         def execute
           self
         end
       end
-      
-      
+
+
       class PaginatedCollection < Array
-        
+
         def total_count
           0
         end
         alias :total_entries :total_count
-        
+
         def current_page
           1
         end
-        
+
         def per_page
           30
         end
         alias :limit_value :per_page
-        
+
         def total_pages
           1
         end
@@ -152,7 +160,7 @@ module Sunspot
         def offset
           0
         end
-        
+
       end
 
       class FacetStub
@@ -162,7 +170,7 @@ module Sunspot
         end
 
       end
-      
+
     end
   end
 end

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -140,5 +140,19 @@ describe 'specs with Sunspot stubbed' do
     it 'should return empty array if listing facets' do
       @search.facets.should == []
     end
+
+    describe '#data_accessor_for' do
+      before do
+        @accessor = @search.data_accessor_for(Post)
+      end
+
+      it 'should provide accessor for select' do
+        @accessor.should respond_to(:select, :select=)
+      end
+
+      it 'should provide accessor for include' do
+        @accessor.should respond_to(:include, :include=)
+      end
+    end
   end
 end


### PR DESCRIPTION
**Issue description:**

When I try to use sunspot like this:
```ruby
search = Sunspot.new_search(Post)
search.data_accessor_for(Post).include = %i[comments]
```
Everything works :ok: in `development`, but when I try to run `rspec` I get the following error: 
```
NoMethodError:
    undefined method `data_accessor_for' for #<Sunspot::Rails::StubSessionProxy::Search>
```
(`::Sunspot.session` is set to `StubSessionProxy` obviously)