### PR TITLE
Configurable commitWithin behaviour

### DIFF
--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -36,6 +36,7 @@ module Sunspot
           indexing do
             default_batch_size 50
           end
+          commit_within nil
         end
       end
 

--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -11,7 +11,7 @@ module Sunspot
 
     def initialize(connection, options = {})
       @connection = connection
-      @update_options = {params: options.delete_if { |key, value| value.nil? }}
+      @update_options = {params: options.delete_if { |_, value| value.nil? }}
     end
 
     # 

--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -11,7 +11,7 @@ module Sunspot
 
     def initialize(connection, options = {})
       @connection = connection
-      @update_options = options.delete_if { |key, value| value.nil? }
+      @update_options = {params: options.delete_if { |key, value| value.nil? }}
     end
 
     # 

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -262,7 +262,7 @@ module Sunspot
     end
 
     def indexer
-      @indexer ||= Indexer.new(connection)
+      @indexer ||= Indexer.new(connection, commitWithin: config.commit_within)
     end
 
     def setup_for_types(types)

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -22,7 +22,7 @@ describe 'document removal', :type => :indexer do
   end
 
   it 'removes an object by type and ids and immediately commits' do
-    connection.should_receive(:delete_by_id).with(['Post 1', 'Post 2', 'Post 3']).ordered
+    connection.should_receive(:delete_by_id).with(['Post 1', 'Post 2', 'Post 3'], {}).ordered
     connection.should_receive(:commit).ordered
     session.remove_by_id!(Post, 1, 2, 3)
   end
@@ -50,7 +50,7 @@ describe 'document removal', :type => :indexer do
   end
 
   it 'correctly escapes namespaced classes when removing everything from the index' do
-    connection.should_receive(:delete_by_query).with('type:Namespaced\:\:Comment')
+    connection.should_receive(:delete_by_query).with('type:Namespaced\:\:Comment', {})
     session.remove_all(Namespaced::Comment)
   end
 

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -22,7 +22,7 @@ describe 'document removal', :type => :indexer do
   end
 
   it 'removes an object by type and ids and immediately commits' do
-    connection.should_receive(:delete_by_id).with(['Post 1', 'Post 2', 'Post 3'], {}).ordered
+    connection.should_receive(:delete_by_id).with(['Post 1', 'Post 2', 'Post 3'], {:params =>{}}).ordered
     connection.should_receive(:commit).ordered
     session.remove_by_id!(Post, 1, 2, 3)
   end
@@ -50,7 +50,7 @@ describe 'document removal', :type => :indexer do
   end
 
   it 'correctly escapes namespaced classes when removing everything from the index' do
-    connection.should_receive(:delete_by_query).with('type:Namespaced\:\:Comment', {})
+    connection.should_receive(:delete_by_query).with('type:Namespaced\:\:Comment', {:params =>{}})
     session.remove_all(Namespaced::Comment)
   end
 

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -36,17 +36,17 @@ module Mock
     end
 
     def add(documents, opts = {})
-      @committed_within = opts.delete :commitWithin
+      @committed_within = commitWithinValue(opts)
       @adds << Array(documents)
     end
 
     def delete_by_id(ids, opts = {})
-      @committed_within = opts.delete :commitWithin
+      @committed_within = commitWithinValue(opts)
       @deletes << Array(ids)
     end
 
     def delete_by_query(query, opts = {})
-      @committed_within = opts.delete :commitWithin
+      @committed_within = commitWithinValue(opts)
       @deletes_by_query << query
     end
 
@@ -127,6 +127,10 @@ module Mock
       else
         request.has_key?(params)
       end
+    end
+
+    def commitWithinValue(opts = {})
+      opts[:params][:commitWithin] if opts[:params] && opts[:params][:commitWithin]
     end
   end
 end

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -22,7 +22,8 @@ module Mock
   end
 
   class Connection
