### PR TITLE
Two additions to the Joins documentation in README.md for clarity and correctness. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ end
 ### Joins
 
 **Solr 4 and above**
+**Sunspot version > 2.1.1 required**
 
 Solr joins allow you to filter objects by joining on additional documents.  More information can be found on the [Solr Wiki](http://wiki.apache.org/solr/Join).
 
@@ -707,6 +708,7 @@ end
 
 class PhotoContainer < ActiveRecord::Base
   searchable do
+    integer :id
     text :name
     join(:description, :target => Photo, :type => :text, :join => { :from => :photo_container_id, :to => :id })
     join(:caption, :target => Photo, :type => :string, :join => { :from => :photo_container_id, :to => :id })


### PR DESCRIPTION
First, add the 'integer :id' field directive that's required to the PhotoContainer example, and second specify that you need a version of sunspot greater than 2.1.1 (that is, currently, HEAD).  Without adding the integer :id, the example code will not work (complains about not finding :id field), and  without more recent commits than v2.1.1, the join functionality will not work (complains about :target).
