### PR TITLE
Atomic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ sunspot_solr/solr/solr-webapp
 .yardoc
 docs
 *.swp
+.idea

--- a/README.md
+++ b/README.md
@@ -953,6 +953,31 @@ end
 2. You're able to use functions for ordering (see examples for [order_by_function](#ordering))
 
 
+### Atomic updates
+
+Atomic Updates is a feature in Solr 4.0 that allows you to update on a field level rather than on a document level. This means that you can update individual fields without having to send the entire document to Solr with the un-updated fields values. For more details, please read [Atomic Update documentation](https://wiki.apache.org/solr/Atomic_Updates).
+
+All fields of the model must be **stored**, otherwise non-stored values will be lost after an update.
+
+```ruby
+class Post < ActiveRecord::Base
+  searchable do
+    # all fields stored
+    text :body, :stored => true
+    string :title, :stored => true
+  end
+end
+
+post1 = Post.create #...
+post2 = Post.create #...
+
+# atomic update on class level
+Post.atomic_update post1.id => {title: 'A New Title'}, post2.id => {body: 'A New Body'}
+
+# atomic update on instance level
+post1.atomic_update body: 'A New Body', title: 'Another New Title'
+```
+
 ### More Like This
 
 Sunspot can extract related items using more_like_this. When searching

--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -196,6 +196,40 @@ module Sunspot
       session.index!(*objects)
     end
 
+    # Atomic update object properties on the singleton session.
+    #
+    # ==== Parameters
+    #
+    # clazz<Class>:: the class of the objects to be updated
+    # updates<Hash>:: hash of updates where keys are model ids
+    #                 and values are hash with property name/values to be updated
+    #
+    # ==== Example
+    #
+    #   post1, post2 = new Array(2) { Post.create }
+    #   Sunspot.atomic_update(Post, post1.id => {title: 'New Title'}, post2.id => {description: 'new description'})
+    #
+    # Note that indexed objects won't be reflected in search until a commit is
+    # sent - see Sunspot.index! and Sunspot.commit
+    #
+    def atomic_update(clazz, updates = {})
+      session.atomic_update(clazz, updates)
+    end
+
+    # Atomic update object properties on the singleton session.
+    #
+    # See: Sunspot.atomic_update and Sunspot.commit
+    #
+    # ==== Parameters
+    #
+    # clazz<Class>:: the class of the objects to be updated
+    # updates<Hash>:: hash of updates where keys are model ids
+    #                 and values are hash with property name/values to be updated
+    #
+    def atomic_update!(clazz, updates = {})
+      session.atomic_update!(clazz, updates)
+    end
+
     # Commits (soft or hard) the singleton session
     #
     # When documents are added to or removed from Solr, the changes are

--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -22,6 +22,23 @@ module Sunspot
             DataExtractor::AttributeExtractor.new(options.delete(:using) || name)
           end
       end
+
+      #
+      # Extract the encapsulated field's data from the given model and add it
+      # into the Solr document for indexing. (noop here for joins)
+      #
+      def populate_document(document, model, options = {}) #:nodoc:
+      end
+
+      protected
+
+      def extract_value(model, options = {})
+        if options.has_key?(:value)
+          options.delete(:value)
+        else
+          @data_extractor.value_for(model)
+        end
+      end
     end
 
     # 
@@ -54,15 +71,16 @@ module Sunspot
       # Extract the encapsulated field's data from the given model and add it
       # into the Solr document for indexing.
       #
-      def populate_document(document, model) #:nodoc:
-        unless (value = @data_extractor.value_for(model)).nil?
+      def populate_document(document, model, options = {}) #:nodoc:
+        value = extract_value(model, options)
+        unless value.nil?
           Util.Array(@field.to_indexed(value)).each do |scalar_value|
-            options = {}
-            options[:boost] = @field.boost if @field.boost
+            field_options = {}
+            field_options[:boost] = @field.boost if @field.boost
             document.add_field(
               @field.indexed_name.to_sym,
               scalar_value,
-              options
+              field_options.merge(options)
             )
           end
         end
@@ -92,14 +110,7 @@ module Sunspot
         @field
       end
 
-      # 
-      # Extract the encapsulated field's data from the given model and add it
-      # into the Solr document for indexing. (noop here for joins)
       #
-      def populate_document(document, model) #:nodoc:
-      end
-
-      # 
       # A unique signature identifying this field by name and type.
       #
       def signature
@@ -135,14 +146,16 @@ module Sunspot
       # Generate dynamic fields based on hash returned by data accessor and
       # add the field data to the document.
       #
-      def populate_document(document, model)
-        if values = @data_extractor.value_for(model)
+      def populate_document(document, model, options = {})
+        values = extract_value(model, options)
+        if values
           values.each_pair do |dynamic_name, value|
             field_instance = build(dynamic_name)
             Util.Array(field_instance.to_indexed(value)).each do |scalar_value|
               document.add_field(
                 field_instance.indexed_name.to_sym,
-                scalar_value
+                scalar_value,
+                options
               )
             end
           end

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -100,6 +100,22 @@ module Sunspot
     end
 
     #
+    # See Sunspot.atomic_update
+    #
+    def atomic_update(clazz, updates = {})
+      @adds += updates.keys.length
+      indexer.add_atomic_update(clazz, updates)
+    end
+
+    #
+    # See Sunspot.atomic_update!
+    #
+    def atomic_update!(clazz, updates = {})
+      atomic_update(clazz, updates)
+      commit
+    end
+
+    #
     # See Sunspot.commit
     #
     def commit(soft_commit = false)

--- a/sunspot/lib/sunspot/session_proxy/master_slave_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/master_slave_session_proxy.rb
@@ -19,8 +19,8 @@ module Sunspot
 
       delegate :batch, :commit, :commit_if_delete_dirty, :commit_if_dirty,
                :config, :delete_dirty?, :dirty?, :index, :index!, :optimize, :remove,
-               :remove!, :remove_all, :remove_all!, :remove_by_id,
-               :remove_by_id!, :to => :master_session
+               :remove!, :remove_all, :remove_all!, :remove_by_id, :remove_by_id!,
+               :atomic_update, :atomic_update!, :to => :master_session
       delegate :new_search, :search, :new_more_like_this, :more_like_this, :to => :slave_session
 
       def initialize(master_session, slave_session)

--- a/sunspot/lib/sunspot/session_proxy/retry_5xx_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/retry_5xx_session_proxy.rb
@@ -59,7 +59,7 @@ module Sunspot
 
       delegate :batch, :commit, :commit_if_dirty, :commit_if_delete_dirty,
         :dirty?, :index!, :index, :optimize, :remove!, :remove, :remove_all!,
-        :remove_all, :remove_by_id!, :remove_by_id,
+        :remove_all, :remove_by_id!, :remove_by_id, :atomic_update, :atomic_update!,
         :to => :retry_handler
 
     end

--- a/sunspot/lib/sunspot/session_proxy/sharding_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/sharding_session_proxy.rb
@@ -27,9 +27,11 @@ module Sunspot
     # * remove_by_id!
     # * remove_all with an argument
     # * remove_all! with an argument
+    # * atomic_update with arguments
+    # * atomic_update! with arguments
     #
     class ShardingSessionProxy < AbstractSessionProxy
-      not_supported :batch, :config, :remove_by_id, :remove_by_id!
+      not_supported :batch, :config, :remove_by_id, :remove_by_id!, :atomic_update, :atomic_update!
 
       # 
       # +search_session+ is the session that should be used for searching.
@@ -71,20 +73,6 @@ module Sunspot
       end
 
       #
-      # See Sunspot.atomic_update
-      #
-      def atomic_update(*objects)
-        using_sharded_session(objects) { |session, group| session.atomic_update(group) }
-      end
-
-      #
-      # See Sunspot.atomic_update!
-      #
-      def atomic_update!(*objects)
-        using_sharded_session(objects) { |session, group| session.atomic_update!(group) }
-      end
-
-      # 
       # See Sunspot.remove
       #
       def remove(*objects)

--- a/sunspot/lib/sunspot/session_proxy/sharding_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/sharding_session_proxy.rb
@@ -70,6 +70,20 @@ module Sunspot
         using_sharded_session(objects) { |session, group| session.index!(group) }
       end
 
+      #
+      # See Sunspot.atomic_update
+      #
+      def atomic_update(*objects)
+        using_sharded_session(objects) { |session, group| session.atomic_update(group) }
+      end
+
+      #
+      # See Sunspot.atomic_update!
+      #
+      def atomic_update!(*objects)
+        using_sharded_session(objects) { |session, group| session.atomic_update!(group) }
+      end
+
       # 
       # See Sunspot.remove
       #

--- a/sunspot/lib/sunspot/session_proxy/silent_fail_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/silent_fail_session_proxy.rb
@@ -22,7 +22,7 @@ module Sunspot
       SUPPORTED_METHODS = [
         :batch, :commit, :commit_if_dirty, :commit_if_delete_dirty, :dirty?,
         :index!, :index, :optimize, :remove!, :remove, :remove_all!, :remove_all,
-        :remove_by_id!, :remove_by_id
+        :remove_by_id!, :remove_by_id, :atomic_update, :atomic_update!
       ]
 
       SUPPORTED_METHODS.each do |method|

--- a/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
@@ -17,7 +17,9 @@ module Sunspot
       attr_reader :config
       @@next_id = 0
 
-      delegate :batch, :commit, :commit_if_delete_dirty, :commit_if_dirty, :delete_dirty?, :dirty?, :index, :index!, :new_search, :optimize, :remove, :remove!, :remove_all, :remove_all!, :remove_by_id, :remove_by_id!, :search, :more_like_this, :new_more_like_this, :to => :session
+      delegate :batch, :commit, :commit_if_delete_dirty, :commit_if_dirty, :delete_dirty?, :dirty?, :index, :index!,
+               :new_search, :optimize, :remove, :remove!, :remove_all, :remove_all!, :remove_by_id, :remove_by_id!,
+               :search, :more_like_this, :new_more_like_this, :atomic_update, :atomic_update!, :to => :session
 
       # 
       # Optionally pass an existing Sunspot::Configuration object. If none is

--- a/sunspot/spec/api/session_proxy/sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/sharding_session_proxy_spec.rb
@@ -15,7 +15,7 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
     end
   end
 
-  [:remove_by_id, :remove_by_id!].each do |method|
+  [:remove_by_id, :remove_by_id!, :atomic_update, :atomic_update!].each do |method|
     it "should raise NotSupportedError when #{method} called" do
       lambda { @proxy.send(method, Post, 1) }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
     end

--- a/sunspot/spec/integration/atomic_updates_spec.rb
+++ b/sunspot/spec/integration/atomic_updates_spec.rb
@@ -1,0 +1,44 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+describe 'atomic updates' do
+  before :all do
+    Sunspot.remove_all
+  end
+
+  def validate_hit(hit, title, featured)
+    hit.stored(:title).should == title
+    hit.stored(:featured).should == featured
+  end
+
+  def find_indexed_post(id)
+    hit = Sunspot.search(Post).hits.find{ |h| h.primary_key.to_i == id }
+    hit.should_not be_nil
+    hit
+  end
+
+  it 'should update single record fields one by one' do
+    post = Post.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+    
+    validate_hit(find_indexed_post(post.id), post.title, post.featured)
+
+    Sunspot.atomic_update!(Post, post.id => {title: 'A New Title'})
+    validate_hit(find_indexed_post(post.id), 'A New Title', true)
+
+    Sunspot.atomic_update!(Post, post.id => {featured: false})
+    validate_hit(find_indexed_post(post.id), 'A New Title', false)
+  end
+
+  it 'should update fields for multiple records' do
+    post1 = Post.new(title: 'A First Title', featured: true)
+    post2 = Post.new(title: 'A Second Title', featured: false)
+    Sunspot.index!(post1, post2)
+
+    validate_hit(find_indexed_post(post1.id), post1.title, post1.featured)
+    validate_hit(find_indexed_post(post2.id), post2.title, post2.featured)
+
+    Sunspot.atomic_update!(Post, post1.id => {title: 'A New Title'}, post2.id => {featured: true})
+    validate_hit(find_indexed_post(post1.id), 'A New Title', true)
+    validate_hit(find_indexed_post(post2.id), 'A Second Title', true)
+  end
+end

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -134,6 +134,8 @@ module Sunspot #:nodoc:
             alias_method :index, :solr_index unless method_defined? :index
             alias_method :index_orphans, :solr_index_orphans unless method_defined? :index_orphans
             alias_method :clean_index_orphans, :solr_clean_index_orphans unless method_defined? :clean_index_orphans
+            alias_method :atomic_update, :solr_atomic_update unless method_defined? :atomic_update
+            alias_method :atomic_update!, :solr_atomic_update! unless method_defined? :atomic_update!
           end
         end
         # 
@@ -257,9 +259,9 @@ module Sunspot #:nodoc:
           if options[:batch_size].to_i > 0
             batch_counter = 0
             self.includes(options[:include]).find_in_batches(options.slice(:batch_size, :start)) do |records|
-              
+
               solr_benchmark(options[:batch_size], batch_counter += 1) do
-                Sunspot.index(records.select { |model| model.indexable? })
+                Sunspot.index(records.select(&:indexable?))
                 Sunspot.commit if options[:batch_commit]
               end
 
@@ -271,6 +273,46 @@ module Sunspot #:nodoc:
 
           # perform a final commit if not committing in batches
           Sunspot.commit unless options[:batch_commit]
+        end
+
+        #
+        # Update properties of existing records in the Solr index.
+        # Atomic updates available only for the stored properties.
+        #
+        # ==== Updates (passed as a hash)
+        #
+        # updates should be specified as a hash, where key - is the object ID
+        # and values is hash with property name/values to be updated.
+        #
+        # ==== Examples
+        #
+        #   class Post < ActiveRecord::Base
+        #     searchable do
+        #       string :title, stored: true
+        #       string :description, stored: true
+        #     end
+        #   end
+        #
+        #   post1 = Post.create(title: 'A Title', description: nil)
+        #
+        #   # update single property
+        #   Post.atomic_update(post1.id => {description: 'New post description'})
+        #
+        # ==== Notice
+        # all non-stored properties in Solr index will be lost after update.
+        # Read Solr wiki page: https://wiki.apache.org/solr/Atomic_Updates
+        def solr_atomic_update(updates = {})
+          Sunspot.atomic_update(self, updates)
+        end
+
+        #
+        # Update properties of existing records in the Solr index atomically, and
+        # immediately commits.
+        #
+        # See #solr_atomic_update for information on options, etc.
+        #
+        def solr_atomic_update!(updates = {})
+          Sunspot.atomic_update!(self, updates)
         end
 
         # 
@@ -376,6 +418,8 @@ module Sunspot #:nodoc:
             alias_method :remove_from_index!, :solr_remove_from_index! unless method_defined? :remove_from_index!
             alias_method :more_like_this, :solr_more_like_this unless method_defined? :more_like_this
             alias_method :more_like_this_ids, :solr_more_like_this_ids unless method_defined? :more_like_this_ids
+            alias_method :atomic_update, :solr_atomic_update unless method_defined? :atomic_update
+            alias_method :atomic_update!, :solr_atomic_update! unless method_defined? :atomic_update!
           end
         end
         # 
@@ -395,6 +439,23 @@ module Sunspot #:nodoc:
         #
         def solr_index!
           Sunspot.index!(self)
+        end
+
+        #
+        # Updates specified model properties in Solr.
+        # Unlike ClassMethods#solr_atomic_update you dont need to pass object id,
+        # you only need to pass hash with property changes
+        #
+        def solr_atomic_update(updates = {})
+          Sunspot.atomic_update(self.class, self.id => updates)
+        end
+
+        #
+        # Updates specified model properties in Solr and immediately commit.
+        # See #solr_atomic_update
+        #
+        def solr_atomic_update!(updates = {})
+          Sunspot.atomic_update!(self.class, self.id => updates)
         end
         
         # 

--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -17,6 +17,12 @@ module Sunspot
       def index!(*objects)
       end
 
+      def atomic_update(clazz, updates = {})
+      end
+
+      def atomic_update!(clazz, updates = {})
+      end
+
       def remove(*objects)
       end
 

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -28,6 +28,16 @@ describe 'specs with Sunspot stubbed' do
     @post.index!
   end
 
+  it 'should not send atomic_update to session' do
+    @session.should_not_receive(:atomic_update)
+    @post.index
+  end
+
+  it 'should not send atomic_update! to session' do
+    @session.should_not_receive(:atomic_update!)
+    @post.index!
+  end
+
   it 'should not send commit to session' do
     @session.should_not_receive(:commit)
     Sunspot.commit


### PR DESCRIPTION
Add atomic updates to sunspot making possible to update individual properties of indexed document without having to post a bunch of unchanged fields

Inspired by https://wiki.apache.org/solr/Atomic_Updates.