### PR TITLE
Suppress `warning: method redefined` and `warning: mismatched indentations`

### DIFF
--- a/sunspot/lib/sunspot/dsl/scope.rb
+++ b/sunspot/lib/sunspot/dsl/scope.rb
@@ -199,25 +199,25 @@ module Sunspot
 
       def add_restriction(negated, *args)
         case args.first
-          when String, Symbol
-            raise ArgumentError if args.length > 2
-            field = @setup.field(args[0].to_sym)
-            if args.length > 1
-              value = args[1]
-              @scope.add_shorthand_restriction(negated, field, value)
-            else # NONE
-              DSL::Restriction.new(field, @scope, negated)
-            end
-          else # args are instances
-            @scope.add_restriction(
-              negated,
-              IdField.instance,
-              Sunspot::Query::Restriction::AnyOf,
-              args.flatten.map { |instance|
-                Sunspot::Adapters::InstanceAdapter.adapt(instance).index_id }
-            )
+        when String, Symbol
+          raise ArgumentError if args.length > 2
+          field = @setup.field(args[0].to_sym)
+          if args.length > 1
+            value = args[1]
+            @scope.add_shorthand_restriction(negated, field, value)
+          else # NONE
+            DSL::Restriction.new(field, @scope, negated)
           end
+        else # args are instances
+          @scope.add_restriction(
+            negated,
+            IdField.instance,
+            Sunspot::Query::Restriction::AnyOf,
+            args.flatten.map { |instance|
+              Sunspot::Adapters::InstanceAdapter.adapt(instance).index_id }
+          )
         end
+      end
     end
   end
 end

--- a/sunspot/lib/sunspot/search/abstract_search.rb
+++ b/sunspot/lib/sunspot/search/abstract_search.rb
@@ -16,7 +16,7 @@ module Sunspot
       # Retrieve all facet objects defined for this search, in order they were
       # defined. To retrieve an individual facet by name, use #facet()
       #
-      attr_reader :facets, :groups, :stats
+      attr_reader :facets, :groups
       attr_reader :query #:nodoc:
       attr_accessor :request_handler
 


### PR DESCRIPTION
This PR suppresses the following warning at sunspot/lib/sunspot/dsl/scope.rb and  sunspot/lib/sunspot/search/abstract_search.rb.

```
ruby -v                                                                                                                                 
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin16]

RUBYOPT=-w bundle exec rake

/Users/numata/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sunspot-2.2.7/lib/sunspot/search/abstract_search.rb:173: warning: method redefined; discarding old stats
/Users/numata/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sunspot-2.2.7/lib/sunspot/dsl/scope.rb:214: warning: mismatched indentations at 'end' with 'case' at 196
/Users/numata/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sunspot-2.2.7/lib/sunspot/dsl/scope.rb:215: warning: mismatched indentations at 'end' with 'def' at 195

```
