### PR TITLE
add rails 5 and ruby 2.3 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.3.1
   # - rbx-2.0
   # - jruby
 
@@ -17,6 +18,7 @@ env:
   - GEM=sunspot_rails RAILS=4.0.0
   - GEM=sunspot_rails RAILS=4.1.0
   - GEM=sunspot_rails RAILS=4.2.0
+  - GEM=sunspot_rails RAILS=5.0
   - GEM=sunspot_solr
 
 # Limit the size of the matrix by only performing the most common builds
@@ -29,6 +31,8 @@ matrix:
       env: GEM=sunspot_rails RAILS=3.1.0
   allow_failures:
     # SQLITE fails to load correctly on Travis in Ruby 2.0
+    - rvm: 1.9.3
+      env: GEM=sunspot_rails RAILS=5.0
     - rvm: 2.0.0
       env: GEM=sunspot_rails RAILS=3.2.0
     - rvm: 2.0.0
@@ -37,6 +41,10 @@ matrix:
       env: GEM=sunspot_rails RAILS=4.1.0
     - rvm: 2.0.0
       env: GEM=sunspot_rails RAILS=4.2.0
+    - rvm: 2.0.0
+      env: GEM=sunspot_rails RAILS=5.0
+    - rvm: 2.1.0
+      env: GEM=sunspot_rails RAILS=5.0
 
 script:
   - ci/travis.sh

--- a/Rakefile
+++ b/Rakefile
@@ -57,5 +57,6 @@ task :default do
                 "GEM=sunspot_rails RAILS=3.2.0 ci/travis.sh",
                 "GEM=sunspot_rails RAILS=4.0.0 ci/travis.sh",
                 "GEM=sunspot_rails RAILS=4.1.0 ci/travis.sh",
-                "GEM=sunspot_rails RAILS=4.2.0 ci/travis.sh"].join(" && ")) ? 0 : 1
+                "GEM=sunspot_rails RAILS=4.2.0 ci/travis.sh",
+                "GEM=sunspot_rails RAILS=5.0 ci/travis.sh"].join(" && ")) ? 0 : 1
 end

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
-if SystemRubyVersion.new.to_s =~ /1.9/
+if RUBY_VERSION < '2.0'
   gem 'mime-types', '~> 2.99.0'
 end
 

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
-if SystemRubyVersion.new.to_s =~ /1.9/
+if RUBY_VERSION < '2.0'
   gem 'mime-types', '~> 2.99.0'
 end
 

--- a/sunspot_rails/gemfiles/rails-5.0
+++ b/sunspot_rails/gemfiles/rails-5.0
@@ -1,16 +1,12 @@
 source 'http://rubygems.org'
 
-gem 'rails', '~> 4.2.0'
-if RUBY_VERSION < '2.0'
-  gem 'mime-types', '~> 2.99.0'
-end
-
+gem 'rails', '~> 5.0'
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
+  gem 'protected_attributes_continued'
   gem 'rspec-rails', '~> 2.14.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end

--- a/sunspot_rails/spec/rails_template/config/initializers/rails_5_override.rb
+++ b/sunspot_rails/spec/rails_template/config/initializers/rails_5_override.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_record.belongs_to_required_by_default = false if Rails::VERSION::MAJOR == 5


### PR DESCRIPTION
Added ruby 2.3 and rails 5 to travis.yml.This PR is compatible with other versions as well.