### PR TITLE
Don't fail on hostnames with '_' in them

### DIFF
--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -43,13 +43,12 @@ module Sunspot #:nodoc:
 
       def master_config(sunspot_rails_configuration)
         config = Sunspot::Configuration.build
-        builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
-        config.solr.url = builder.build(
-          :host => sunspot_rails_configuration.master_hostname,
-          :port => sunspot_rails_configuration.master_port,
-          :path => sunspot_rails_configuration.master_path,
-          :userinfo => sunspot_rails_configuration.userinfo
-        ).to_s
+        config.solr.url = URI.parse("#{sunspot_rails_configuration.scheme}://example.com").tap do |builder|
+          builder.hostname = sunspot_rails_configuration.master_hostname
+          builder.port = sunspot_rails_configuration.master_port
+          builder.path = sunspot_rails_configuration.master_path
+          builder.userinfo = sunspot_rails_configuration.userinfo
+        end.to_s
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy
@@ -59,13 +58,12 @@ module Sunspot #:nodoc:
 
       def slave_config(sunspot_rails_configuration)
         config = Sunspot::Configuration.build
-        builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
-        config.solr.url = builder.build(
-          :host => sunspot_rails_configuration.hostname,
-          :port => sunspot_rails_configuration.port,
-          :path => sunspot_rails_configuration.path,
-          :userinfo => sunspot_rails_configuration.userinfo
-        ).to_s
+        config.solr.url = URI.parse("#{sunspot_rails_configuration.scheme}://example.com").tap do |builder|
+          builder.hostname = sunspot_rails_configuration.hostname
+          builder.port = sunspot_rails_configuration.port
+          builder.path = sunspot_rails_configuration.path
+          builder.userinfo = sunspot_rails_configuration.userinfo
+        end.to_s
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy


### PR DESCRIPTION
At work today, we had a SOLR instance running on a domain name with an underscore in it:

```
URI::InvalidComponentError: bad component(expected host component): int-geocodes_domain-solr.practicefusion.net
/var/www/geocode_domain/shared/bundle/ruby/2.2.0/gems/sunspot_rails-2.2.0/lib/sunspot/rails.rb:61:in `slave_config'
/var/www/geocode_domain/shared/bundle/ruby/2.2.0/gems/sunspot_rails-2.2.0/lib/sunspot/rails.rb:38:in `build_session'
```

While unconventional, the RFCS do seem to support this. There's even an [old thread on ruby-forum](https://www.ruby-forum.com/topic/171362). discussing this.

This fix works by skipping `URI::HTTP.build` in favor of simply setting the values on an existing URI object.

I couldn't get specs to run locally (something in my environment), but I'll try again next week unless someone else can run them for me before then.
