### PR TITLE
Fix sunspot:solr:stop & sunspot:solr:restart .

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -158,7 +158,7 @@ module Sunspot
       end
 
       def exec_in_solr_executable_directory(command)
-        FileUtils.cd(solr_executable_directory) { exec(*command) }
+        FileUtils.cd(solr_executable_directory) { system(*command) }
       end
 
       #

--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -158,7 +158,7 @@ module Sunspot
       end
 
       def exec_in_solr_executable_directory(command)
-        FileUtils.cd(solr_executable_directory) { system(*command) }
+        FileUtils.cd(solr_executable_directory) {  system(*command) }
       end
 
       #


### PR DESCRIPTION
Bugs: 
* Restart task doesn't actually work.
* Stop task won't print the line "Successfully stopped Solr ...".

Reason:
Use exec will replace the current process by running the given external command, which means `sunspot:solr:stop` task will return before `p 'Successfully stopped Solr ...'`, and `sunspot:solr:restart` will stopped after shuting down solr process.

Fix:
Change `exec` to `system` or other backstick things