### PR TITLE
remove_solr_rails_logger_body_length

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/solr_logging.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_logging.rb
@@ -17,7 +17,6 @@ module Sunspot
           action = "Commit"
           body = ""
         end
-        body = body[0, 800] + '...' if body.length > 800
 
         # Make request and log.
         response = nil


### PR DESCRIPTION
the default length of the body for solr rails log is set to 800 characters.Sometimes it's tough for developers  to view the entire log in different  environment and is not configurable.This PR gets rid of logger length