### PR TITLE
Update home page in gemspec

### DIFF
--- a/sunspot_solr/sunspot_solr.gemspec
+++ b/sunspot_solr/sunspot_solr.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                   'Brian Atkinson', 'Tom Coleman', 'Matt Mitchell', 'Nathan Beyer', 'Kieran Topping', 'Nicolas Braem', 'Jeremy Ashkenas',
                   'Dylan Vaughn', 'Brian Durand', 'Sam Granieri', 'Nick Zadrozny', 'Jason Ronallo']
   s.email       = ["mat@patch.com"]
-  s.homepage    = 'https://github.com/outoftime/sunspot/tree/master/sunspot_solr'
+  s.homepage    = 'https://github.com/sunspot/sunspot/tree/master/sunspot_solr'
   s.summary     = 'Bundled Solr distribution for Sunspot'
   s.license     = 'MIT'
   s.description = <<-TEXT


### PR DESCRIPTION
The home page link on the [RubyGems][1] page points to the old repository which lead to some confusion earlier about the version of solr that is embedded.

[1]: https://rubygems.org/gems/sunspot_solr