### PR TITLE
Configure master via a MASTER_SOLR_URL envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,7 +1245,7 @@ TODO
 
 ## Configuration
 
-Configure Sunspot by creating a *config/sunspot.yml* file or by setting a `SOLR_URL` or a `WEBSOLR_URL` environment variable.
+Configure Sunspot by creating a *config/sunspot.yml* file or by setting a `SOLR_URL` or a `WEBSOLR_URL` or a `MASTER_SOLR_URL` environment variable.
 The defaults are as follows.
 
 ```yaml

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -156,7 +156,12 @@ module Sunspot #:nodoc:
       # String:: host name
       #
       def master_hostname
-        @master_hostname ||= (user_configuration_from_key('master_solr', 'hostname') || hostname)
+        unless defined?(@master_hostname)
+          @master_hostname   = master_solr_url.host if master_solr_url
+          @master_hostname ||= user_configuration_from_key('master_solr', 'hostname')
+          @master_hostname ||= hostname
+        end
+        @master_hostname
       end
 
       #
@@ -168,7 +173,13 @@ module Sunspot #:nodoc:
       # Integer:: port
       #
       def master_port
-        @master_port ||= (user_configuration_from_key('master_solr', 'port') || port).to_i
+        unless defined?(@master_port)
+          @master_port   = master_solr_url.port if master_solr_url
+          @master_port ||= user_configuration_from_key('master_solr', 'port')
+          @master_port ||= port
+          @master_port   = @master_port.to_i
+        end
+        @master_port
       end
 
       #
@@ -180,7 +191,12 @@ module Sunspot #:nodoc:
       # String:: path
       #
       def master_path
-        @master_path ||= (user_configuration_from_key('master_solr', 'path') || path)
+        unless defined?(@master_path)
+          @master_path   = master_solr_url.path if master_solr_url
+          @master_path ||= user_configuration_from_key('master_solr', 'path')
+          @master_path ||= path
+        end
+        @master_path
       end
 
       #
@@ -191,7 +207,7 @@ module Sunspot #:nodoc:
       # Boolean:: bool
       #
       def has_master?
-        @has_master = !!user_configuration_from_key('master_solr')
+        @has_master = !!(master_solr_url || user_configuration_from_key('master_solr'))
       end
 
       #
@@ -392,6 +408,12 @@ module Sunspot #:nodoc:
       def solr_url
         if ENV['SOLR_URL'] || ENV['WEBSOLR_URL']
           URI.parse(ENV['SOLR_URL'] || ENV['WEBSOLR_URL'])
+        end
+      end
+
+      def master_solr_url
+        if ENV['MASTER_SOLR_URL']
+          URI.parse(ENV['MASTER_SOLR_URL'])
         end
       end
 

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -313,3 +313,32 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] including useri
     @config.path.should == '/solr/a1b2c3d4e5f'
   end
 end
+
+describe Sunspot::Rails::Configuration, "with ENV['MASTER_SOLR_URL'] overriding sunspot.yml" do
+  before(:all) do
+    ENV['MASTER_SOLR_URL'] = 'http://master.host:5433/solr/master'
+  end
+
+  before(:each) do
+    ::Rails.stub(:env => 'config_test')
+    @config = Sunspot::Rails::Configuration.new
+  end
+
+  after(:all) do
+    ENV.delete('MASTER_SOLR_URL')
+  end
+
+  it "should handle the 'hostname' property when set" do
+    @config.master_hostname.should == 'master.host'
+  end
+
+  it "should handle the 'port' property when set" do
+    @config.master_port.should == 5433
+  end
+
+  it "should handle the 'path' property when set" do
+    @config.master_path.should == '/solr/master'
+  end
+
+  it { @config.should have_master }
+end


### PR DESCRIPTION
Allow `MASTER_SOLR_URL` to configure sunspot like `SOLR_URL`
