### PR TITLE
Bugfix:  Log File configuration

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -343,7 +343,7 @@ module Sunspot #:nodoc:
       # String:: default_log_file_location
       #
       def default_log_file_location
-        File.join(::Rails.root, 'log', "solr_" + ::Rails.env + ".log")
+        File.join(::Rails.root, 'log', "sunspot-solr-" + ::Rails.env + ".log")
       end
 
       #

--- a/sunspot_rails/lib/sunspot/rails/server.rb
+++ b/sunspot_rails/lib/sunspot/rails/server.rb
@@ -52,7 +52,7 @@ module Sunspot
       # Log file for Solr. File is in the rails log/ directory.
       #
       def log_file
-        File.join(::Rails.root, 'log', "sunspot-solr-#{::Rails.env}.log")
+        configuration.log_file
       end
 
       # 

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -59,7 +59,7 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   end
 
   it "should handle the 'log_file' property" do
-    @config.log_file.should =~ /log\/solr_test.log/
+    @config.log_file.should =~ /log\/sunspot-solr-test.log/
   end
 
   it "should handle the 'solr_home' property when not set" do


### PR DESCRIPTION
Fixes #565 .  This is necessary for anyone running Sunspot outside of Rails because `Rails.root` was overriding the `log_file` configuration (and non-existent outside of Rails).

Additionally, the specs had conflicting log file names so I normalized them to `sunspot-solr-#{env}.log`.
