### PR TITLE
Removed before_filter as this is being deprecated

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/request_lifecycle.rb
+++ b/sunspot_rails/lib/sunspot/rails/request_lifecycle.rb
@@ -20,8 +20,10 @@ module Sunspot #:nodoc:
           # this case, since after_filter uses the inheritable_attribute
           # structure, the already-loaded subclasses don't get the filters. So,
           # the below ensures that all loaded controllers have the filter.
+          callback = ::Rails::VERSION::MAJOR > 3 ? :after_action : :after_filter
+
           loaded_controllers.each do |controller|
-            controller.after_filter do
+            controller.send(callback) do
               if Sunspot::Rails.configuration.auto_commit_after_request?
                 Sunspot.commit_if_dirty
               elsif Sunspot::Rails.configuration.auto_commit_after_delete_request?


### PR DESCRIPTION
Do a Rails version check if it is above 4 send before_action, if not send before_filter
to controller with the block.
