### PR TITLE
Fixed java installation check when java is present, but doesn't execute with exit status 0.

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/java.rb
+++ b/sunspot_solr/lib/sunspot/solr/java.rb
@@ -6,7 +6,7 @@ module Sunspot
       NULL_DEVICE = RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL' : '/dev/null'
 
       def self.installed?
-        system "java -version >#{NULL_DEVICE} 2>&1"
+        !system("java -version >#{NULL_DEVICE} 2>&1").nil?
       end
     end
   end


### PR DESCRIPTION
When I switched my console application from Windows prompt to Cmder (https://github.com/bliker/cmder), sunspot_solr stopped detecting Java on my machine. I found out 

```ruby
system("java -version >#{NULL_DEVICE} 2>&1")
```

was returning ```false```. According to the ruby docs (http://ruby-doc.org/core-1.9.3/Kernel.html#method-i-system), ```system``` calls will return nil when there is a fail to execute or a boolean value, depending on the exit code. So, I think it is ok to just check whether the return is nil. 