### PR TITLE
Adjust multiple parameters

### DIFF
--- a/sunspot/lib/sunspot/dsl/adjustable.rb
+++ b/sunspot/lib/sunspot/dsl/adjustable.rb
@@ -26,9 +26,9 @@ module Sunspot
       #       params["mlt.match.include"] = true
       #     end
       #   end
-      # 
+      #
       def adjust_solr_params( &block )
-        @query.solr_parameter_adjustment = block
+        @query.add_parameter_adjustment(block)
       end
 
       #

--- a/sunspot/lib/sunspot/query/common_query.rb
+++ b/sunspot/lib/sunspot/query/common_query.rb
@@ -12,11 +12,11 @@ module Sunspot
         end
 
         @pagination = nil
-        @parameter_adjustment = nil
+        @parameter_adjustments = []
       end
 
-      def solr_parameter_adjustment=(block)
-        @parameter_adjustment = block
+      def add_parameter_adjustment(block)
+        @parameter_adjustments << block
       end
 
       def add_sort(sort)
@@ -68,7 +68,11 @@ module Sunspot
         @components.each do |component|
           Sunspot::Util.deep_merge!(params, component.to_params)
         end
-        @parameter_adjustment.call(params) if @parameter_adjustment
+
+        @parameter_adjustments.each do |_block|
+          _block.call(params)
+        end
+
         params[:q] ||= '*:*'
         params
       end


### PR DESCRIPTION
I know this method is undocumented and according to the documentation should not be used under "normal" circumstances. However, it is really unclear that it's a single block you are passing and only the last one will be executed.

Lets take an example

```
        search.build do
          adjust_solr_params do |params|
            params[:fq] << "{!geofilt sfield=location_ll pt=#{options[:lat]},#{options[:lng]} d=#{distance}}"
          end
        end

        if center_lat && center_lng
          search.build do
            adjust_solr_params do |params|
              params[:sort] = "distanceScore(location_ll,#{center_lat},#{center_lng}) asc"
            end
          end
        end
```

The "fix"/feature here will simply add any block passed into `adjust_solr_params` to an array of blocks that will be executed one after the other.

This is fully backward compatible.