### PR TITLE
Show a reasonable message for reindexing an empty database

### DIFF
--- a/sunspot_rails/gemfiles/rails-3.0.0
+++ b/sunspot_rails/gemfiles/rails-3.0.0
@@ -8,6 +8,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 2.14.0'
+  gem 'progress_bar', '~> 1.0.5', require: false
 end
 
 group :postgres do

--- a/sunspot_rails/gemfiles/rails-3.1.0
+++ b/sunspot_rails/gemfiles/rails-3.1.0
@@ -8,6 +8,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 2.14.0'
+  gem 'progress_bar', '~> 1.0.5', require: false
 end
 
 group :postgres do

--- a/sunspot_rails/gemfiles/rails-3.2.0
+++ b/sunspot_rails/gemfiles/rails-3.2.0
@@ -8,6 +8,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'rspec-rails', '~> 2.14.0'
+  gem 'progress_bar', '~> 1.0.5', require: false
 end
 
 group :postgres do

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -5,6 +5,7 @@ gem 'rails', '~> 4.0.0'
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
+gem 'progress_bar', '~> 1.0.5'
 
 group :test do
 	gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -5,11 +5,11 @@ gem 'rails', '~> 4.0.0'
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
-gem 'progress_bar', '~> 1.0.5'
 
 group :test do
 	gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
   gem 'rspec-rails', '~> 2.14.0'
+  gem 'progress_bar', '~> 1.0.5', require: false
 end
 
 group :postgres do

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -9,6 +9,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
   gem 'rspec-rails', '~> 2.14.0'
+  gem 'progress_bar', '~> 1.0.5', require: false
 end
 
 group :postgres do

--- a/sunspot_rails/gemfiles/rails-4.2.0
+++ b/sunspot_rails/gemfiles/rails-4.2.0
@@ -9,6 +9,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
   gem 'rspec-rails', '~> 2.14.0'
+  gem 'progress_bar', '~> 1.0.5', require: false
 end
 
 group :postgres do

--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -49,6 +49,8 @@ namespace :sunspot do
         reindex_options[:progress_bar] = ProgressBar.new(total_documents)
       rescue LoadError => e
         $stdout.puts "Skipping progress bar: for progress reporting, add gem 'progress_bar' to your Gemfile"
+      rescue ProgressBar::ArgumentError => e
+        $stdout.puts "You have no data in the database. Reindexing does nothing here."
       rescue Exception => e
         $stderr.puts "Error using progress bar: #{e.message}"
       end unless args[:silence]

--- a/sunspot_rails/spec/rake_task_spec.rb
+++ b/sunspot_rails/spec/rake_task_spec.rb
@@ -30,6 +30,12 @@ describe 'sunspot namespace rake task' do
 
       run_rake_task("sunspot:reindex", '', "Post+Author", true)
     end
+
+    it "should raise exception when all tables of sunspot models are empty" do
+      STDOUT.should_receive(:puts).with("You have no data in the database. Reindexing does nothing here.")
+      empty_tables
+      run_rake_task("sunspot:reindex")
+    end
   end
 end
 


### PR DESCRIPTION
When the database is empty, sunspot raises error Error **using progress bar: Max must be a positive integer** from progress bar gem. There's no mistake here, but users can hardly understand what is going on by the message. 

A few questions in stackoverflow (e.g. http://stackoverflow.com/questions/25244964/rails-sunspot-reindex-progress-bar-max-must-be-a-positive-integer#autocomment53976291) have been asked, so I think it's not only me that found the message is confusing.