### PR TITLE
ThreadLocalSessionProxy can be instantiated without parameters

### DIFF
--- a/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/thread_local_session_proxy.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), 'abstract_session_proxy')
 
 module Sunspot
   module SessionProxy
-    # 
+    #
     # This class implements a session proxy that creates a different Session
     # object for each thread. Any multithreaded application should use this
     # proxy.
@@ -21,12 +21,12 @@ module Sunspot
                :new_search, :optimize, :remove, :remove!, :remove_all, :remove_all!, :remove_by_id, :remove_by_id!,
                :search, :more_like_this, :new_more_like_this, :atomic_update, :atomic_update!, :to => :session
 
-      # 
+      #
       # Optionally pass an existing Sunspot::Configuration object. If none is
       # passed, a default configuration is used; it can then be modified using
       # the #config attribute.
       #
-      def initialize(config = Sunspot::Configuration.new)
+      def initialize(config = Sunspot::Configuration.build)
         @config = config
         ObjectSpace.define_finalizer(self, FINALIZER)
       end

--- a/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
@@ -2,38 +2,48 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 require 'weakref'
 
 describe Sunspot::SessionProxy::ThreadLocalSessionProxy do
-  before :each do
-    @config = Sunspot::Configuration.build
-    @proxy = Sunspot::SessionProxy::ThreadLocalSessionProxy.new(@config)
-  end
-
-  it 'should have the same session for the same thread' do
-    @proxy.session.should eql(@proxy.session)
-  end
-
-  it 'should not have the same session for different threads' do
-    session1 = @proxy.session
-    session2 = nil
-    Thread.new do
-      session2 = @proxy.session
-    end.join
-    session1.should_not eql(session2)
-  end
-
-  it 'should not have the same session for the same thread in different proxy instances' do
-    proxy2 = Sunspot::SessionProxy::ThreadLocalSessionProxy.new(@config)
-    @proxy.session.should_not eql(proxy2.session)
-  end
-
-  (Sunspot::Session.public_instance_methods(false) - ['config', :config]).each do |method|
-    it "should delegate #{method.inspect} to its session" do
-      args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
-        stub('arg')
-      end
-      @proxy.session.should_receive(method).with(*args)
-      @proxy.send(method, *args)
+  context 'when not passing a config' do
+    before :each do
+      @proxy = Sunspot::SessionProxy::ThreadLocalSessionProxy.new
     end
+
+    it_should_behave_like 'session proxy'
   end
 
-  it_should_behave_like 'session proxy'
+  context 'when passing a config' do
+    before :each do
+      @config = Sunspot::Configuration.build
+      @proxy = Sunspot::SessionProxy::ThreadLocalSessionProxy.new(@config)
+    end
+
+    it 'should have the same session for the same thread' do
+      @proxy.session.should eql(@proxy.session)
+    end
+
+    it 'should not have the same session for different threads' do
+      session1 = @proxy.session
+      session2 = nil
+      Thread.new do
+        session2 = @proxy.session
+      end.join
+      session1.should_not eql(session2)
+    end
+
+    it 'should not have the same session for the same thread in different proxy instances' do
+      proxy2 = Sunspot::SessionProxy::ThreadLocalSessionProxy.new(@config)
+      @proxy.session.should_not eql(proxy2.session)
+    end
+
+    (Sunspot::Session.public_instance_methods(false) - ['config', :config]).each do |method|
+      it "should delegate #{method.inspect} to its session" do
+        args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
+          stub('arg')
+        end
+        @proxy.session.should_receive(method).with(*args)
+        @proxy.send(method, *args)
+      end
+    end
+
+    it_should_behave_like 'session proxy'
+  end
 end


### PR DESCRIPTION
`.new` would fail unless a `Sunspot::Configuration` was passed because its default parameter called `Sunspot::Configuration.new` instead of `Sunspot::Configuration.build`.