### PR TITLE
Edismax multiplicative boost parameter

### DIFF
--- a/sunspot/lib/sunspot/dsl/fulltext.rb
+++ b/sunspot/lib/sunspot/dsl/fulltext.rb
@@ -168,14 +168,22 @@ module Sunspot
       # will be boosted by (average_rating + popularity * 10).
       #
       def boost(factor_or_function, &block)
+        additive_boost(factor_or_function, &block)
+      end
+
+      def additive_boost(factor_or_function, &block)
         if factor_or_function.is_a?(Sunspot::Query::FunctionQuery)
-          @query.add_boost_function(factor_or_function)
+          @query.add_additive_boost_function(factor_or_function)
         else
           Sunspot::Util.instance_eval_or_call(
             Scope.new(@query.create_boost_query(factor_or_function), @setup),
             &block
           )
         end
+      end
+
+      def multiplicative_boost(factor_or_function)
+        @query.add_multiplicative_boost_function(factor_or_function)
       end
 
       #

--- a/sunspot/lib/sunspot/query/abstract_fulltext.rb
+++ b/sunspot/lib/sunspot/query/abstract_fulltext.rb
@@ -18,8 +18,15 @@ module Sunspot
       #
       # Add a boost function
       #
-      def add_boost_function(function_query)
-        @boost_functions << function_query
+      def add_additive_boost_function(function_query)
+        @additive_boost_functions << function_query
+      end
+
+      #
+      # Add a multiplicative boost function
+      #
+      def add_multiplicative_boost_function(function_query)
+        @multiplicative_boost_functions << function_query
       end
 
       #

--- a/sunspot/lib/sunspot/query/dismax.rb
+++ b/sunspot/lib/sunspot/query/dismax.rb
@@ -13,7 +13,8 @@ module Sunspot
         @keywords = keywords
         @fulltext_fields = {}
         @boost_queries = []
-        @boost_functions = []
+        @additive_boost_functions = []
+        @multiplicative_boost_functions = []
         @highlights = []
 
         @minimum_match = nil
@@ -46,9 +47,15 @@ module Sunspot
           end
         end
 
-        unless @boost_functions.empty?
-          params[:bf] = @boost_functions.map do |boost_function|
-            boost_function.to_s
+        unless @additive_boost_functions.empty?
+          params[:bf] = @additive_boost_functions.map do |additive_boost_function|
+            additive_boost_function.to_s
+          end
+        end
+
+        unless @multiplicative_boost_functions.empty?
+          params[:boost] = @multiplicative_boost_functions.map do |multiplicative_boost_function|
+            multiplicative_boost_function.to_s
           end
         end
 

--- a/sunspot/spec/api/query/function_spec.rb
+++ b/sunspot/spec/api/query/function_spec.rb
@@ -103,9 +103,6 @@ describe 'function query' do
     end.should raise_error(Sunspot::UnrecognizedFieldError)
   end
 
-
-
-
   it "should send query to solr with multiplicative boost function" do
     session.search Post do
       keywords('pizza') do

--- a/sunspot/spec/api/query/function_spec.rb
+++ b/sunspot/spec/api/query/function_spec.rb
@@ -102,5 +102,111 @@ describe 'function query' do
       end
     end.should raise_error(Sunspot::UnrecognizedFieldError)
   end
+
+
+
+
+  it "should send query to solr with multiplicative boost function" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { :average_rating })
+      end
+    end
+    connection.should have_last_search_including(:boost, 'average_rating_ft')
+  end
+
+  it "should send query to solr with multiplicative boost function and boost amount" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { :average_rating }^5)
+      end
+    end
+    connection.should have_last_search_including(:boost, 'average_rating_ft^5')
+  end
+
+  it "should handle multiplicative boost function with constant float" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { 10.5 })
+      end
+    end
+    connection.should have_last_search_including(:boost, '10.5')
+  end
+
+  it "should handle multiplicative boost function with constant float and boost amount" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { 10.5 }^5)
+      end
+    end
+    connection.should have_last_search_including(:boost, '10.5^5')
+  end
+
+  it "should handle multiplicative boost function with time literal" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { Time.parse('2010-03-25 14:13:00 EDT') })
+      end
+    end
+    connection.should have_last_search_including(:boost, '2010-03-25T18:13:00Z')
+  end
+ 
+  it "should handle arbitrary functions in a function query block" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { product(:average_rating, 10) })
+      end
+    end
+    connection.should have_last_search_including(:boost, 'product(average_rating_ft,10)')
+  end
+
+  it "should handle the sub function in a multiplicative boost function query block" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { sub(:average_rating, 10) })
+      end
+    end
+    connection.should have_last_search_including(:boost, 'sub(average_rating_ft,10)')
+  end
+
+  it "should handle boost amounts on multiplicative boost function query block" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { sub(:average_rating, 10)^5 })
+      end
+    end
+    connection.should have_last_search_including(:boost, 'sub(average_rating_ft,10)^5')
+  end
+ 
+  it "should handle nested functions in a multiplicative boost function query block" do
+    session.search Post do
+      keywords('pizza') do
+        multiplicative_boost(function { product(:average_rating, sum(:average_rating, 20)) })
+      end
+    end
+    connection.should have_last_search_including(:boost, 'product(average_rating_ft,sum(average_rating_ft,20))')
+  end
+
+  # TODO SOLR 1.5
+  it "should raise ArgumentError if string literal passed to multiplicative boost" do
+    lambda do
+      session.search Post do
+        keywords('pizza') do
+          multiplicative_boost(function { "hello world" })
+        end
+      end
+    end.should raise_error(ArgumentError)
+  end
+
+  it "should raise UnrecognizedFieldError if bogus field name passed to multiplicative boost" do
+    lambda do
+      session.search Post do
+        keywords('pizza') do
+          multiplicative_boost(function { :bogus })
+        end
+      end
+    end.should raise_error(Sunspot::UnrecognizedFieldError)
+  end
+
 end
 


### PR DESCRIPTION
Solr's edismax query parser allows a parameter named 'boost' that works just as the 'bf' parameter, but instead of adding the boost value to the base score of a document, it multiplies the boost value to it. This PR adds this parameter to Sunspot's DSL. 

For more information: 
https://wiki.apache.org/solr/ExtendedDisMax#boost_.28Boost_Function.2C_multiplicative.29
http://nolanlawson.com/2012/06/02/comparing-boost-methods-in-solr/