### PR TITLE
add update_format option for rsolr connector

### DIFF
--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -258,7 +258,8 @@ module Sunspot
         self.class.connection_class.connect(:url          => config.solr.url,
                                             :read_timeout => config.solr.read_timeout,
                                             :open_timeout => config.solr.open_timeout,
-                                            :proxy        => config.solr.proxy)
+                                            :proxy        => config.solr.proxy,
+                                            :update_format => :xml)
     end
 
     def indexer


### PR DESCRIPTION
Force new RSolr 2.0.* client to use xml request format. 

See https://github.com/sunspot/sunspot/issues/856