### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ end
 ```
 
 ```ruby
-# Posts with blog_id 1 and author_id 2
+# Posts that have 'keyword1' in the title or 'keyword2' in the body
 Post.search do
   any do
     fulltext "keyword1", :fields => :title


### PR DESCRIPTION
an example repeated `# Posts with blog_id 1 and author_id 2`.  Still learning sunspot but did my best to correct the issue