### PR TITLE
Fix example code about batch indexing

### DIFF
--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -490,9 +490,9 @@ module Sunspot
     #
     #   Sunspot.batch do
     #     post = Post.new
-    #     Sunspot.add(post)
+    #     Sunspot.index(post)
     #     comment = Comment.new
-    #     Sunspot.add(comment)
+    #     Sunspot.index(comment)
     #   end
     #
     # Sunspot will send both the post and the comment in a single request.


### PR DESCRIPTION
`Sunspot.add` is not defined, and I think `Sunspot.index` is correct.