### PR TITLE
Add order_by_function support to groups.

### DIFF
--- a/sunspot/lib/sunspot/dsl/group.rb
+++ b/sunspot/lib/sunspot/dsl/group.rb
@@ -78,6 +78,31 @@ module Sunspot
           end
         @group.add_sort(sort)
       end
+
+      #
+      # Specify that results should be ordered based on a
+      # FunctionQuery - http://wiki.apache.org/solr/FunctionQuery
+      # Solr 3.1 and up
+      #
+      #  For example, to order by field1 + (field2*field3):
+      #
+      #    order_by_function :sum, :field1, [:product, :field2, :field3], :desc
+      #
+      # ==== Parameters
+      # function_name<Symbol>::
+      #   the function to run
+      # arguments::
+      #   the arguments for this function.
+      #   - Symbol for a field or function name
+      #   - Array for a nested function
+      #   - String for a literal constant
+      # direction<Symbol>::
+      #   :asc or :desc
+      def order_by_function(*args)
+        @group.add_sort(
+          Sunspot::Query::Sort::FunctionSort.new(@setup,args)
+        )
+      end
     end
   end
 end

--- a/sunspot/spec/integration/field_grouping_spec.rb
+++ b/sunspot/spec/integration/field_grouping_spec.rb
@@ -72,6 +72,19 @@ describe "field grouping" do
     title1_group.hits.first.primary_key.to_i.should == highest_ranked_post.id
   end
 
+  it "allows specification of an ordering function within groups" do
+    search = Sunspot.search(Post) do
+      group :title do
+        order_by_function(:product, :average_rating, -2, :asc)
+      end
+    end
+
+    highest_ranked_post = @posts.sort_by { |p| -p.ratings_average }.first
+
+    title1_group = search.group(:title).groups.detect { |g| g.value == "Title1" }
+    title1_group.hits.first.primary_key.to_i.should == highest_ranked_post.id
+  end
+
   it "allows pagination within groups" do
     search = Sunspot.search(Post) do
       group :title


### PR DESCRIPTION
This fixes issue #633.

(Ideally, to reduce duplication, both `order_by` and `order_by_function` would be pulled into a module that both `FieldGroup` and `FieldQuery` include, but that would also require having a consistent name for what is now either `@group` or `@query`.)