### PR TITLE
Add ability to specify multiple hosts in sunspot.yml as an array (fixes #608)

### DIFF
--- a/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
@@ -24,7 +24,7 @@ module Sunspot
       # passed, a default configuration is used; it can then be modified using
       # the #config attribute.
       #
-      def initialize(config = Sunspot::Configuration.new)
+      def initialize(config = Sunspot::Configuration.build)
         @config = config
         ObjectSpace.define_finalizer(self, FINALIZER)
       end

--- a/sunspot_rails/lib/generators/sunspot_rails/install/templates/config/sunspot.yml
+++ b/sunspot_rails/lib/generators/sunspot_rails/install/templates/config/sunspot.yml
@@ -1,23 +1,19 @@
 production:
   solr:
-    hostname: localhost
-    port: 8983
+    hosts:
+      - 'localhost:8983/solr/production'
     log_level: WARNING
-    path: /solr/production
     # read_timeout: 2
     # open_timeout: 0.5
 
 development:
   solr:
-    hostname: localhost
-    port: 8982
+    hosts:
+      - 'localhost:8982/solr/development'
     log_level: INFO
-    path: /solr/development
 
 test:
   solr:
-    hostname: localhost
-    port: 8981
+    hosts:
+      - 'localhost:8981/solr/test'
     log_level: WARNING
-    path: /solr/test
-    

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -42,28 +42,44 @@ module Sunspot #:nodoc:
       private
 
       def master_config(sunspot_rails_configuration)
-        config = Sunspot::Configuration.build
-        builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
-        config.solr.url = builder.build(
-          :host => sunspot_rails_configuration.master_hostname,
-          :port => sunspot_rails_configuration.master_port,
-          :path => sunspot_rails_configuration.master_path,
-          :userinfo => sunspot_rails_configuration.userinfo
-        ).to_s
-        config.solr.read_timeout = sunspot_rails_configuration.read_timeout
-        config.solr.open_timeout = sunspot_rails_configuration.open_timeout
-        config
+        build_config(sunspot_rails_configuration) do |config|
+          config.solr.url = if sunspot_rails_configuration.master_hosts.empty?
+            builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
+
+            builder.build(
+              :host => sunspot_rails_configuration.master_hostname,
+              :port => sunspot_rails_configuration.master_port,
+              :path => sunspot_rails_configuration.master_path,
+              :userinfo => sunspot_rails_configuration.userinfo
+            ).to_s
+          else
+            sunspot_rails_configuration.hosts
+          end
+        end
       end
 
       def slave_config(sunspot_rails_configuration)
+        build_config(sunspot_rails_configuration) do |config|
+          config.solr.url = if sunspot_rails_configuration.hosts.empty?
+            builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
+
+            builder.build(
+              :host => sunspot_rails_configuration.hostname,
+              :port => sunspot_rails_configuration.port,
+              :path => sunspot_rails_configuration.path,
+              :userinfo => sunspot_rails_configuration.userinfo
+            ).to_s
+          else
+            sunspot_rails_configuration.hosts
+          end
+        end
+      end
+
+      def build_config(sunspot_rails_configuration)
         config = Sunspot::Configuration.build
-        builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
-        config.solr.url = builder.build(
-          :host => sunspot_rails_configuration.hostname,
-          :port => sunspot_rails_configuration.port,
-          :path => sunspot_rails_configuration.path,
-          :userinfo => sunspot_rails_configuration.userinfo
-        ).to_s
+
+        yield config
+
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -53,8 +53,25 @@ module Sunspot #:nodoc:
       # ActiveSupport log levels are integers; this array maps them to the
       # appropriate java.util.logging.Level constant
       LOG_LEVELS = %w(FINE INFO WARNING SEVERE SEVERE INFO)
+      SCHEME_EXP = /\Ahttps?:\/\//
 
       attr_writer :user_configuration
+      #
+      # The host names array at which to connect to Solr.
+      #
+      # ==== Returns
+      #
+      # Array:: hosts
+      #
+      def hosts
+        unless defined?(@hosts)
+          @hosts = [user_configuration_from_key('solr', 'hosts')].flatten.compact.
+            map { |host| host.prepend("#{scheme}://") unless host[SCHEME_EXP] }
+        end
+
+        @hosts
+      end
+
       #
       # The host name at which to connect to Solr. Default 'localhost'.
       #
@@ -143,6 +160,22 @@ module Sunspot #:nodoc:
       end
 
       #
+      # The host names array at which to connect to the master Solr instances.
+      #
+      # ==== Returns
+      #
+      # Array:: master_hosts
+      #
+      def master_hosts
+        unless defined?(@master_hosts)
+          @master_hosts = [user_configuration_from_key('solr', 'master_hosts')].flatten.compact.
+            map { |host| host.prepend("#{scheme}://") unless host[SCHEME_EXP] }
+        end
+
+        @master_hosts
+      end
+
+      #
       # The host name at which to connect to the master Solr instance. Defaults
       # to the 'hostname' configuration option.
       #
@@ -186,7 +219,7 @@ module Sunspot #:nodoc:
       # Boolean:: bool
       #
       def has_master?
-        @has_master = !!user_configuration_from_key('master_solr')
+        @has_master = !!user_configuration_from_key('master_solr') || !!user_configuration_from_key('master_hosts')
       end
 
       #

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -45,6 +45,14 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
     end
   end
 
+  it "should set hosts to an empty array when not set" do
+    @config.hosts.should eq []
+  end
+
+  it "should set master_hosts to an empty array when not set" do
+    @config.master_hosts.should eq []
+  end
+
   it "should set the read timeout to nil when not set" do
     @config.read_timeout == nil
   end
@@ -98,6 +106,14 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
   before(:each) do
     ::Rails.stub(:env => 'config_test')
     @config = Sunspot::Rails::Configuration.new
+  end
+
+  it "should parse hosts array" do
+    @config.hosts.should eq ['http://localhost:8081/solr/test', 'http://localhost:8091/solr/test']
+  end
+
+  it "should parse master_hosts array" do
+    @config.master_hosts.should eq ['http://localhost:8080/solr/test', 'http://localhost:8090/solr/test']
   end
 
   it "should handle the 'scheme' property when set" do

--- a/sunspot_rails/spec/rails_template/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot.yml
@@ -8,6 +8,12 @@ development:
     port: 8981
 config_test:
   solr:
+    hosts:
+      - 'localhost:8081/solr/test'
+      - 'localhost:8091/solr/test'
+    master_hosts:
+      - 'localhost:8080/solr/test'
+      - 'localhost:8090/solr/test'
     scheme: http
     user: user
     pass: pass

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -10,7 +10,7 @@ describe 'specs with Sunspot stubbed' do
   end
 
   it 'should batch' do
-    foo = mock('Foo')
+    foo = double('Foo')
     block = lambda { foo.bar }
 
     foo.should_receive(:bar)


### PR DESCRIPTION
This change depends of: https://github.com/rsolr/rsolr/pull/88 which adds the ability to pass an array of urls to RSolr. @njakobsen 

Allows to specify:
```yaml
production:
  solr:
    hosts:
      - 'localhost:8081/solr/core'
      - 'localhost:8091/solr/core'
    master_hosts:
      - 'localhost:8080/solr/core'
      - 'localhost:8090/solr/core'
    read_timeout: 20
    open_timeout: 1
    log_level: WARNING
```