### PR TITLE
Add the stats in the StubSessionProxy for testing purposes

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -110,6 +110,10 @@ module Sunspot
           DataAccessorStub.new
         end
 
+        def stats(name)
+          StatsStub.new
+        end
+
         def execute
           self
         end
@@ -167,6 +171,49 @@ module Sunspot
 
         def rows
           []
+        end
+
+      end
+
+      class StatsStub
+        def min
+          0
+        end
+
+        def max
+          100
+        end
+
+        def count
+          30
+        end
+
+        def sum
+          500
+        end
+
+        def missing
+          3
+        end
+
+        def sum_of_squares
+          5000
+        end
+
+        def mean
+          50
+        end
+
+        def standard_deviation
+          20
+        end
+
+        def facets
+          []
+        end
+
+        def facet(name)
+          FacetStub.new
         end
 
       end

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -162,7 +162,7 @@ end
 
 describe Sunspot::Rails::Configuration, "with auto_index_callback and auto_remove_callback set" do
   before do
-    ::Rails.stub!(:env => 'config_commit_test')
+    ::Rails.stub(:env => 'config_commit_test')
     @config = Sunspot::Rails::Configuration.new
   end
 

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -10,7 +10,7 @@ describe 'specs with Sunspot stubbed' do
   end
 
   it 'should batch' do
-    foo = mock('Foo')
+    foo = double('Foo')
     block = lambda { foo.bar }
 
     foo.should_receive(:bar)
@@ -153,6 +153,33 @@ describe 'specs with Sunspot stubbed' do
       it 'should provide accessor for include' do
         @accessor.should respond_to(:include, :include=)
       end
+    end
+
+    describe '#stats' do
+      before do
+        @stats = @search.stats(:price)
+      end
+
+      it 'should response to all the available data methods' do
+        @stats.should respond_to(
+          :min,
+          :max,
+          :count,
+          :sum,
+          :missing,
+          :sum_of_squares,
+          :mean,
+          :standard_deviation)
+      end
+
+      it 'should return empty results for a given facet' do
+        @stats.facet(:category_id).rows.should == []
+      end
+
+      it 'should return empty array if listing facets' do
+        @stats.facets.should == []
+      end
+
     end
   end
 end


### PR DESCRIPTION
In order to be able to test agains stubbed versions of the search and have the ability to use `stats` in them.

Previously I get this errors when I run the tests:
```ruby
NoMethodError:
       undefined method `stats' for #<Sunspot::Rails::StubSessionProxy::Search:0x007f8c526cd000>
```

Also correct some deprecation warnings