### PR TITLE
Option to set query parser to dismax via sunspot.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Post.search do
   without(:category_ids, [1, 3])
   field_list [:title, :author_id]
 end
+```
 
 #### Disjunctions and Conjunctions
 

--- a/sunspot/lib/sunspot/version.rb
+++ b/sunspot/lib/sunspot/version.rb
@@ -1,3 +1,3 @@
 module Sunspot
-  VERSION = '2.2.5'
+  VERSION = '2.2.6'
 end

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -331,6 +331,14 @@ module Sunspot #:nodoc:
           (user_configuration_from_key('auto_remove_callback') || 'after_destroy')
       end
 
+      #
+      # The query parser that should be used (useful for legacy systems).
+      # Default 'edismax'.
+      #
+      def query_parser
+        @query_parser ||= (user_configuration_from_key('query_parser') || 'edismax')
+      end
+
       private
 
       #


### PR DESCRIPTION
This pull request adds the option to set the query parser to dismax vs. the default edismax.  In order to do so a new param can be added to the sunspot.yml called `query_parser`. If the setting is not found then sunspot defaults to edismax.  

Ex:

```
production:
  solr:
    hostname: search.your-server.com
    port: 8984
    path: /solr-master
    log_level: WARNING
  auto_commit_after_request: false
  query_parser: dismax
```

This may make it easier for those who are using an up-to-date app that requires interfacing an older version of Solr w/o having to monkey patch.