-    attr_reader :adds, :commits, :soft_commits, :optims, :searches, :message, :opts, :deletes_by_query
+    attr_reader :adds, :commits, :soft_commits, :optims, :searches, :message, :opts, :deletes, :deletes_by_query,
+                :committed_within
     attr_accessor :response
     attr_writer :expected_handler
     undef_method :select # annoyingly defined on Object
@@ -34,15 +35,18 @@ module Mock
       @expected_handler = :select
     end
 
-    def add(documents)
+    def add(documents, opts = {})
+      @committed_within = opts.delete :commitWithin
       @adds << Array(documents)
     end
 
-    def delete_by_id(ids)
+    def delete_by_id(ids, opts = {})
+      @committed_within = opts.delete :commitWithin
       @deletes << Array(ids)
     end
 
-    def delete_by_query(query)
+    def delete_by_query(query, opts = {})
+      @committed_within = opts.delete :commitWithin
       @deletes_by_query << query
     end
 

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -36,17 +36,17 @@ module Mock
     end
 
     def add(documents, opts = {})
-      @committed_within = commitWithinValue(opts)
+      @committed_within = commit_within_value(opts)
       @adds << Array(documents)
     end
 
     def delete_by_id(ids, opts = {})
-      @committed_within = commitWithinValue(opts)
+      @committed_within = commit_within_value(opts)
       @deletes << Array(ids)
     end
 
     def delete_by_query(query, opts = {})
-      @committed_within = commitWithinValue(opts)
+      @committed_within = commit_within_value(opts)
       @deletes_by_query << query
     end
 
@@ -129,7 +129,7 @@ module Mock
       end
     end
 
-    def commitWithinValue(opts = {})
+    def commit_within_value(opts = {})
       opts[:params][:commitWithin] if opts[:params] && opts[:params][:commitWithin]
     end
   end

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -42,32 +42,26 @@ module Sunspot #:nodoc:
       private
 
       def master_config(sunspot_rails_configuration)
-        config = Sunspot::Configuration.build
-        builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
-        config.solr.url = builder.build(
-          :host => sunspot_rails_configuration.master_hostname,
-          :port => sunspot_rails_configuration.master_port,
-          :path => sunspot_rails_configuration.master_path,
-          :userinfo => sunspot_rails_configuration.userinfo
-        ).to_s
-        config.solr.read_timeout = sunspot_rails_configuration.read_timeout
-        config.solr.open_timeout = sunspot_rails_configuration.open_timeout
-        config.solr.proxy = sunspot_rails_configuration.proxy
-        config
+        build_config(sunspot_rails_configuration, :master_hostname, :master_port, :master_path)
       end
 
       def slave_config(sunspot_rails_configuration)
+        build_config(sunspot_rails_configuration, :hostname, :port, :path)
+      end
+
+      def build_config(sunspot_rails_configuration, host_property, port_property, path_property)
         config = Sunspot::Configuration.build
         builder = sunspot_rails_configuration.scheme == 'http' ? URI::HTTP : URI::HTTPS
         config.solr.url = builder.build(
-          :host => sunspot_rails_configuration.hostname,
-          :port => sunspot_rails_configuration.port,
-          :path => sunspot_rails_configuration.path,
+          :host => sunspot_rails_configuration.send(host_property),
+          :port => sunspot_rails_configuration.send(port_property),
+          :path => sunspot_rails_configuration.send(path_property),
           :userinfo => sunspot_rails_configuration.userinfo
         ).to_s
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy
+        config.commit_within = sunspot_rails_configuration.commit_within
         config
       end
     end

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -205,10 +205,7 @@ module Sunspot #:nodoc:
       # String:: log_level
       #
       def log_level
-        @log_level ||= (
-          user_configuration_from_key('solr', 'log_level') ||
-          LOG_LEVELS[::Rails.logger.level]
-        )
+        @log_level ||= (user_configuration_from_key('solr', 'log_level') || LOG_LEVELS[::Rails.logger.level])
       end
 
       #
