### PR TITLE
fix broken memory settings

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -12,8 +12,7 @@ module Sunspot #:nodoc:
     #     solr:
     #       hostname: localhost
     #       port: 8982
-    #       min_memory: 512M
-    #       max_memory: 1G
+    #       memory: 1G
     #       solr_jar: /some/path/solr15/start.jar
     #       bind_address: 0.0.0.0
     #     disabled: false
@@ -278,17 +277,10 @@ module Sunspot #:nodoc:
       end
 
       #
-      # Minimum java heap size for Solr instance
+      # java heap size for Solr instance
       #
-      def min_memory
-        @min_memory ||= user_configuration_from_key('solr', 'min_memory')
-      end
-
-      #
-      # Maximum java heap size for Solr instance
-      #
-      def max_memory
-        @max_memory ||= user_configuration_from_key('solr', 'max_memory')
+      def memory
+        @memory ||= user_configuration_from_key('solr', 'memory')
       end
 
       #

--- a/sunspot_rails/lib/sunspot/rails/server.rb
+++ b/sunspot_rails/lib/sunspot/rails/server.rb
@@ -2,21 +2,21 @@ module Sunspot
   module Rails
     class Server < Sunspot::Solr::Server
 
-      # 
+      #
       # Directory in which to store PID files
       #
       def pid_dir
         configuration.pid_dir || File.join(::Rails.root, 'tmp', 'pids')
       end
 
-      # 
+      #
       # Name of the PID file
       #
       def pid_file
         "sunspot-solr-#{::Rails.env}.pid"
       end
 
-      # 
+      #
       # Directory to use for Solr home.
       #
       def solr_home
@@ -30,14 +30,14 @@ module Sunspot
         configuration.solr_executable || super
       end
 
-      # 
+      #
       # Address on which to run Solr
       #
       def bind_address
         configuration.bind_address
       end
 
-      # 
+      #
       # Port on which to run Solr
       #
       def port
@@ -48,25 +48,18 @@ module Sunspot
         configuration.log_level
       end
 
-      # 
+      #
       # Log file for Solr. File is in the rails log/ directory.
       #
       def log_file
         File.join(::Rails.root, 'log', "sunspot-solr-#{::Rails.env}.log")
       end
 
-      # 
-      # Minimum Java heap size for Solr
       #
-      def min_memory
-        configuration.min_memory
-      end
-
-      # 
-      # Maximum Java heap size for Solr
+      # Java heap size for Solr
       #
-      def max_memory
-        configuration.max_memory
+      def memory
+        configuration.memory
       end
 
       private

--- a/sunspot_solr/bin/sunspot-solr
+++ b/sunspot_solr/bin/sunspot-solr
@@ -46,12 +46,8 @@ opts = OptionParser.new do |opts|
     server.log_file = File.expand_path(lf)
   end
 
-  opts.on '--max-memory=MEMORY', 'Specify the maximum size of the memory allocation pool' do |mm|
-    server.max_memory = mm
-  end
-
-  opts.on '--min-memory=MEMORY', 'Specify the initial size of the memory allocation pool' do |mm|
-    server.min_memory = mm
+  opts.on '--memory=MEMORY', 'Specify the size of the memory allocation pool' do |m|
+    server.memory = m
   end
 end
 

--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -19,7 +19,7 @@ module Sunspot
 
       LOG_LEVELS = Set['SEVERE', 'WARNING', 'INFO', 'CONFIG', 'FINE', 'FINER', 'FINEST']
 
-      attr_accessor :min_memory, :max_memory, :bind_address, :port, :log_file
+      attr_accessor :memory, :bind_address, :port, :log_file
 
       attr_writer :pid_dir, :pid_file, :solr_home, :solr_executable
 
@@ -92,8 +92,7 @@ module Sunspot
         bootstrap
 
         command = %w[./solr start -f]
-        command << "-Xms#{min_memory}" if min_memory
-        command << "-Xmx#{max_memory}" if max_memory
+        command << "-m" << "#{memory}" if memory
         command << "-p" << "#{port}" if port
         command << "-h" << "#{bind_address}" if bind_address
         command << "-s" << "#{solr_home}" if solr_home

--- a/sunspot_solr/spec/server_spec.rb
+++ b/sunspot_solr/spec/server_spec.rb
@@ -16,15 +16,10 @@ describe Sunspot::Solr::Server do
     @server.run
   end
 
-  it 'runs Java with min memory' do
-    @server.min_memory = 1024
-    @server.should_receive(:exec).with(/-Xms1024/)
-    @server.run
-  end
-
-  it 'runs Java with max memory' do
-    @server.max_memory = 2048
+  it 'runs Java with memory set' do
+    @server.memory = 2048
     @server.should_receive(:exec).with(/-Xmx2048/)
+    @server.should_receive(:exec).with(/-Xms2048/)
     @server.run
   end
 


### PR DESCRIPTION
This replaces min_memory and max_memory, which no longer work, with a single 'memory' setting.

It's not ideal, as we lose a bit of flexibility this way, but there doesn't appear to be any other way to pass memory settings to the current version of the script `sunspot_solr/solr/bin/solr` which is used to start and stop an instance of Sunspot::Solr::Server.