### PR TITLE
lock rsolr verision for ruby 1.8.7

### DIFF
--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rsolr', '~>1.0.7'
+  s.add_dependency 'rsolr', '~>1.0.7', ('<=1.0.10' if RUBY_VERSION < '1.9')
+
   s.add_dependency 'pr_geohash', '~>1.0'
 
   s.add_development_dependency 'rspec', '~>2.6.0'


### PR DESCRIPTION
It looks like rsolr dropped 1.8.7 support recently.
