### PR TITLE
Change _version_ field to be compatible with Solr 5

### DIFF
--- a/sunspot_solr/solr/solr/configsets/sunspot/conf/schema.xml
+++ b/sunspot_solr/solr/solr/configsets/sunspot/conf/schema.xml
@@ -254,8 +254,8 @@
     <dynamicField name="*_llms" stored="true" type="location" multiValued="true" indexed="true"/>
     <field name="textSpell" stored="false" type="textSpell" multiValued="true" indexed="true"/>
     
-    <!-- required by Solr 4 -->
-    <field name="_version_" type="string" indexed="true" stored="true" multiValued="false" />
+    <!-- required by Solr 5 -->
+    <field name="_version_" type="tlong" indexed="true" stored="true" multiValued="false" />
   </fields>
   
   <!-- Field to use to determine and enforce document uniqueness.


### PR DESCRIPTION
I ran into an issue where having the `_version_` field stored as string (which is the default this commit is changing) was causing Solr cores not to be able to reload on restart.

In particular it was causing this exception when attempting to load the transaction log from disk:
```
java.lang.NullPointerException
	at org.apache.lucene.util.NumericUtils.prefixCodedToLong(NumericUtils.java:226)
	at org.apache.lucene.util.NumericUtils.getMaxLong(NumericUtils.java:582)
	at org.apache.solr.update.VersionInfo.getMaxVersionFromIndex(VersionInfo.java:234)
	at org.apache.solr.update.UpdateLog.seedBucketsWithHighestVersion(UpdateLog.java:1580)
	at org.apache.solr.update.UpdateLog.seedBucketsWithHighestVersion(UpdateLog.java:1610)
	at org.apache.solr.core.SolrCore.seedVersionBuckets(SolrCore.java:861)
	at org.apache.solr.core.SolrCore.<init>(SolrCore.java:843)
	at org.apache.solr.core.SolrCore.<init>(SolrCore.java:658)
	at org.apache.solr.core.CoreContainer.create(CoreContainer.java:637)
	at org.apache.solr.core.CoreContainer$1.call(CoreContainer.java:381)
	at org.apache.solr.core.CoreContainer$1.call(CoreContainer.java:375)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at org.apache.solr.common.util.ExecutorUtil$MDCAwareThreadPoolExecutor$1.run(ExecutorUtil.java:148)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```

So I delved into more what the `_version_` field does an it appears it's only used to support partial updates with the help of the transaction log. Further analysis strongly suggests this field is meant to be of type "long". This is supported by the default in the Solr example config for Solr 5.2.1:
https://github.com/apache/lucene-solr/blob/trunk/solr/server/solr/configsets/basic_configs/conf/schema.xml#L96

However, what I found perplexing was it was of type "long" even in the Solr 4.X branch.. so I am not entirely sure where this setting comes from and was hoping someone could shed some light on this

This commit seems to fix the issue for me however.