@@ -220,8 +217,7 @@ module Sunspot #:nodoc:
       # Boolean: auto_commit_after_request?
       #
       def auto_commit_after_request?
-        @auto_commit_after_request ||=
-          user_configuration_from_key('auto_commit_after_request') != false
+        @auto_commit_after_request ||= user_configuration_from_key('auto_commit_after_request') != false
       end
 
       #
@@ -233,8 +229,19 @@ module Sunspot #:nodoc:
       # Boolean: auto_commit_after_delete_request?
       #
       def auto_commit_after_delete_request?
-        @auto_commit_after_delete_request ||=
-          (user_configuration_from_key('auto_commit_after_delete_request') || false)
+        @auto_commit_after_delete_request ||= (user_configuration_from_key('auto_commit_after_delete_request') || false)
+      end
+
+      #
+      # Time interval for the solr to queue soft commit (https://wiki.apache.org/solr/CommitWithin)
+      # Default nil
+      #
+      # ==== Returns
+      #
+      # Fixnum: time interval in milliseconds
+      #
+      def commit_within
+        @commit_within ||= (user_configuration_from_key('commit_within') || nil)
       end
 
 
@@ -264,12 +271,7 @@ module Sunspot #:nodoc:
       # String:: solr_home
       #
       def solr_home
-        @solr_home ||=
-          if user_configuration_from_key('solr', 'solr_home')
-            user_configuration_from_key('solr', 'solr_home')
-          else
-            File.join(::Rails.root, 'solr')
-          end
+        @solr_home ||= user_configuration_from_key('solr', 'solr_home') || File.join(::Rails.root, 'solr')
       end
 
       #

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -50,11 +50,11 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   end
 
   it "should set the read timeout to nil when not set" do
-    @config.read_timeout == nil
+    @config.read_timeout.should == nil
   end
 
   it "should set the open timeout to nil when not set" do
-    @config.open_timeout == nil
+    @config.open_timeout.should == nil
   end
 
   it "should set 'log_level' property using Rails log level when not set" do
@@ -98,6 +98,10 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
 
   it "should handle the 'auto_remove_callback' property when not set" do
     @config.auto_remove_callback.should == "after_destroy"
+  end
+
+  it "should set the commit_within to nil when not set" do
+    @config.commit_within.should be_nil
   end
 end
 
@@ -165,6 +169,10 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
 
   it "should handle the 'proxy' property when set" do
     @config.proxy.should == 'http://proxy.com:12345'
+  end
+
+  it "should handle the 'commit_within' property when set" do
+    @config.commit_within.should == 3000
   end
 end
 

--- a/sunspot_rails/spec/rails_template/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_template/config/sunspot.yml
@@ -25,6 +25,7 @@ config_test:
     proxy: http://proxy.com:12345
   auto_commit_after_request: false
   auto_commit_after_delete_request: true
+  commit_within: 3000
 config_disabled_test:
   disabled: true
 config_commit_test:

--- a/sunspot_rails/spec/rails_template/db/schema.rb
+++ b/sunspot_rails/spec/rails_template/db/schema.rb
@@ -5,7 +5,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.integer :location_id
     t.text :body
     t.references :blog
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :locations, :force => true do |t|
@@ -16,12 +16,12 @@ ActiveRecord::Schema.define(:version => 0) do
   create_table :blogs, :force => true do |t|
     t.string :name
     t.string :subdomain
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :writers, :force => true, :primary_key => :writer_id do |t|
     t.string :name
-    t.timestamps
+    t.timestamps null: false
   end
 
 end


### PR DESCRIPTION
This enables Solr's [commitWithin](https://wiki.apache.org/solr/CommitWithin) feature and allows to configure commit interval via `sunspot.yml`

Same behavior could be achieved by configuring `autoSoftCommit` property of `solrconfig.xml`, but this requires server restart which is sometimes extremely expensive (like I'm my case). 
So  having an option to configure this feature via Rails app could be useful.

P.S. don't see a good place to describe this in README.md, so Im open to this if someone can point me to a proper section
