### PR TITLE
fix Rails 5 runtime deprecation warnings

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/request_lifecycle.rb
+++ b/sunspot_rails/lib/sunspot/rails/request_lifecycle.rb
@@ -20,8 +20,10 @@ module Sunspot #:nodoc:
           # this case, since after_filter uses the inheritable_attribute
           # structure, the already-loaded subclasses don't get the filters. So,
           # the below ensures that all loaded controllers have the filter.
+          callback = ::Rails::VERSION::MAJOR > 3 ? :after_action : :after_filter
+
           loaded_controllers.each do |controller|
-            controller.after_filter do
+            controller.send(callback) do
               if Sunspot::Rails.configuration.auto_commit_after_request?
                 Sunspot.commit_if_dirty
               elsif Sunspot::Rails.configuration.auto_commit_after_delete_request?

--- a/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_instrumentation.rb
@@ -4,9 +4,9 @@ module Sunspot
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :send_and_receive, :as_instrumentation
+        alias_method :send_and_receive_without_as_instrumentation, :send_and_receive
+        alias_method :send_and_receive, :send_and_receive_with_as_instrumentation
       end
-
 
       def send_and_receive_with_as_instrumentation(path, opts)
         parameters = (opts[:params] || {})

--- a/sunspot_rails/lib/sunspot/rails/solr_logging.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_logging.rb
@@ -2,12 +2,6 @@ module Sunspot
   module Rails
     module SolrLogging
 
-      class <<self
-        def included(base)
-          base.alias_method_chain :execute, :rails_logging
-        end
-      end
-
       COMMIT = %r{<commit/>}
 
       def execute_with_rails_logging(client, request_context)
@@ -55,4 +49,6 @@ end
 
 RSolr::Connection.module_eval do
   include Sunspot::Rails::SolrLogging
+  alias_method :execute_without_rails_logging, :execute
+  alias_method :execute, :execute_with_rails_logging
 end


### PR DESCRIPTION
This is a followup PR to #794, #799 and #813

It removes `alias_method_chain` warning while keeping code logic the same (without using `Module#prepend`) and replaces `after_filter` with `after_action` for Rails5

I have no Idea why was PR #813 closed, guessing because of complexity, but this one is quite simpler and it does not depend on ruby version

We have beed used a forked repo with these fixes in out production app for a couple months already, it would be nice to see it merged and released to rubygems. Im guessing Im not the only one deprecation warning hater here 😉