### PR TITLE
Adhering to container based infrastructure of Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+language: ruby
+cache: bundler
+sudo: false
+
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
All sunspot builds in Travis are currently running on an older infrastructure. 

![image](https://cloud.githubusercontent.com/assets/1298587/11022233/9cbf048a-867f-11e5-8b08-6f5c76f67c38.png)

Sample: https://travis-ci.org/sunspot/sunspot/jobs/89973013

Updating the `.travis.yml` to adhere to the new container infrastructure Travis provides for faster builds.

Source: http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade