### PR TITLE
Fix incorrect query filter parameter for MoreLikeThis

### DIFF
--- a/sunspot/lib/sunspot/query/more_like_this.rb
+++ b/sunspot/lib/sunspot/query/more_like_this.rb
@@ -50,7 +50,7 @@ module Sunspot
         params[:"mlt.fl"] = @fields.keys.join(",")
         boosted_fields = @fields.values.select { |field| field.boost }
         unless boosted_fields.empty?
-          params[:qf] = boosted_fields.map do |field|
+          params[:"mlt.qf"] = boosted_fields.map do |field|
             field.to_boosted_field
           end.join(' ')
         end

--- a/sunspot/spec/api/query/more_like_this_spec.rb
+++ b/sunspot/spec/api/query/more_like_this_spec.rb
@@ -36,7 +36,7 @@ describe 'more_like_this' do
       fields :body, :tags => 8
     end
     connection.searches.last[:"mlt.fl"].split(',').sort.should == %w(body_textsv tags_textv)
-    connection.should have_last_search_with(:qf => "tags_textv^8")
+    connection.should have_last_search_with(:"mlt.qf" => "tags_textv^8")
   end
 
   it 'doesn\'t assign boosts to fields when not specified' do


### PR DESCRIPTION
We noticed that specifying a boost for fields in `Sunsot.more_like_this` had no effect. Looking at the generated query, we noticed that boost fields were specified in a `qf` parameter.

According to Solr's [MoreLikeThis documentation](https://wiki.apache.org/solr/MoreLikeThis), the correct parameter name is `mlt.qf` rather than `qf`.

This change fixed the problem for us. Results are now boosted correctly.