### PR TITLE
Add auto_index_callback and auto_remove_callback config option

### DIFF
--- a/sunspot_rails/README.rdoc
+++ b/sunspot_rails/README.rdoc
@@ -188,6 +188,29 @@ remove those documents from the index, use +clean_index_orphans+. Note that
 neither of these operations should be needed if Sunspot and Sunspot::Rails are
 used as intended.
 
+=== Configuration
+
+==== ActiveRecord index hooks
+
+By default, `sunspot_rails` uses `after_save` and `after_destroy` hooks to
+automatically index or remove ActiveRecord models. When you're using any sort
+of asynchronous indexing like
+[sunspot_index_queue](https://github.com/bdurand/sunspot_index_queue) or
+[sunspot-queue](https://github.com/gaffneyc/sunspot-queue) you may want
+these to be after_commit hooks or you may have timing issues.
+
+To do this, add the following to your `sunspot.yml` for each environment:
+
+    production:
+      # ...
+      auto_index_callback: after_commit
+      auto_remove_callback: after_commit
+
+Note that if you set these to `after_commit` in the `test` environment you may
+need https://github.com/grosser/test_after_commit if you use
+`transactionnal_fixtures = true`.
+
+
 == Testing Solr integration using RSpec
 
 To disable the sunspot-solr integration for your active record models, require

--- a/sunspot_rails/generators/sunspot/templates/sunspot.yml
+++ b/sunspot_rails/generators/sunspot/templates/sunspot.yml
@@ -6,6 +6,8 @@ production:
     path: /solr/production
     read_timeout: 20
     open_timeout: 1
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit
 
 development:
   solr:
@@ -13,6 +15,8 @@ development:
     port: 8983
     log_level: INFO
     path: /solr/development
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit
 
 test:
   solr:
@@ -20,4 +24,5 @@ test:
     port: 8983
     log_level: WARNING
     path: /solr/test
-    
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -39,6 +39,8 @@ module Sunspot #:nodoc:
     #       hostname: localhost
     #       port: 8982
     #       path: /solr
+    #     auto_index_callback: after_commit
+    #     auto_remove_callback: after_commit
     #     auto_commit_after_request: true
     #
     # Sunspot::Rails uses the configuration to set up the Solr connection, as
@@ -313,6 +315,24 @@ module Sunspot #:nodoc:
       #
       def disabled?
         @disabled ||= (user_configuration_from_key('disabled') || false)
+      end
+
+      #
+      # The callback to use when automatically indexing records.
+      # Defaults to after_save.
+      #
+      def auto_index_callback
+        @auto_index_callback ||=
+          (user_configuration_from_key('auto_index_callback') || 'after_save')
+      end
+
+      #
+      # The callback to use when automatically removing records after deletation.
+      # Defaults to after_destroy.
+      #
+      def auto_remove_callback
+        @auto_remove_callback ||=
+          (user_configuration_from_key('auto_remove_callback') || 'after_destroy')
       end
 
       private

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -90,16 +90,21 @@ module Sunspot #:nodoc:
 
             unless options[:auto_index] == false
               before_save :mark_for_auto_indexing_or_removal
-              after_save :perform_index_tasks
+
+              # after_commit :perform_index_tasks, :if => :persisted?
+              __send__ Sunspot::Rails.configuration.auto_index_callback,
+                       :perform_index_tasks,
+                       :if => :persisted?
             end
 
             unless options[:auto_remove] == false
-              after_destroy do |searchable|
-                searchable.remove_from_index
-              end
+              # after_commit { |searchable| searchable.remove_from_index }, :on => :destroy
+              __send__ Sunspot::Rails.configuration.auto_remove_callback,
+                       proc { |searchable| searchable.remove_from_index },
+                       :on => :destroy
             end
             options[:include] = Util::Array(options[:include])
-            
+
             self.sunspot_options = options
           end
         end

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -92,6 +92,14 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   it "should handle the 'disabled' property when not set" do
     @config.disabled?.should be_false
   end
+
+  it "should handle the 'auto_index_callback' property when not set" do
+    @config.auto_index_callback.should == "after_save"
+  end
+
+  it "should handle the 'auto_remove_callback' property when not set" do
+    @config.auto_remove_callback.should == "after_destroy"
+  end
 end
 
 describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
@@ -158,6 +166,21 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
 
   it "should handle the 'open_timeout' property when set" do
     @config.open_timeout.should == 0.5
+  end
+end
+
+describe Sunspot::Rails::Configuration, "with auto_index_callback and auto_remove_callback set" do
+  before do
+    ::Rails.stub!(:env => 'config_commit_test')
+    @config = Sunspot::Rails::Configuration.new
+  end
+
+  it "should handle the 'auto_index_callback' property when set" do
+    @config.auto_index_callback.should == "after_commit"
+  end
+
+  it "should handle the 'auto_remove_callback' property when set" do
+    @config.auto_remove_callback.should == "after_commit"
   end
 end
 

--- a/sunspot_rails/spec/rails_template/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot.yml
@@ -2,6 +2,8 @@ test:
   solr:
     hostname: localhost
     port: 8983
+  auto_index_callback: after_save
+  auto_remove_callback: after_destroy
 development:
   solr:
     hostname: localhost
@@ -25,3 +27,6 @@ config_test:
   auto_commit_after_delete_request: true
 config_disabled_test:
   disabled: true
+config_commit_test:
+  auto_index_callback: after_commit
+  auto_remove_callback: after_commit


### PR DESCRIPTION
This is a port of https://github.com/sunspot/sunspot/pull/249 which was merged into the 1-3-stable

* Auto index and auto removal can now be done in the after_commit
  callback in Rails 3, which is a better option in general because the
  transaction will have been finished.
* Since switching to after_commit might be a breaking change for some
  (especially in tests), it was decided to add a config option that
  defaults to after_save.