### PR TITLE
Add `scopes` inherited attributes to ActiveRecordDataAccessor

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/adapters.rb
+++ b/sunspot_rails/lib/sunspot/rails/adapters.rb
@@ -21,11 +21,12 @@ module Sunspot #:nodoc:
       class ActiveRecordDataAccessor < Sunspot::Adapters::DataAccessor
         # options for the find
         attr_accessor :include
+        attr_accessor :scopes
         attr_reader :select
 
         def initialize(clazz)
           super(clazz)
-          @inherited_attributes = [:include, :select]
+          @inherited_attributes = [:include, :select, :scopes]
         end
 
         #
@@ -77,6 +78,9 @@ module Sunspot #:nodoc:
           scope = relation
           scope = scope.includes(@include) if @include.present?
           scope = scope.select(@select)    if @select.present?
+          Array.wrap(@scopes).each do |s|
+            scope = scope.send(s)
+          end
           scope 
         end
 

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -374,15 +374,15 @@ module Sunspot #:nodoc:
         end
         
         def solr_execute_search(options = {})
-          options.assert_valid_keys(:include, :select)
+          inherited_attributes = [:include, :select, :scopes]
+          options.assert_valid_keys(*inherited_attributes)
           search = yield
           unless options.empty?
             search.build do |query|
-              if options[:include]
-                query.data_accessor_for(self).include = options[:include]
-              end
-              if options[:select]
-                query.data_accessor_for(self).select = options[:select]
+              inherited_attributes.each do |attr|
+                if options[attr]
+                  query.data_accessor_for(self).send("#{attr}=", options[attr])
+                end
               end
             end
           end

--- a/sunspot_rails/spec/model_spec.rb
+++ b/sunspot_rails/spec/model_spec.rb
@@ -165,6 +165,22 @@ describe 'ActiveRecord mixin' do
       end.results.first.attribute_names.sort.should == ['body', 'id', 'title']
     end
 
+    it 'should use the scoped option from search call to data accessor' do
+      Post.search(:scopes => [:includes_location]) do
+        with :title, 'Test Post'
+      end.data_accessor_for(Post).scopes.should == [:includes_location]
+    end
+
+    it 'should use the scopes option on the data accessor when specified' do
+      @post.update_attribute(:location, Location.create)
+      post = Post.search do
+        with :title, 'Test Post'
+        data_accessor_for(Post).scopes = [:includes_location]
+      end.results.first
+
+      (Rails.version >= '3.1' ? post.association(:location).loaded? : post.loaded_location?).should be_true # Rails 3.1 removed "loaded_#{association}" method
+    end
+
     it 'should gracefully handle nonexistent records' do
       post2 = Post.create!(:title => 'Test Post')
       post2.index!

--- a/sunspot_rails/spec/rails_template/app/models/post.rb
+++ b/sunspot_rails/spec/rails_template/app/models/post.rb
@@ -10,4 +10,8 @@ class Post < ActiveRecord::Base
     text :body, :more_like_this => true
     location :location
   end
+
+  scope :includes_location, -> {
+    includes(:location)
+  }
 end


### PR DESCRIPTION
I add `scopes` to `@inherited_attributes` of `ActiveRecordDataAccessor` to allow specifying model scopes.
Sometimes, I define `includes_*` scopes to include multiple associations and I want to specify the scopes also to `search` option.
