### PR TITLE
Remove  alias_method_chain warning

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -4,17 +4,26 @@ module Sunspot
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :send_and_receive, :as_instrumentation
+        if Module.respond_to?(:prepend)
+          prepend Sunspot::SolrRailsInstrumentation
+        else
+          include Sunspot::SolrRailsInstrumentation
+          alias_method :send_and_receive_without_as_instrumentation, :send_and_receive
+        end
       end
 
+    end
+  end
+end
 
-      def send_and_receive_with_as_instrumentation(path, opts)
-        parameters = (opts[:params] || {})
-        parameters.merge!(opts[:data]) if opts[:data].is_a? Hash
-        payload = {:path => path, :parameters => parameters}
-        ActiveSupport::Notifications.instrument("request.rsolr", payload) do
-          send_and_receive_without_as_instrumentation(path, opts)
-        end
+module Sunspot
+  module SolrRailsInstrumentation
+    def send_and_receive(path, opts)
+      parameters = (opts[:params] || {})
+      parameters.merge!(opts[:data]) if opts[:data].is_a? Hash
+      payload = {:path => path, :parameters => parameters}
+      ActiveSupport::Notifications.instrument("request.rsolr", payload) do
+        Module.respond_to?(:prepend) ?  super(path,opts) : send_and_receive_without_as_instrumentation(path, opts)
       end
     end
   end

--- a/sunspot_rails/lib/sunspot/rails/solr_logging.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_logging.rb
@@ -2,56 +2,66 @@ module Sunspot
   module Rails
     module SolrLogging
 
-      class <<self
-        def included(base)
-          base.alias_method_chain :execute, :rails_logging
-        end
-      end
-
       COMMIT = %r{<commit/>}
 
-      def execute_with_rails_logging(client, request_context)
-        body = (request_context[:data]||"").dup
-        action = request_context[:path].capitalize
-        if body =~ COMMIT
-          action = "Commit"
-          body = ""
-        end
-
-        # Make request and log.
-        response = nil
-        begin
-          ms = Benchmark.ms do
-            response = execute_without_rails_logging(client, request_context)
+      class <<self
+        def included(base)
+          if Module.respond_to?(:prepend)
+            prepend Sunspot::SolrRailsLogger
+          else
+            include Sunspot::SolrRailsLogger
+            alias_method :execute_without_rails_logging, :execute
           end
-          log_name = 'Solr %s (%.1fms)' % [action, ms]
-          ::Rails.logger.debug(format_log_entry(log_name, body))
-        rescue Exception => e
-          log_name = 'Solr %s (Error)' % [action]
-          ::Rails.logger.error(format_log_entry(log_name, body))
-          raise e
-        end
-
-        response
-      end
-
-      private
-
-      def format_log_entry(message, dump = nil)
-        @colorize_logging ||= ::Rails.application.config.colorize_logging
-          
-        if @colorize_logging
-          message_color, dump_color = "4;32;1", "0;1"
-          log_entry = "  \e[#{message_color}m#{message}\e[0m   "
-          log_entry << "\e[#{dump_color}m%#{String === dump ? 's' : 'p'}\e[0m" % dump if dump
-          log_entry
-        else
-          "%s  %s" % [message, dump]
         end
       end
     end
   end
 end
+
+module Sunspot
+  module SolrRailsLogger
+    def execute(client, request_context)
+      body = (request_context[:data]||"").dup
+      action = request_context[:path].capitalize
+      if body =~ COMMIT
+        action = "Commit"
+        body = ""
+      end
+
+      # Make request and log.
+      response = nil
+      begin
+        ms = Benchmark.ms do
+          response = Module.respond_to?(:prepend) ?  super(client, request_context) : execute_without_rails_logging(client, request_context)
+        end
+
+        log_name = 'Solr %s (%.1fms)' % [action, ms]
+        ::Rails.logger.debug(format_log_entry(log_name, body))
+      rescue Exception => e
+        log_name = 'Solr %s (Error)' % [action]
+        ::Rails.logger.error(format_log_entry(log_name, body))
+        raise e
+      end
+
+      response
+    end
+
+    private
+
+    def format_log_entry(message, dump = nil)
+      @colorize_logging ||= ::Rails.application.config.colorize_logging
+      if @colorize_logging
+        message_color, dump_color = "4;32;1", "0;1"
+        log_entry = "  \e[#{message_color}m#{message}\e[0m   "
+        log_entry << "\e[#{dump_color}m%#{String === dump ? 's' : 'p'}\e[0m" % dump if dump
+        log_entry
+      else
+        "%s  %s" % [message, dump]
+      end
+    end
+  end
+end
+
 
 RSolr::Connection.module_eval do
   include Sunspot::Rails::SolrLogging

--- a/sunspot_rails/spec/solr_instrumentation_spec.rb
+++ b/sunspot_rails/spec/solr_instrumentation_spec.rb
@@ -1,0 +1,8 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+
+describe Sunspot::Rails::SolrInstrumentation do
+
+  it "should respond_to execute_with_rails_logging" do
+    expect(Sunspot::Rails::SolrInstrumentation.instance_methods.include?(:send_and_receive_without_as_instrumentation)).to eq !Module.respond_to?(:prepend)
+  end
+end

--- a/sunspot_rails/spec/solr_logging_spec.rb
+++ b/sunspot_rails/spec/solr_logging_spec.rb
@@ -1,0 +1,8 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+
+describe Sunspot::Rails::SolrLogging do
+
+  it "should respond_to execute_with_rails_logging" do
+    expect(Sunspot::Rails::SolrLogging.instance_methods.include?(:execute_without_rails_logging)).to eq !Module.respond_to?(:prepend)
+  end
+end


### PR DESCRIPTION
This PR removes alias_method_chain warning and is compatible with ruby 1.9.3