### PR TITLE
Adds a failing integration spec related to nil values and conjunctions/disjunctions

### DIFF
--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -438,6 +438,23 @@ describe 'scoped_search' do
       end
       search.results.should == posts[0..2]
     end
+
+    it 'should return results that have no value for field in conjunction of a single nil condition nested in disjunction alongside a single nil condition' do
+      posts = [
+        Post.new(:title => nil, :blog_id => 1),
+        Post.new(:title => 'Yes', :blog_id => nil),
+        Post.new(:title => nil, :blog_id => 2)
+      ]
+      Sunspot.index!(posts)
+      Sunspot.search(Post) do
+        any_of do
+          with(:title, nil)
+          all_of do
+            with(:blog_id, nil)
+          end
+        end
+      end.results.should == posts
+    end
   end
 
   describe 'multiple column ordering' do


### PR DESCRIPTION
The search I've added in the spec produces a malformed query and thus a solr "Bad Request" error,
I stumbled upon a similar query generated by a user and while it might not make a lot of sense in the way its constructed, it would be great if it didn't fail.
