### PR TITLE
Fix "Field List" feature

### DIFF
--- a/sunspot/lib/sunspot/dsl/scope.rb
+++ b/sunspot/lib/sunspot/dsl/scope.rb
@@ -14,7 +14,8 @@ module Sunspot
 
       # Build a restriction to return only fields of the type in the results.
       def field_list(*args)
-        @query.add_field_list(Sunspot::Query::FieldList.new(args.flatten))
+        list = args.flatten.map { |field| @setup.field(field.to_sym).indexed_name.to_sym }
+        @query.add_field_list(Sunspot::Query::FieldList.new([:id] + list)) unless list.empty?
       end
 
       #

--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -93,6 +93,17 @@ module Sunspot
       !!@joined
     end
 
+    #
+    # Whether the field is stored or not.
+    #
+    # ==== Returns
+    #
+    # Boolean:: True if this field is a stored field
+    #
+    def stored?
+      !!@stored
+    end
+
     def hash
       indexed_name.hash
     end

--- a/sunspot/spec/api/query/dsl_spec.rb
+++ b/sunspot/spec/api/query/dsl_spec.rb
@@ -8,7 +8,7 @@ describe 'query DSL', :type => :query do
       query.with(:blog_id, @blog_id)
     end
     connection.should have_last_search_including(:fq, 'blog_id_i:1')
-    connection.should have_last_search_with(fl: [:blog_id, :title])
+    connection.should have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
   end
 
   it 'should allow field_list specified as arguments' do
@@ -17,7 +17,7 @@ describe 'query DSL', :type => :query do
       query.field_list :blog_id, :title
       query.with(:blog_id, @blog_id)
     end
-    connection.should have_last_search_with(fl: [:blog_id, :title])
+    connection.should have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
   end
 
   it 'should accept a block in the #new_search method' do

--- a/sunspot/spec/integration/field_lists_spec.rb
+++ b/sunspot/spec/integration/field_lists_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+describe 'fields lists' do
+  before :all do
+    Sunspot.remove_all
+    @post = Post.new(title: 'A Title', body: 'A Body', featured: true)
+    Sunspot.index!(@post)
+  end
+
+  let(:stored_field_names) do
+    (Sunspot::Setup.for(Post).fields + Sunspot::Setup.for(Post).all_text_fields)
+      .select { |f| f.stored? }
+      .map { |f| f.name }
+  end
+
+  it 'loads all stored fields by dafault' do
+    hit = Sunspot.search(Post).hits.first
+
+    stored_field_names.each do |field|
+      hit.stored(field).should_not be_nil
+    end
+  end
+
+  it 'loads only filtered fields' do
+    hit =
+      Sunspot.search(Post) do
+        field_list :title
+      end.hits.first
+
+    hit.stored(:title).should == @post.title
+
+    (stored_field_names - [:title]).each do |field|
+      hit.stored(field).should be_nil
+    end
+  end
+end


### PR DESCRIPTION
There is a `field_list` DSL in this gem currently, but it is not working. 

The thing is that it builds **fl** Solr query parameter inproperly, listing Sunspot field names (e.g. `blog_id`) instead of Solr field names (e.g. `blog_id_i`).
Also, it does not lists `id`, but it is required in order to build search hits.

This PR is intended to fix these issues