### PR TITLE
fix deprecation warnings from RSolr 1.0.11

### DIFF
--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -8,7 +8,6 @@ module Sunspot
   # subclasses).
   #
   class Indexer #:nodoc:
-    include RSolr::Char
 
     def initialize(connection)
       @connection = connection
@@ -55,7 +54,7 @@ module Sunspot
     #
     def remove_all(clazz = nil)
       if clazz
-        @connection.delete_by_query("type:#{escape(clazz.name)}")
+        @connection.delete_by_query("type:#{Util.escape(clazz.name)}")
       else
         @connection.delete_by_query("*:*")
       end

--- a/sunspot/lib/sunspot/query/function_query.rb
+++ b/sunspot/lib/sunspot/query/function_query.rb
@@ -4,7 +4,6 @@ module Sunspot
     # Abstract class for function queries.
     #
     class FunctionQuery 
-      include RSolr::Char
 
       def ^(y)
         @boost_amount = y
@@ -34,7 +33,7 @@ module Sunspot
       end
 
       def to_s
-        "#{escape(@field.indexed_name)}" << (@boost_amount ? "^#{@boost_amount}" : "")
+        "#{Util.escape(@field.indexed_name)}" << (@boost_amount ? "^#{@boost_amount}" : "")
       end
     end
 

--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -38,7 +38,6 @@ module Sunspot
       #
       class Base #:nodoc:
         include Filter
-        include RSolr::Char
 
         RESERVED_WORDS = Set['AND', 'OR', 'NOT']
 
@@ -92,7 +91,7 @@ module Sunspot
         # String:: Boolean phrase for restriction in the positive
         #
         def to_positive_boolean_phrase
-          "#{escape(@field.indexed_name)}:#{to_solr_conditional}"
+          "#{Util.escape(@field.indexed_name)}:#{to_solr_conditional}"
         end
 
         # 
@@ -138,7 +137,7 @@ module Sunspot
         # String:: Solr API representation of given value
         #
         def solr_value(value = @value)
-          solr_value = escape(@field.to_indexed(value))
+          solr_value = Util.escape(@field.to_indexed(value))
           if RESERVED_WORDS.include?(solr_value)
             %Q("#{solr_value}")
           else
@@ -168,7 +167,7 @@ module Sunspot
           unless @value.nil?
             super
           else
-            "#{escape(@field.indexed_name)}:[* TO *]"
+            "#{Util.escape(@field.indexed_name)}:[* TO *]"
           end
         end
 

--- a/sunspot/lib/sunspot/util.rb
+++ b/sunspot/lib/sunspot/util.rb
@@ -155,6 +155,23 @@ module Sunspot
         deep_merge_into(left, left, right)
       end
 
+      #
+      # Escapes characters for the Solr query parser
+      #
+      # ==== Parameters
+      #
+      # string<String>:: String to escape
+      #
+      # ==== Returns
+      #
+      # String:: escaped string
+      #
+      def escape(value)
+        # RSolr.solr_escape doesn't handle spaces or period chars,
+        # which do need to be escaped
+        RSolr.solr_escape(value).gsub(/([\s\.])/, '\\\\\1')
+      end
+
       private
 
       # 


### PR DESCRIPTION
This is a fix for Issue #661 

Note that Rsolr.escape and Rsolr.solr_escape are different. The deprecated version escapes any non-alphanumeric character; the new function specifically escapes a list of known special characters in the following list:

https://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters

The tests do not pass by simply replacing the deprecated function, because spaces and periods need to be escaped as well. So I've put this wrapped functionality in Sunspot::Util#escape.