### PR TITLE
Attempt to solve the issue when indexing attributes for a Class that has #id method defined

### DIFF
--- a/sunspot/lib/sunspot/util.rb
+++ b/sunspot/lib/sunspot/util.rb
@@ -257,7 +257,15 @@ module Sunspot
       end
 
       def id
-        @__calling_context__.__send__(:id)
+        begin
+          @__calling_context__.__send__(:id)
+        rescue ::NoMethodError => e
+          begin
+            @__receiver__.__send__(:id)
+          rescue ::NoMethodError
+            raise(e)
+          end
+        end
       end
 
       # Special case due to `Kernel#sub`'s existence

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -1,6 +1,9 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
+if SystemRubyVersion.new.to_s =~ /1.9/
+  gem 'mime-types', '~> 2.99.0'
+end
 
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -1,6 +1,9 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
+if SystemRubyVersion.new.to_s =~ /1.9/
+  gem 'mime-types', '~> 2.99.0'
+end
 
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)

--- a/sunspot_rails/gemfiles/rails-4.2.0
+++ b/sunspot_rails/gemfiles/rails-4.2.0
@@ -1,6 +1,9 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
+if SystemRubyVersion.new.to_s =~ /1.9/
+  gem 'mime-types', '~> 2.99.0'
+end
 
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)


### PR DESCRIPTION
This PR is related to the issue #331.

Tha idea is that if the method `#id` is already defined in the `@__reciever__` then be able to fallback to it if the `@__calling_context__` don't have it.

I think that maybe I'm missing something here, please feel free to let me know if that's the case. Or if another approach is preferred.

Thanks!