### PR TITLE
Adding the option to provide a proxy in the config file for solr

### DIFF
--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -25,6 +25,7 @@ module Sunspot
             url 'http://127.0.0.1:8983/solr/default'
             read_timeout nil
             open_timeout nil
+            proxy nil
           end
           master_solr do
             url nil
@@ -37,7 +38,7 @@ module Sunspot
           end
         end
       end
-      
+
       # Location for the default solr configuration files,
       # required for bootstrapping a new solr installation
       #

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -1,5 +1,5 @@
 module Sunspot
-  # 
+  #
   # A Sunspot session encapsulates a connection to Solr and a set of
   # configuration choices. Though users of Sunspot may manually instantiate
   # Session objects, in the general case it's easier to use the singleton
@@ -10,8 +10,8 @@ module Sunspot
   class Session
     class <<self
       attr_writer :connection_class #:nodoc:
-      
-      # 
+
+      #
       # For testing purposes
       #
       def connection_class #:nodoc:
@@ -19,12 +19,12 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # Sunspot::Configuration object for this session
     #
     attr_reader :config
 
-    # 
+    #
     # Sessions are initialized with a Sunspot configuration and a Solr
     # connection. Usually you will want to stick with the default arguments
     # when instantiating your own sessions.
@@ -36,7 +36,7 @@ module Sunspot
       @deletes = @adds = 0
     end
 
-    # 
+    #
     # See Sunspot.new_search
     #
     def new_search(*types, &block)
@@ -59,7 +59,7 @@ module Sunspot
       search.execute
     end
 
-    # 
+    #
     # See Sunspot.new_more_like_this
     #
     def new_more_like_this(object, *types, &block)
@@ -91,7 +91,7 @@ module Sunspot
       indexer.add(objects)
     end
 
-    # 
+    #
     # See Sunspot.index!
     #
     def index!(*objects)
@@ -131,7 +131,7 @@ module Sunspot
       connection.optimize
     end
 
-    # 
+    #
     # See Sunspot.remove
     #
     def remove(*objects, &block)
@@ -155,7 +155,7 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # See Sunspot.remove!
     #
     def remove!(*objects, &block)
@@ -163,7 +163,7 @@ module Sunspot
       commit
     end
 
-    # 
+    #
     # See Sunspot.remove_by_id
     #
     def remove_by_id(clazz, *ids)
@@ -176,7 +176,7 @@ module Sunspot
       indexer.remove_by_id(class_name, ids)
     end
 
-    # 
+    #
     # See Sunspot.remove_by_id!
     #
     def remove_by_id!(clazz, *ids)
@@ -198,7 +198,7 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # See Sunspot.remove_all!
     #
     def remove_all!(*classes)
@@ -206,35 +206,35 @@ module Sunspot
       commit
     end
 
-    # 
+    #
     # See Sunspot.dirty?
     #
     def dirty?
       (@deletes + @adds) > 0
     end
 
-    # 
+    #
     # See Sunspot.commit_if_dirty
     #
     def commit_if_dirty(soft_commit = false)
       commit soft_commit if dirty?
     end
-    
-    # 
+
+    #
     # See Sunspot.delete_dirty?
     #
     def delete_dirty?
       @deletes > 0
     end
 
-    # 
+    #
     # See Sunspot.commit_if_delete_dirty
     #
     def commit_if_delete_dirty(soft_commit = false)
       commit soft_commit if delete_dirty?
     end
-    
-    # 
+
+    #
     # See Sunspot.batch
     #
     def batch
@@ -245,7 +245,7 @@ module Sunspot
 
     private
 
-    # 
+    #
     # Retrieve the Solr connection for this session, creating one if it does not
     # already exist.
     #
@@ -257,7 +257,8 @@ module Sunspot
       @connection ||=
         self.class.connection_class.connect(:url          => config.solr.url,
                                             :read_timeout => config.solr.read_timeout,
-                                            :open_timeout => config.solr.open_timeout)
+                                            :open_timeout => config.solr.open_timeout,
+                                            :proxy        => config.solr.proxy)
     end
 
     def indexer

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -117,6 +117,12 @@ describe 'Session' do
       Sunspot.commit
       connection.opts[:open_timeout].should == 0.5
     end
+
+    it 'should open a connection through a provided proxy' do
+      Sunspot.config.solr.proxy = 'http://proxy.com:1234'
+      Sunspot.commit
+      connection.opts[:proxy].should == 'http://proxy.com:1234'
+    end
   end
 
   context 'custom session' do
