### PR TITLE
To remove Rails 5 deprecations for using alias_method_chain

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -1,20 +1,22 @@
 module Sunspot
+  module SolrRailsInstrumentation
+    def send_and_receive(path, opts)
+      parameters = (opts[:params] || {})
+      parameters.merge!(opts[:data]) if opts[:data].is_a? Hash
+      payload = {:path => path, :parameters => parameters}
+      ActiveSupport::Notifications.instrument("request.rsolr", payload) do
+        super
+      end
+    end
+  end
+end
+
+module Sunspot
   module Rails
     module SolrInstrumentation
       extend ActiveSupport::Concern
-
       included do
-        alias_method_chain :send_and_receive, :as_instrumentation
-      end
-
-
-      def send_and_receive_with_as_instrumentation(path, opts)
-        parameters = (opts[:params] || {})
-        parameters.merge!(opts[:data]) if opts[:data].is_a? Hash
-        payload = {:path => path, :parameters => parameters}
-        ActiveSupport::Notifications.instrument("request.rsolr", payload) do
-          send_and_receive_without_as_instrumentation(path, opts)
-        end
+        prepend Sunspot::SolrRailsInstrumentation
       end
     end
   end

--- a/sunspot_rails/lib/sunspot/rails/solr_logging.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_logging.rb
@@ -1,59 +1,51 @@
 module Sunspot
-  module Rails
-    module SolrLogging
+  module SolrRailsLogger
+    COMMIT = %r{<commit/>}
 
-      class <<self
-        def included(base)
-          base.alias_method_chain :execute, :rails_logging
+    def execute(client, request_context)
+      body = (request_context[:data]||"").dup
+      action = request_context[:path].capitalize
+      if body =~ COMMIT
+        action = "Commit"
+        body = ""
+      end
+      body = body[0, 800] + '...' if body.length > 800
+
+      # Make request and log.
+      response = nil
+      begin
+        ms = Benchmark.ms do
+          response = super
         end
+        log_name = 'Solr %s (%.1fms)' % [action, ms]
+        ::Rails.logger.debug(format_log_entry(log_name, body))
+      rescue Exception => e
+        log_name = 'Solr %s (Error)' % [action]
+        ::Rails.logger.error(format_log_entry(log_name, body))
+        raise e
       end
 
-      COMMIT = %r{<commit/>}
+      response
+    end
 
-      def execute_with_rails_logging(client, request_context)
-        body = (request_context[:data]||"").dup
-        action = request_context[:path].capitalize
-        if body =~ COMMIT
-          action = "Commit"
-          body = ""
-        end
-        body = body[0, 800] + '...' if body.length > 800
+    private
 
-        # Make request and log.
-        response = nil
-        begin
-          ms = Benchmark.ms do
-            response = execute_without_rails_logging(client, request_context)
-          end
-          log_name = 'Solr %s (%.1fms)' % [action, ms]
-          ::Rails.logger.debug(format_log_entry(log_name, body))
-        rescue Exception => e
-          log_name = 'Solr %s (Error)' % [action]
-          ::Rails.logger.error(format_log_entry(log_name, body))
-          raise e
-        end
+    def format_log_entry(message, dump = nil)
+      @colorize_logging ||= ::Rails.application.config.colorize_logging
 
-        response
-      end
-
-      private
-
-      def format_log_entry(message, dump = nil)
-        @colorize_logging ||= ::Rails.application.config.colorize_logging
-          
-        if @colorize_logging
-          message_color, dump_color = "4;32;1", "0;1"
-          log_entry = "  \e[#{message_color}m#{message}\e[0m   "
-          log_entry << "\e[#{dump_color}m%#{String === dump ? 's' : 'p'}\e[0m" % dump if dump
-          log_entry
-        else
-          "%s  %s" % [message, dump]
-        end
+      if @colorize_logging
+        message_color, dump_color = "4;32;1", "0;1"
+        log_entry = "  \e[#{message_color}m#{message}\e[0m   "
+        log_entry << "\e[#{dump_color}m%#{String === dump ? 's' : 'p'}\e[0m" % dump if dump
+        log_entry
+      else
+        "%s  %s" % [message, dump]
       end
     end
   end
 end
 
+
 RSolr::Connection.module_eval do
-  include Sunspot::Rails::SolrLogging
+  prepend Sunspot::SolrRailsLogger
 end


### PR DESCRIPTION
This fix will work only Ruby 2.0 and above only and this PR is incompatible with Ruby 1.9.3 and below. 

This PR resolves issue #794 