### PR TITLE
add ability to specify separator for dynamic fields

### DIFF
--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -112,18 +112,19 @@ module Sunspot
     # configuration.
     #
     class Dynamic < Abstract
-      attr_accessor :name, :type
+      attr_accessor :name, :type, :separator
 
       def initialize(name, type, options = {}, &block)
         super(name, options, &block)
         @type, @options = type, options
+        @separator = @options.delete(:separator) || ':'
       end
 
       #
       # Build a field based on the dynamic name given.
       #
       def build(dynamic_name)
-        AttributeField.new("#{@name}:#{dynamic_name}", @type, @options.dup)
+        AttributeField.new([@name, dynamic_name].join(separator), @type, @options.dup)
       end
       # 
       # This alias allows a DynamicFieldFactory to be used in place of a Setup

--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -160,11 +160,13 @@ module Sunspot
       #
       def facet(name, dynamic_name = nil)
         if name
-          if dynamic_name
-            @facets_by_name[:"#{name}:#{dynamic_name}"]
-          else
-            @facets_by_name[name.to_sym]
-          end
+          facet_name = if dynamic_name
+                         separator = @setup.dynamic_field_factory(name).separator
+                         [name, dynamic_name].join(separator)
+                       else
+                         name
+                       end.to_sym
+          @facets_by_name[facet_name]
         end
       end
 

--- a/sunspot/spec/integration/dynamic_fields_spec.rb
+++ b/sunspot/spec/integration/dynamic_fields_spec.rb
@@ -1,17 +1,17 @@
 require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
-describe 'dynamic fields' do
+shared_examples 'dynamic fields' do
   before :each do
     Sunspot.remove_all
-    @posts = Post.new(:custom_string => { :cuisine => 'Pizza' }),
-             Post.new(:custom_string => { :cuisine => 'Greek' }),
-             Post.new(:custom_string => { :cuisine => 'Greek' })
+    @posts = Post.new(field_name => { :cuisine => 'Pizza' }),
+             Post.new(field_name => { :cuisine => 'Greek' }),
+             Post.new(field_name => { :cuisine => 'Greek' })
     Sunspot.index!(@posts)
   end
 
   it 'should search for dynamic string field' do
     Sunspot.search(Post) do
-      dynamic(:custom_string) do
+      dynamic(field_name) do
         with(:cuisine, 'Pizza')
       end
     end.results.should == [@posts.first]
@@ -20,20 +20,20 @@ describe 'dynamic fields' do
   describe 'faceting' do
     before :each do
       @search = Sunspot.search(Post) do
-        dynamic :custom_string do
+        dynamic field_name do
           facet :cuisine
         end
       end
     end
 
     it 'should return value "value" with count 2' do
-      row = @search.dynamic_facet(:custom_string, :cuisine).rows[0]
+      row = @search.dynamic_facet(field_name, :cuisine).rows[0]
       row.value.should == 'Greek'
       row.count.should == 2
     end
 
     it 'should return value "other" with count 1' do
-      row = @search.dynamic_facet(:custom_string, :cuisine).rows[1]
+      row = @search.dynamic_facet(field_name, :cuisine).rows[1]
       row.value.should == 'Pizza'
       row.count.should == 1
     end
@@ -41,7 +41,7 @@ describe 'dynamic fields' do
 
   it 'should order by dynamic string field ascending' do
     Sunspot.search(Post) do
-      dynamic :custom_string do
+      dynamic field_name do
         order_by :cuisine, :asc
       end
     end.results.last.should == @posts.first
@@ -49,9 +49,20 @@ describe 'dynamic fields' do
 
   it 'should order by dynamic string field descending' do
     Sunspot.search(Post) do
-      dynamic :custom_string do
+      dynamic field_name do
         order_by :cuisine, :desc
       end
     end.results.first.should == @posts.first
+  end
+end
+
+describe "default separator" do
+  it_behaves_like "dynamic fields" do
+    let(:field_name) { :custom_string }
+  end
+end
+describe "custom separator" do
+  it_behaves_like "dynamic fields" do
+    let(:field_name) { :custom_underscored_string }
   end
 end

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -14,6 +14,10 @@ class Post < SuperClass
     @custom_string ||= {}
   end
 
+  def custom_underscored_string
+    @custom_underscored_string ||= {}
+  end
+
   def custom_fl
     @custom_fl ||= {}
   end
@@ -27,7 +31,7 @@ class Post < SuperClass
   end
 
   private
-  attr_writer :category_ids, :custom_string, :custom_fl, :custom_time, :custom_boolean
+  attr_writer :category_ids, :custom_string, :custom_underscored_string, :custom_fl, :custom_time, :custom_boolean
 end
 
 Sunspot.setup(Post) do
@@ -57,6 +61,7 @@ Sunspot.setup(Post) do
   latlon(:coordinates_new) { coordinates }
 
   dynamic_string :custom_string, :stored => true
+  dynamic_string :custom_underscored_string, separator: '__'
   dynamic_float :custom_float, :multiple => true, :using => :custom_fl
   dynamic_integer :custom_integer do
     category_ids.inject({}) do |hash, category_id|


### PR DESCRIPTION
Reference: https://github.com/sunspot/sunspot/issues/229

This patch adds ability to specify the separator character/string for generating dynamic field names. The existing hard-coded ":" is a bad choice. But obviously it needs to stay as the default to keep existing code working. So this commit allows user to specify a custom separator per dynamic_field, using the ":" if not specified.

