### PR TITLE
Update the after_filter for auto-commit to be overridable on a per class basis.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/request_lifecycle.rb
+++ b/sunspot_rails/lib/sunspot/rails/request_lifecycle.rb
@@ -1,6 +1,6 @@
 module Sunspot #:nodoc:
   module Rails #:nodoc:
-    # 
+    #
     # This module adds an after_filter to ActionController::Base that commits
     # the Sunspot session if any documents have been added, changed, or removed
     # in the course of the request.
@@ -21,14 +21,16 @@ module Sunspot #:nodoc:
           # structure, the already-loaded subclasses don't get the filters. So,
           # the below ensures that all loaded controllers have the filter.
           loaded_controllers.each do |controller|
-            controller.after_filter do
-              if Sunspot::Rails.configuration.auto_commit_after_request?
-                Sunspot.commit_if_dirty
-              elsif Sunspot::Rails.configuration.auto_commit_after_delete_request?
-                Sunspot.commit_if_delete_dirty
-              end
-            end
+            controller.after_filter :auto_commit_if_needed
           end
+        end
+      end
+
+      def auto_commit_if_needed
+        if Sunspot::Rails.configuration.auto_commit_after_request?
+          Sunspot.commit_if_dirty
+        elsif Sunspot::Rails.configuration.auto_commit_after_delete_request?
+          Sunspot.commit_if_delete_dirty
         end
       end
     end

--- a/sunspot_rails/spec/request_lifecycle_spec.rb
+++ b/sunspot_rails/spec/request_lifecycle_spec.rb
@@ -24,7 +24,7 @@ describe PostsController, :type => :controller do
     Sunspot.should_receive(:commit_if_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
-  
+
   it 'should not commit, if configuration is set to false' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false }
     Sunspot.should_not_receive(:commit_if_dirty)
@@ -36,16 +36,16 @@ describe PostsController, :type => :controller do
     Sunspot.should_receive(:commit_if_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
-  
+
   ### auto_commit_if_delete_dirty
-  
+
   it 'should automatically commit after each delete if specified' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false,
                                           'auto_commit_after_delete_request' => true }
     Sunspot.should_receive(:commit_if_delete_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
-  
+
   it 'should not automatically commit on delete if configuration is set to false' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false,
                                           'auto_commit_after_delete_request' => false }


### PR DESCRIPTION
We have situations where a controller should avoid committing to Solr since the immediate availability of a document is not critical. The case we use this for is on API calls where we want to do the indexing inline (so we give some back-pressure on the caller) but the update doesn't need to be immediately available. These API calls happen frequently so reducing load on Solr is important.

This could be implemented with the `auto_commit_after_request: false` option, and then add the commit as an `after_filter` everywhere we want it, but this use case is a bit of an inversion of how `auto_commit_after_request` is best used.