### PR TITLE
Fix test in sunspot_rails

### DIFF
--- a/sunspot_rails/gemfiles/rails-3.0.0
+++ b/sunspot_rails/gemfiles/rails-3.0.0
@@ -9,12 +9,13 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 group :test do
   gem 'rspec-rails', '~> 2.14.0'
   gem 'progress_bar', '~> 1.0.5', require: false
+  gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end
 
 group :postgres do
-	gem 'pg'
+  gem 'pg'
 end
 
 group :sqlite do
-	gem 'sqlite3', '~> 1.3.7'
+  gem 'sqlite3', '~> 1.3.7'
 end

--- a/sunspot_rails/gemfiles/rails-3.1.0
+++ b/sunspot_rails/gemfiles/rails-3.1.0
@@ -9,12 +9,13 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 group :test do
   gem 'rspec-rails', '~> 2.14.0'
   gem 'progress_bar', '~> 1.0.5', require: false
+  gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end
 
 group :postgres do
-	gem 'pg'
+  gem 'pg'
 end
 
 group :sqlite do
-	gem 'sqlite3', '~> 1.3.7'
+  gem 'sqlite3', '~> 1.3.7'
 end

--- a/sunspot_rails/gemfiles/rails-3.2.0
+++ b/sunspot_rails/gemfiles/rails-3.2.0
@@ -9,12 +9,13 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 group :test do
   gem 'rspec-rails', '~> 2.14.0'
   gem 'progress_bar', '~> 1.0.5', require: false
+  gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end
 
 group :postgres do
-	gem 'pg'
+  gem 'pg'
 end
 
 group :sqlite do
-	gem 'sqlite3', '~> 1.3.7'
+  gem 'sqlite3', '~> 1.3.7'
 end

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -10,15 +10,16 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-	gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
+  gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
   gem 'rspec-rails', '~> 2.14.0'
   gem 'progress_bar', '~> 1.0.5', require: false
+  gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end
 
 group :postgres do
-	gem 'pg'
+  gem 'pg'
 end
 
 group :sqlite do
-	gem 'sqlite3', '~> 1.3.7'
+  gem 'sqlite3', '~> 1.3.7'
 end


### PR DESCRIPTION
When I tried to run tests for sunspot_rails, an error has occured in Rails 3.0.0 ~ 4.0.0 with ruby 2.2.0 or later.

In ruby 2.2.0, `minitest` and `test-unit` are remomved from standard library.
FYI: https://www.ruby-lang.org/en/news/2014/12/25/ruby-2-2-0-released/

So I added `gem mini-test` in Gemfiles for ruby 2.2.0 or later, and change some indent hard tab to soft tab.

```
bundle exec rspec spec/*_spec.rb --color
/Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/values/time_zone.rb:270: warning: circular argument reference - now
/Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `require': cannot load such file -- test/unit/assertions (LoadError)
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `block in require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:225:in `load_dependency'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-rails-2.14.2/lib/rspec/rails/adapters.rb:17:in `rescue in <module:Rails>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-rails-2.14.2/lib/rspec/rails/adapters.rb:12:in `<module:Rails>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-rails-2.14.2/lib/rspec/rails/adapters.rb:6:in `<module:RSpec>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-rails-2.14.2/lib/rspec/rails/adapters.rb:5:in `<top (required)>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `block in require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:225:in `load_dependency'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-rails-2.14.2/lib/rspec/rails.rb:11:in `<top (required)>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `block in require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:225:in `load_dependency'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:240:in `require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/spec/spec_helper.rb:13:in `<top (required)>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/spec/configuration_spec.rb:1:in `require'
        from /Users/takanamito/projects/sunspot/sunspot_rails/spec/configuration_spec.rb:1:in `<top (required)>'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `each'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load_spec_files'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:22:in `run'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
        from /Users/takanamito/projects/sunspot/sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
rake aborted!
Command failed with status (1): [bundle exec rspec spec/*_spec.rb --color...]
dev_tasks/spec.rake:59:in `block (2 levels) in <top (required)>'
dev_tasks/spec.rake:95:in `block (2 levels) in <top (required)>'
dev_tasks/spec.rake:90:in `each'
dev_tasks/spec.rake:90:in `block in <top (required)>'
Tasks: TOP => spec:run_with_rails => spec:run
(See full trace by running task with --trace)
```