@@ -143,7 +149,7 @@ describe 'Session' do
     it 'should start out not dirty' do
       @session.dirty?.should be_false
     end
-    
+
     it 'should start out not delete_dirty' do
       @session.delete_dirty?.should be_false
     end
@@ -152,7 +158,7 @@ describe 'Session' do
       @session.index(Post.new)
       @session.dirty?.should be_true
     end
-    
+
     it 'should be not be delete_dirty after adding an item' do
       @session.index(Post.new)
       @session.delete_dirty?.should be_false
@@ -182,12 +188,12 @@ describe 'Session' do
       @session.remove_all
       @session.dirty?.should be_true
     end
-    
+
     it 'should be delete_dirty after a global remove_all' do
       @session.remove_all
       @session.delete_dirty?.should be_true
     end
-    
+
     it 'should not be dirty after a commit' do
       @session.index(Post.new)
       @session.commit
@@ -227,14 +233,14 @@ describe 'Session' do
       @session.commit_if_dirty
       connection.should have(1).commits
     end
-    
+
     it 'should soft commit when commit_if_dirty called on dirty session' do
       @session.index(Post.new)
       @session.commit_if_dirty(true)
       connection.should have(1).commits
       connection.should have(1).soft_commits
     end
-    
+
     it 'should hard commit when commit_if_delete_dirty called on delete_dirty session' do
       @session.remove(Post.new)
       @session.commit_if_delete_dirty

--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rsolr', '~>1.0.7'
+  s.add_dependency 'rsolr', '~>1.1.1'
   s.add_dependency 'pr_geohash', '~>1.0'
 
   s.add_development_dependency 'rspec', '~>2.6.0'

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -52,6 +52,7 @@ module Sunspot #:nodoc:
         ).to_s
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
+        config.solr.proxy = sunspot_rails_configuration.proxy
         config
       end
 
@@ -66,6 +67,7 @@ module Sunspot #:nodoc:
         ).to_s
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
+        config.solr.proxy = sunspot_rails_configuration.proxy
         config
       end
     end

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -15,6 +15,7 @@ module Sunspot #:nodoc:
     #       memory: 1G
     #       solr_jar: /some/path/solr15/start.jar
     #       bind_address: 0.0.0.0
+    #       proxy: false
     #     disabled: false
     #   test:
     #     solr:
@@ -23,6 +24,7 @@ module Sunspot #:nodoc:
     #       log_level: OFF
     #       open_timeout: 0.5
     #       read_timeout: 2
+    #       proxy: false
     #   production:
     #     solr:
     #       scheme: http
@@ -35,6 +37,7 @@ module Sunspot #:nodoc:
     #       solr_home: /some/path
     #       open_timeout: 0.5
     #       read_timeout: 2
+    #       proxy: http://proxy.com:12345
     #     master_solr:
     #       hostname: localhost
     #       port: 8982
@@ -296,6 +299,10 @@ module Sunspot #:nodoc:
 
       def open_timeout
         @open_timeout ||= user_configuration_from_key('solr', 'open_timeout')
+      end
+
+      def proxy
+        @proxy ||= user_configuration_from_key('solr', 'proxy')
       end
 
       #

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -22,6 +22,10 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
     @config.userinfo.should be_nil
   end
 
+  it "should not set a proxy" do
+    @config.proxy.should be_nil
+  end
+
   describe "port" do
     it "should default to port 8981 in test" do
       ::Rails.stub(:env => 'test')
@@ -157,6 +161,10 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
 
   it "should handle the 'open_timeout' property when set" do
     @config.open_timeout.should == 0.5
+  end
+
+  it "should handle the 'proxy' property when set" do
+    @config.proxy.should == 'http://proxy.com:12345'
   end
 end
 

--- a/sunspot_rails/spec/rails_template/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot.yml
@@ -22,6 +22,7 @@ config_test:
     bind_address: 127.0.0.1
     read_timeout: 2
     open_timeout: 0.5
+    proxy: http://proxy.com:12345
   auto_commit_after_request: false
   auto_commit_after_delete_request: true
 config_disabled_test:


### PR DESCRIPTION
This will allow specifying a proxy in the `sunspot.yml` file under the `solr` setting which will be then passed transparently to `rsolr` when we create the connection.  Prior to this there was no way to use a proxy with sunspot (that I know of).