### PR TITLE
Fix travis error last comment and uninitialized constant r solr connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   # - jruby
 
 env:
-  - GEM=sunspot RSOLR=2.0.0.pre1
+  - GEM=sunspot RSOLR=1.1.2
   - GEM=sunspot
   - GEM=sunspot_rails RAILS=3.0.0
   - GEM=sunspot_rails RAILS=3.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
       env: GEM=sunspot_rails RAILS=3.1.0
   allow_failures:
     # SQLITE fails to load correctly on Travis in Ruby 2.0
-    - rvm: 1.9.3
-      env: GEM=sunspot_rails RAILS=5.0
     - rvm: 2.0.0
       env: GEM=sunspot_rails RAILS=3.2.0
     - rvm: 2.0.0
@@ -42,9 +40,14 @@ matrix:
       env: GEM=sunspot_rails RAILS=4.1.0
     - rvm: 2.0.0
       env: GEM=sunspot_rails RAILS=4.2.0
+    # rails 5.0 doesn't work with rspec-rails-2.14.2 undefined method 'alias_method_chain'
+    - rvm: 1.9.3
+      env: GEM=sunspot_rails RAILS=5.0
     - rvm: 2.0.0
       env: GEM=sunspot_rails RAILS=5.0
     - rvm: 2.1.0
+      env: GEM=sunspot_rails RAILS=5.0
+    - rvm: 2.3.1
       env: GEM=sunspot_rails RAILS=5.0
 
 script:

--- a/sunspot/Gemfile
+++ b/sunspot/Gemfile
@@ -5,7 +5,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../sunspot_solr', __FILE__)
 gemspec
 
 group :development do
-  gem 'rake'
+  gem 'rake', '~> 10.5'
 end
 
 gem 'rsolr', ENV['RSOLR'] if ENV['RSOLR']

--- a/sunspot_rails/gemfiles/rails-3.0.0
+++ b/sunspot_rails/gemfiles/rails-3.0.0
@@ -2,6 +2,10 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 3.0.0'
 
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/gemfiles/rails-3.1.0
+++ b/sunspot_rails/gemfiles/rails-3.1.0
@@ -2,6 +2,10 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 3.1.0'
 
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/gemfiles/rails-3.2.0
+++ b/sunspot_rails/gemfiles/rails-3.2.0
@@ -2,6 +2,10 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 3.2.0'
 
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -5,6 +5,10 @@ if RUBY_VERSION < '2.0'
   gem 'mime-types', '~> 2.99.0'
 end
 
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -5,6 +5,10 @@ if RUBY_VERSION < '2.0'
   gem 'mime-types', '~> 2.99.0'
 end
 
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/gemfiles/rails-4.2.0
+++ b/sunspot_rails/gemfiles/rails-4.2.0
@@ -5,6 +5,10 @@ if RUBY_VERSION < '2.0'
   gem 'mime-types', '~> 2.99.0'
 end
 
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/gemfiles/rails-5.0
+++ b/sunspot_rails/gemfiles/rails-5.0
@@ -1,6 +1,10 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 5.0'
+if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '~> 1.6.8'
+end
+
 gem 'sunspot', :path => File.expand_path('../../../sunspot', __FILE__)
 gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)

--- a/sunspot_rails/lib/sunspot/rails/solr_logging.rb
+++ b/sunspot_rails/lib/sunspot/rails/solr_logging.rb
@@ -4,7 +4,7 @@ module Sunspot
 
       COMMIT = %r{<commit/>}
 
-      def execute_with_rails_logging(client, request_context)
+      def execute_with_rails_logging(request_context)
         body = (request_context[:data]||"").dup
         action = request_context[:path].capitalize
         if body =~ COMMIT
@@ -16,7 +16,7 @@ module Sunspot
         response = nil
         begin
           ms = Benchmark.ms do
-            response = execute_without_rails_logging(client, request_context)
+            response = execute_without_rails_logging(request_context)
           end
           log_name = 'Solr %s (%.1fms)' % [action, ms]
           ::Rails.logger.debug(format_log_entry(log_name, body))
@@ -47,7 +47,7 @@ module Sunspot
   end
 end
 
-RSolr::Connection.module_eval do
+RSolr::Client.class_eval do
   include Sunspot::Rails::SolrLogging
   alias_method :execute_without_rails_logging, :execute
   alias_method :execute, :execute_with_rails_logging

--- a/sunspot_rails/spec/spec_helper.rb
+++ b/sunspot_rails/spec/spec_helper.rb
@@ -12,7 +12,10 @@ Bundler.require(ENV['DB'])
 require File.expand_path('config/environment', ENV['RAILS_ROOT'])
 require 'rspec/rails'
 require 'rspec/autorun'
-require File.join('sunspot', 'rails', 'solr_logging')
+
+if RSolr::VERSION >= '2'
+  require File.join('sunspot', 'rails', 'solr_logging')
+end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
1. RSolr 2.0 is released so bundler automatically installs the latest version. Test also against older RSolr version.
-> NoMethodError: undefined method `last_comment' for #Rake::Application:0x00000000f63650>
2. The method `last_comment` which is called from rspec-core was removed from rake 11. https://github.com/rspec/rspec-core/commit/8e723fc805e901ac4fa5483837138b175d411d6e 
-> /home/travis/build/sunspot/sunspot/sunspot_rails/lib/sunspot/rails/solr_logging.rb:50:in `<top (required)>': uninitialized constant RSolr::Connection (NameError)
3. Fix Gem::InstallError: nokogiri ~> 1.7 requires Ruby version >= 2.1.0.
4. allow_failures for rails 5.0 because it doesn't work with rspec-rails-2.14.2 undefined method 'alias_method_chain'