### PR TITLE
fix_pg_dependency

### DIFF
--- a/sunspot_rails/gemfiles/rails-3.0.0
+++ b/sunspot_rails/gemfiles/rails-3.0.0
@@ -13,7 +13,7 @@ group :test do
 end
 
 group :postgres do
-  gem 'pg'
+  gem 'pg', '~> 0.18.4'
 end
 
 group :sqlite do

--- a/sunspot_rails/gemfiles/rails-3.1.0
+++ b/sunspot_rails/gemfiles/rails-3.1.0
@@ -13,7 +13,7 @@ group :test do
 end
 
 group :postgres do
-  gem 'pg'
+  gem 'pg', '~> 0.18.4'
 end
 
 group :sqlite do

--- a/sunspot_rails/gemfiles/rails-3.2.0
+++ b/sunspot_rails/gemfiles/rails-3.2.0
@@ -13,7 +13,7 @@ group :test do
 end
 
 group :postgres do
-  gem 'pg'
+  gem 'pg', '~> 0.18.4'
 end
 
 group :sqlite do

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -17,7 +17,7 @@ group :test do
 end
 
 group :postgres do
-  gem 'pg'
+  gem 'pg', '~> 0.18.4'
 end
 
 group :sqlite do

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -16,7 +16,7 @@ group :test do
 end
 
 group :postgres do
-  gem 'pg'
+  gem 'pg', '~> 0.18.4'
 end
 
 group :sqlite do

--- a/sunspot_rails/gemfiles/rails-4.2.0
+++ b/sunspot_rails/gemfiles/rails-4.2.0
@@ -16,7 +16,7 @@ group :test do
 end
 
 group :postgres do
-  gem 'pg'
+  gem 'pg', '~> 0.18.4'
 end
 
 group :sqlite do


### PR DESCRIPTION
gem 'pg' have been updated to version 0.19 and minimum required ruby version is 2.0. This failed installing dependencies for rvm ruby version 1.9.3 in travis .Fixed the same in this PR.