### PR TITLE
Update to support RSolr 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   # - jruby
 
 env:
+  - GEM=sunspot RSOLR=2.0.0.pre1
   - GEM=sunspot
   - GEM=sunspot_rails RAILS=3.0.0
   - GEM=sunspot_rails RAILS=3.1.0

--- a/sunspot/Gemfile
+++ b/sunspot/Gemfile
@@ -7,3 +7,5 @@ gemspec
 group :development do
   gem 'rake'
 end
+
+gem 'rsolr', ENV['RSOLR'] if ENV['RSOLR']

--- a/sunspot/lib/sunspot/query/abstract_field_facet.rb
+++ b/sunspot/lib/sunspot/query/abstract_field_facet.rb
@@ -1,8 +1,6 @@
 module Sunspot
   module Query
     class AbstractFieldFacet
-      include RSolr::Char
-
       def initialize(field, options)
         @field, @options = field, options
       end

--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rsolr', '~>1.1.1'
+  s.add_dependency 'rsolr', '>= 1.1.1', '< 3'
   s.add_dependency 'pr_geohash', '~>1.0'
 
   s.add_development_dependency 'rspec', '~>2.6.0'


### PR DESCRIPTION
I just released [RSolr 2.0.0.pre1](https://github.com/rsolr/rsolr/releases/tag/v2.0.0.pre10 for testing, which makes some pretty major changes to request building (defaulting to a new JSON serializer, among other changes).

I ran the sunspot test suite against it successfully, but you may want to perform additional testing.