### PR TITLE
Alias prev_page to previous_page for kaminari compatibility

### DIFF
--- a/sunspot/lib/sunspot/search/paginated_collection.rb
+++ b/sunspot/lib/sunspot/search/paginated_collection.rb
@@ -32,6 +32,7 @@ module Sunspot
       def previous_page
         current_page > 1 ? (current_page - 1) : nil
       end
+      alias :prev_page :previous_page
 
       def next_page
         current_page < total_pages ? (current_page + 1) : nil

--- a/sunspot/spec/api/search/paginated_collection_spec.rb
+++ b/sunspot/spec/api/search/paginated_collection_spec.rb
@@ -23,6 +23,7 @@ describe "PaginatedCollection" do
     it { subject.current_page.should eql(1) }
     it { subject.per_page.should eql(10) }
     it { subject.previous_page.should be_nil }
+    it { subject.prev_page.should be_nil }
     it { subject.next_page.should eql(2) }
     it { subject.out_of_bounds?.should_not be_true }
     it { subject.offset.should eql(0) }


### PR DESCRIPTION
An internal change in kaminari https://github.com/amatsuda/kaminari/commit/e07914f69c6878e357d6f44a8663fd7a9223c54b broke compatibility with sunspot, which was reported in https://github.com/amatsuda/kaminari/issues/613. This pull request fixes the issue. Let me know is there's something missing. Thanks!