### PR TITLE
Update docs and fix argument passing to aliased task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,13 +1020,13 @@ If you make a change to the object's "schema" (code in the `searchable` block),
 you must reindex all objects so the changes are reflected in Solr:
 
 ```bash
-bundle exec rake sunspot:solr:reindex
+bundle exec rake sunspot:reindex
 
 # or, to be specific to a certain model with a certain batch size:
-bundle exec rake sunspot:solr:reindex[500,Post] # some shells will require escaping [ with \[ and ] with \]
+bundle exec rake sunspot:reindex[500,Post] # some shells will require escaping [ with \[ and ] with \]
 
 # to skip the prompt asking you if you want to proceed with the reindexing:
-bundle exec rake sunspot:solr:reindex[,,true] # some shells will require escaping [ with \[ and ] with \]
+bundle exec rake sunspot:reindex[,,true] # some shells will require escaping [ with \[ and ] with \]
 ```
 
 ## Use Without Rails

--- a/sunspot_solr/lib/sunspot/solr/tasks.rb
+++ b/sunspot_solr/lib/sunspot/solr/tasks.rb
@@ -24,7 +24,7 @@ namespace :sunspot do
     end
 
     # for backwards compatibility
-    task reindex: :"sunspot:reindex"
+    task :reindex, [:batch_size, :models, :silence] => :"sunspot:reindex"
 
     def server
       case RUBY_PLATFORM


### PR DESCRIPTION
The documentation currently mentions `sunspot:solr:reindex` as the way to reindex models. However, this is actually an alias for `sunspot:reindex`, which is [commented](https://github.com/sunspot/sunspot/blob/master/sunspot_solr/lib/sunspot/solr/tasks.rb#L26) as existing  for backwards compatibility. The problem is that the alias does not pass the arguments through to the aliased method, thus running `rake sunspot:solr:reindex[500,Post]` actually does a full reindex of everything.