### PR TITLE
Fix travis update rspec

### DIFF
--- a/sunspot/.rspec
+++ b/sunspot/.rspec
@@ -1,0 +1,2 @@
+--color
+--format progress

--- a/sunspot/spec/api/adapters_spec.rb
+++ b/sunspot/spec/api/adapters_spec.rb
@@ -2,45 +2,45 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::Adapters::InstanceAdapter do
   it "finds adapter by superclass" do
-    Sunspot::Adapters::InstanceAdapter::for(Model).should be(AbstractModelInstanceAdapter)
+    expect(Sunspot::Adapters::InstanceAdapter::for(Model)).to be(AbstractModelInstanceAdapter)
   end
 
   it "finds adapter by mixin" do
-    Sunspot::Adapters::InstanceAdapter::for(MixModel).should be(MixInModelInstanceAdapter)
+    expect(Sunspot::Adapters::InstanceAdapter::for(MixModel)).to be(MixInModelInstanceAdapter)
   end
 
   it 'throws NoAdapterError if anonymous module passed in' do
-    lambda do
+    expect do
       Sunspot::Adapters::InstanceAdapter::for(Module.new)
-    end.should raise_error(Sunspot::NoAdapterError)
+    end.to raise_error(Sunspot::NoAdapterError)
   end
 
   it "registers adapters found by ancestor lookup with the descendant class" do
-    Sunspot::Adapters::InstanceAdapter::registered_adapter_for(UnseenModel).should be(nil)
+    expect(Sunspot::Adapters::InstanceAdapter::registered_adapter_for(UnseenModel)).to be(nil)
     Sunspot::Adapters::InstanceAdapter::for(UnseenModel)
-    Sunspot::Adapters::InstanceAdapter::registered_adapter_for(UnseenModel).should be(AbstractModelInstanceAdapter)
+    expect(Sunspot::Adapters::InstanceAdapter::registered_adapter_for(UnseenModel)).to be(AbstractModelInstanceAdapter)
   end
 end
 
 describe Sunspot::Adapters::DataAccessor do
   it "finds adapter by superclass" do
-    Sunspot::Adapters::DataAccessor::for(Model).should be(AbstractModelDataAccessor)
+    expect(Sunspot::Adapters::DataAccessor::for(Model)).to be(AbstractModelDataAccessor)
   end
 
   it "finds adapter by mixin" do
-    Sunspot::Adapters::DataAccessor::for(MixModel).should be(MixInModelDataAccessor)
+    expect(Sunspot::Adapters::DataAccessor::for(MixModel)).to be(MixInModelDataAccessor)
   end
 
   it 'throws NoAdapterError if anonymous module passed in' do
-    lambda do
+    expect do
       Sunspot::Adapters::DataAccessor::for(Module.new)
-    end.should raise_error(Sunspot::NoAdapterError)
+    end.to raise_error(Sunspot::NoAdapterError)
   end
 
   it "registers adapters found by ancestor lookup with the descendant class" do
-    Sunspot::Adapters::DataAccessor::registered_accessor_for(UnseenModel).should be(nil)
+    expect(Sunspot::Adapters::DataAccessor::registered_accessor_for(UnseenModel)).to be(nil)
     Sunspot::Adapters::DataAccessor::for(UnseenModel)
-    Sunspot::Adapters::DataAccessor::registered_accessor_for(UnseenModel).should be(AbstractModelDataAccessor)
+    expect(Sunspot::Adapters::DataAccessor::registered_accessor_for(UnseenModel)).to be(AbstractModelDataAccessor)
   end
 end
 
@@ -51,30 +51,30 @@ describe Sunspot::Adapters::Registry do
   let(:mixin_accessor){ Sunspot::Adapters::DataAccessor::for(MixModel) }
 
   it "registers and retrieves a data accessor for abstractclass" do
-      registry.retrieve(AbstractModel).should be_a(abstractclass_accessor)
+      expect(registry.retrieve(AbstractModel)).to be_a(abstractclass_accessor)
   end
 
   it "registers and retrieves a data accessor for superclass" do
-      registry.retrieve(Model).should be_a(superclass_accessor)
+      expect(registry.retrieve(Model)).to be_a(superclass_accessor)
   end
 
   it "registers and retrieves a data accessor for mixin" do
-      registry.retrieve(MixModel).should be_a(mixin_accessor)
+      expect(registry.retrieve(MixModel)).to be_a(mixin_accessor)
   end
 
   it "injects inherited attributes" do
-    AbstractModelDataAccessor.any_instance.stub(:inherited_attributes).and_return([:to_be_injected])
+    allow_any_instance_of(AbstractModelDataAccessor).to receive(:inherited_attributes).and_return([:to_be_injected])
     in_registry_data_accessor = registry.retrieve(AbstractModel)
     in_registry_data_accessor.to_be_injected = "value"
-    registry.retrieve(Model).to_be_injected.should == "value"
+    expect(registry.retrieve(Model).to_be_injected).to eq("value")
   end
 
   it "not overrides inherited attributes" do
-    AbstractModelDataAccessor.any_instance.stub(:inherited_attributes).and_return([:to_be_injected])
+    allow_any_instance_of(AbstractModelDataAccessor).to receive(:inherited_attributes).and_return([:to_be_injected])
     parent_data_accessor = registry.retrieve(AbstractModel)
     current_data_accessor = registry.retrieve(Model)
     parent_data_accessor.to_be_injected = "value"
     current_data_accessor.to_be_injected = "safe-value"
-    registry.retrieve(Model).to_be_injected.should == "safe-value"
+    expect(registry.retrieve(Model).to_be_injected).to eq("safe-value")
   end
 end

--- a/sunspot/spec/api/batcher_spec.rb
+++ b/sunspot/spec/api/batcher_spec.rb
@@ -2,12 +2,12 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::Batcher do
   it "includes Enumerable" do
-    described_class.should include Enumerable
+    expect(described_class).to include Enumerable
   end
 
   describe "#each" do
     let(:current) { [:foo, :bar] }
-    before { subject.stub(:current).and_return current }
+    before { allow(subject).to receive(:current).and_return current }
 
     it "iterates over current" do
       yielded_values = []
@@ -16,25 +16,25 @@ describe Sunspot::Batcher do
         yielded_values << value
       end
 
-      yielded_values.should eq current
+      expect(yielded_values).to eq current
     end
   end
 
   describe "adding to current batch" do
     it "#push pushes to current" do
       subject.push :foo
-      subject.current.should include :foo
+      expect(subject.current).to include :foo
     end
 
     it "#<< pushes to current" do
       subject.push :foo
-      subject.current.should include :foo
+      expect(subject.current).to include :foo
     end
 
     it "#concat concatinates on current batch" do
       subject << :foo
       subject.concat [:bar, :mix]
-      should include :foo, :bar, :mix
+      is_expected.to include :foo, :bar, :mix
     end
   end
 
@@ -46,7 +46,7 @@ describe Sunspot::Batcher do
       end
 
       it "is empty by default" do
-        subject.current.should be_empty
+        expect(subject.current).to be_empty
       end
     end
 
@@ -58,7 +58,7 @@ describe Sunspot::Batcher do
       end
 
       it "returns the same as last time" do
-        subject.current.should eq subject.current
+        expect(subject.current).to eq subject.current
       end
     end
   end
@@ -71,7 +71,7 @@ describe Sunspot::Batcher do
     it "changes current" do
       subject << :foo
       subject.start_new
-      should_not include :foo
+      is_expected.not_to include :foo
     end
   end
 
@@ -88,25 +88,25 @@ describe Sunspot::Batcher do
       it "changes current" do
         subject << :foo
         subject.end_current
-        should_not include :foo
+        is_expected.not_to include :foo
       end
 
       it "returns current" do
         subject << :foo
-        subject.end_current.should include :foo
+        expect(subject.end_current).to include :foo
       end
     end
   end
 
   describe "#batching?" do
     it "is false when depth is 0" do
-      subject.should_receive(:depth).and_return 0
-      should_not be_batching
+      expect(subject).to receive(:depth).and_return 0
+      is_expected.not_to be_batching
     end
 
     it "is true when depth is more than 0" do
-      subject.should_receive(:depth).and_return 1
-      should be_batching
+      expect(subject).to receive(:depth).and_return 1
+      is_expected.to be_batching
     end
   end
 end

--- a/sunspot/spec/api/binding_spec.rb
+++ b/sunspot/spec/api/binding_spec.rb
@@ -6,7 +6,7 @@ describe "DSL bindings" do
     session.search(Post) do
       value = test_method
     end
-    value.should == 'value'
+    expect(value).to eq('value')
   end
 
   it 'should give access to calling context\'s id method in search DSL' do
@@ -14,7 +14,7 @@ describe "DSL bindings" do
     session.search(Post) do
       value = id
     end
-    value.should == 16
+    expect(value).to eq(16)
   end
 
   it 'should give access to calling context\'s methods in nested DSL block' do
@@ -24,7 +24,7 @@ describe "DSL bindings" do
         value = test_method
       end
     end
-    value.should == 'value'
+    expect(value).to eq('value')
   end
 
   it 'should give access to calling context\'s methods in double-nested DSL block' do

--- a/sunspot/spec/api/class_set_spec.rb
+++ b/sunspot/spec/api/class_set_spec.rb
@@ -7,7 +7,7 @@ describe Sunspot::ClassSet do
     set = described_class.new
     set << class1 << class2
 
-    set.to_a.should =~ [class1, class2]
+    expect(set.to_a).to match_array([class1, class2])
   end
 
   it "replaces classes with the same name" do
@@ -15,10 +15,10 @@ describe Sunspot::ClassSet do
 
     class1 = double(:name => "Class1")
     set << class1
-    set.to_a.should == [class1]
+    expect(set.to_a).to eq([class1])
 
     class1_dup = double(:name => "Class1")
     set << class1_dup
-    set.to_a.should == [class1_dup]
+    expect(set.to_a).to eq([class1_dup])
   end
 end

--- a/sunspot/spec/api/hit_enumerable_spec.rb
+++ b/sunspot/spec/api/hit_enumerable_spec.rb
@@ -9,37 +9,37 @@ describe Sunspot::Search::HitEnumerable do
 
   describe "#hits" do
     before do
-      subject.stub(:solr_docs).and_return([{"id" => "Post 1", "score" => 3.14}])
-      subject.stub(:highlights_for)
+      allow(subject).to receive(:solr_docs).and_return([{"id" => "Post 1", "score" => 3.14}])
+      allow(subject).to receive(:highlights_for)
     end
 
     it "retrieves the raw Solr response from #solr_docs and constructs Hit objects" do
-      Sunspot::Search::Hit.should_receive(:new).
+      expect(Sunspot::Search::Hit).to receive(:new).
                            with({"id" => "Post 1", "score" => 3.14}, anything, anything)
 
       subject.hits
     end
 
     it "constructs Hit objects with highlights" do
-      subject.should_receive(:highlights_for).with({"id" => "Post 1", "score" => 3.14})
+      expect(subject).to receive(:highlights_for).with({"id" => "Post 1", "score" => 3.14})
 
       subject.hits
     end
 
     it "returns only verified hits if :verify => true is passed" do
-      Sunspot::Search::Hit.any_instance.stub(:result).and_return(nil)
+      allow_any_instance_of(Sunspot::Search::Hit).to receive(:result).and_return(nil)
 
-      subject.hits(:verify => true).should be_empty
+      expect(subject.hits(:verify => true)).to be_empty
     end
 
     it "returns an empty array if no results are available from Solr" do
-      subject.stub(:solr_docs).and_return(nil)
+      allow(subject).to receive(:solr_docs).and_return(nil)
 
-      subject.hits.should == []
+      expect(subject.hits).to eq([])
     end
 
     it "provides #populate_hits so that querying for one hit result will eager load the rest" do
-      Sunspot::Search::Hit.any_instance.should_receive(:result=)
+      expect_any_instance_of(Sunspot::Search::Hit).to receive(:result=)
 
       subject.populate_hits
     end

--- a/sunspot/spec/api/indexer/attributes_spec.rb
+++ b/sunspot/spec/api/indexer/attributes_spec.rb
@@ -4,151 +4,151 @@ require 'bigdecimal'
 describe 'indexing attribute fields', :type => :indexer do
   it 'should correctly index a stored string attribute field' do
     session.index(post(:title => 'A Title'))
-    connection.should have_add_with(:title_ss => 'A Title')
+    expect(connection).to have_add_with(:title_ss => 'A Title')
   end
 
   it 'should correctly index an integer attribute field' do
     session.index(post(:blog_id => 4))
-    connection.should have_add_with(:blog_id_i => '4')
+    expect(connection).to have_add_with(:blog_id_i => '4')
   end
 
   it 'should correctly index a long attribute field' do
     session.index(Namespaced::Comment.new(:hash => 2**30))
-    connection.should have_add_with(:hash_l => '1073741824')
+    expect(connection).to have_add_with(:hash_l => '1073741824')
   end
 
   it 'should correctly index a float attribute field' do
     session.index(post(:ratings_average => 2.23))
-    connection.should have_add_with(:average_rating_ft => '2.23')
+    expect(connection).to have_add_with(:average_rating_ft => '2.23')
   end
 
   it 'should correctly index a double attribute field' do
     session.index(Namespaced::Comment.new(:average_rating => 2.23))
-    connection.should have_add_with(:average_rating_e => '2.23')
+    expect(connection).to have_add_with(:average_rating_e => '2.23')
   end
 
   it 'should correctly index a trie integer attribute field' do
     session.index(Photo.new(:size => 104856))
-    connection.should have_add_with(:size_it => '104856')
+    expect(connection).to have_add_with(:size_it => '104856')
   end
 
   it 'should correctly index a trie float attribute field' do
     session.index(Photo.new(:average_rating => 2.23))
-    connection.should have_add_with(:average_rating_ft => '2.23')
+    expect(connection).to have_add_with(:average_rating_ft => '2.23')
   end
 
   it 'should correctly index a trie time attribute field' do
     session.index(Photo.new(:created_at => Time.parse('2009-12-16 15:00:00 -0400')))
-    connection.should have_add_with(:created_at_dt => '2009-12-16T19:00:00Z')
+    expect(connection).to have_add_with(:created_at_dt => '2009-12-16T19:00:00Z')
   end
 
   it 'should allow indexing by a multiple-value field' do
     session.index(post(:category_ids => [3, 14]))
-    connection.should have_add_with(:category_ids_im => ['3', '14'])
+    expect(connection).to have_add_with(:category_ids_im => ['3', '14'])
   end
 
   it 'should not index a single-value field with newlines as multiple' do
     session.index(post(:title => "Multi\nLine"))
-    connection.adds.last.first.field_by_name(:title_ss).value.should == "Multi\nLine"
+    expect(connection.adds.last.first.field_by_name(:title_ss).value).to eq("Multi\nLine")
   end
 
   it 'should correctly index a time field' do
     session.index(
       post(:published_at => Time.parse('1983-07-08 05:00:00 -0400'))
     )
-    connection.should have_add_with(:published_at_dt => '1983-07-08T09:00:00Z')
+    expect(connection).to have_add_with(:published_at_dt => '1983-07-08T09:00:00Z')
   end
 
   it 'should correctly index a time field that\'s after 32-bit Y2K' do
     session.index(
       post(:published_at => DateTime.parse('2050-07-08 05:00:00 -0400'))
     )
-    connection.should have_add_with(:published_at_dt => '2050-07-08T09:00:00Z')
+    expect(connection).to have_add_with(:published_at_dt => '2050-07-08T09:00:00Z')
   end
 
   it 'should correctly index a date field' do
     session.index(post(:expire_date => Date.new(2009, 07, 13)))
-    connection.should have_add_with(:expire_date_d => '2009-07-13T00:00:00Z')
+    expect(connection).to have_add_with(:expire_date_d => '2009-07-13T00:00:00Z')
   end
 
   it 'should correctly index a date range field' do
     session.index(post(:featured_for => Date.new(2009, 07, 13)..Date.new(2009, 12, 25)))
-    connection.should have_add_with(:featured_for_dr => '[2009-07-13T00:00:00Z TO 2009-12-25T00:00:00Z]')
+    expect(connection).to have_add_with(:featured_for_dr => '[2009-07-13T00:00:00Z TO 2009-12-25T00:00:00Z]')
   end
 
   it 'should correctly index a boolean field' do
     session.index(post(:featured => true))
-    connection.should have_add_with(:featured_bs => 'true')
+    expect(connection).to have_add_with(:featured_bs => 'true')
   end
 
   it 'should correctly index a false boolean field' do
     session.index(post(:featured => false))
-    connection.should have_add_with(:featured_bs => 'false')
+    expect(connection).to have_add_with(:featured_bs => 'false')
   end
 
   it 'should not index a nil boolean field' do
     session.index(post)
-    connection.should_not have_add_with(:featured_bs)
+    expect(connection).not_to have_add_with(:featured_bs)
   end
 
   it 'should index latitude and longitude as a pair' do
     session.index(post(:coordinates => Sunspot::Util::Coordinates.new(40.7, -73.5)))
-    connection.should have_add_with(:coordinates_s => 'dr5xx3nytvgs')
+    expect(connection).to have_add_with(:coordinates_s => 'dr5xx3nytvgs')
   end
 
   it 'should index latitude and longitude passed as non-Floats' do
     coordinates = Sunspot::Util::Coordinates.new(
       BigDecimal.new('40.7'), BigDecimal.new('-73.5'))
     session.index(post(:coordinates => coordinates))
-    connection.should have_add_with(:coordinates_s => 'dr5xx3nytvgs')
+    expect(connection).to have_add_with(:coordinates_s => 'dr5xx3nytvgs')
   end
 
   it 'should correctly index an attribute field with block access' do
     session.index(post(:title => 'The Blog Post'))
-    connection.should have_add_with(:sort_title_s => 'blog post')
+    expect(connection).to have_add_with(:sort_title_s => 'blog post')
   end
 
   it 'should correctly index an attribute field with instance-external block access' do
     session.index(post(:category_ids => [1, 2, 3]))
-    connection.should have_add_with(:primary_category_id_i => '1')
+    expect(connection).to have_add_with(:primary_category_id_i => '1')
   end
 
   it 'should correctly index a field that is defined on a superclass' do
     Sunspot.setup(SuperClass) { string :author_name }
     session.index(post(:author_name => 'Mat Brown'))
-    connection.should have_add_with(:author_name_s => 'Mat Brown')
+    expect(connection).to have_add_with(:author_name_s => 'Mat Brown')
   end
 
   it 'should throw a NoMethodError only if a nonexistent type is defined' do
-    lambda { Sunspot.setup(Post) { string :author_name }}.should_not raise_error
-    lambda { Sunspot.setup(Post) { bogus :journey }}.should raise_error(NoMethodError)
+    expect { Sunspot.setup(Post) { string :author_name }}.not_to raise_error
+    expect { Sunspot.setup(Post) { bogus :journey }}.to raise_error(NoMethodError)
   end
 
   it 'should throw a NoMethodError if a nonexistent field argument is passed' do
-    lambda { Sunspot.setup(Post) { string :author_name, :bogus => :argument }}.should raise_error(ArgumentError)
+    expect { Sunspot.setup(Post) { string :author_name, :bogus => :argument }}.to raise_error(ArgumentError)
   end
 
   it 'should throw an ArgumentError if single-value field tries to index multiple values' do
-    lambda do
+    expect do
       Sunspot.setup(Post) { string :author_name }
       session.index(post(:author_name => ['Mat Brown', 'Matthew Brown']))
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'should throw an ArgumentError if specifying more_like_this on type that does not support it' do
-    lambda do
+    expect do
       Sunspot.setup(Post) { integer :popularity, :more_like_this => true }
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'should use a specified field name when the :as option is set' do
     session.index(post(:title => 'A Title'))
-    connection.should have_add_with(:legacy_field_s => 'legacy A Title')
+    expect(connection).to have_add_with(:legacy_field_s => 'legacy A Title')
   end
 
   it 'should use a specified field name when the :as option is set for array values' do
     session.index(post(:title => 'Another Title'))
-    connection.should have_add_with(:legacy_array_field_sm => ['first string', 'second string'])
+    expect(connection).to have_add_with(:legacy_array_field_sm => ['first string', 'second string'])
  	end
 end
 

--- a/sunspot/spec/api/indexer/batch_spec.rb
+++ b/sunspot/spec/api/indexer/batch_spec.rb
@@ -9,7 +9,7 @@ describe 'batch indexing', :type => :indexer do
         session.index(post)
       end
     end
-    connection.adds.length.should == 1
+    expect(connection.adds.length).to eq(1)
   end
 
   it 'should add all batched adds' do
@@ -19,8 +19,9 @@ describe 'batch indexing', :type => :indexer do
       end
     end
     add = connection.adds.last
-    connection.adds.first.map { |add| add.field_by_name(:id).value }.should ==
+    expect(connection.adds.first.map { |add| add.field_by_name(:id).value }).to eq(
       posts.map { |post| "Post #{post.id}" }
+    )
   end
 
   it 'should not index changes to models that happen after index call' do
@@ -29,13 +30,13 @@ describe 'batch indexing', :type => :indexer do
       session.index(post)
       post.title = 'Title'
     end
-    connection.adds.first.first.field_by_name(:title_ss).should be_nil
+    expect(connection.adds.first.first.field_by_name(:title_ss)).to be_nil
   end
 
   it 'should batch an add and a delete' do
-    pending 'batching all operations'
-    connection.should_not_receive(:add)
-    connection.should_not_receive(:remove)
+    skip 'batching all operations'
+    expect(connection).not_to receive(:add)
+    expect(connection).not_to receive(:remove)
     session.batch do
       session.index(posts[0])
       session.remove(posts[1])
@@ -64,7 +65,7 @@ describe 'batch indexing', :type => :indexer do
       a_nested_batch
       nested_batches_adds = connection.adds
 
-      nested_batches_adds.first.first.field_by_name(:title_ss).value.should eq(
+      expect(nested_batches_adds.first.first.field_by_name(:title_ss).value).to eq(
         two_sets_of_batches_adds.first.first.field_by_name(:title_ss).value
       )
     end

--- a/sunspot/spec/api/indexer/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/indexer/dynamic_fields_spec.rb
@@ -3,40 +3,40 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe 'indexing dynamic fields' do
   it 'indexes string data' do
     session.index(post(:custom_string => { :test => 'string' }))
-    connection.should have_add_with(:"custom_string:test_ss" => 'string')
+    expect(connection).to have_add_with(:"custom_string:test_ss" => 'string')
   end
 
   it 'indexes integer data with virtual accessor' do
     session.index(post(:category_ids => [1, 2]))
-    connection.should have_add_with(:"custom_integer:1_i" => '1', :"custom_integer:2_i" => '1')
+    expect(connection).to have_add_with(:"custom_integer:1_i" => '1', :"custom_integer:2_i" => '1')
   end
 
   it 'indexes float data' do
     session.index(post(:custom_fl => { :test => 1.5 }))
-    connection.should have_add_with(:"custom_float:test_fm" => '1.5')
+    expect(connection).to have_add_with(:"custom_float:test_fm" => '1.5')
   end
 
   it 'indexes time data' do
     session.index(post(:custom_time => { :test => Time.parse('2009-05-18 18:05:00 -0400') }))
-    connection.should have_add_with(:"custom_time:test_d" => '2009-05-18T22:05:00Z')
+    expect(connection).to have_add_with(:"custom_time:test_d" => '2009-05-18T22:05:00Z')
   end
 
   it 'indexes boolean data' do
     session.index(post(:custom_boolean => { :test => false }))
-    connection.should have_add_with(:"custom_boolean:test_b" => 'false')
+    expect(connection).to have_add_with(:"custom_boolean:test_b" => 'false')
   end
 
   it 'indexes multiple values for a field' do
     session.index(post(:custom_fl => { :test => [1.0, 2.1, 3.2] }))
-    connection.should have_add_with(:"custom_float:test_fm" => %w(1.0 2.1 3.2))
+    expect(connection).to have_add_with(:"custom_float:test_fm" => %w(1.0 2.1 3.2))
   end
 
   it 'should throw a NoMethodError if dynamic text field defined' do
-    lambda do
+    expect do
       Sunspot.setup(Post) do
         dynamic_text :custom_text
       end
-    end.should raise_error(NoMethodError)
+    end.to raise_error(NoMethodError)
   end
 end
 

--- a/sunspot/spec/api/indexer/fixed_fields_spec.rb
+++ b/sunspot/spec/api/indexer/fixed_fields_spec.rb
@@ -3,28 +3,28 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe 'indexing fixed fields', :type => :indexer do
   it 'should index id' do
     session.index post
-    connection.should have_add_with(:id => "Post #{post.id}")
+    expect(connection).to have_add_with(:id => "Post #{post.id}")
   end
 
   it 'should index type' do
     session.index post
-    connection.should have_add_with(:type => ['Post', 'SuperClass', 'MockRecord'])
+    expect(connection).to have_add_with(:type => ['Post', 'SuperClass', 'MockRecord'])
   end
 
   it 'should not index join fields' do
     session.index PhotoContainer.new
-    connection.should_not have_add_with(:photo_caption => 'blah')
+    expect(connection).not_to have_add_with(:photo_caption => 'blah')
   end
 
   it 'should index class name' do
     session.index post
-    connection.should have_add_with(:class_name => 'Post')
+    expect(connection).to have_add_with(:class_name => 'Post')
   end
 
   it 'should index the array of objects supplied' do
     posts = Array.new(2) { Post.new }
     session.index posts
-    connection.should have_add_with(
+    expect(connection).to have_add_with(
       { :id => "Post #{posts.first.id}" },
       { :id => "Post #{posts.last.id}" }
     )
@@ -33,7 +33,7 @@ describe 'indexing fixed fields', :type => :indexer do
   it 'should index an array containing more than one type of object' do
     post1, comment, post2 = objects = [Post.new, Namespaced::Comment.new, Post.new]
     session.index objects
-    connection.should have_add_with(
+    expect(connection).to have_add_with(
       { :id => "Post #{post1.id}", :type => ['Post', 'SuperClass', 'MockRecord'] },
       { :id => "Namespaced::Comment #{comment.id}", :type => ['Namespaced::Comment', 'MockRecord'] },
       { :id => "Post #{post2.id}", :type => ['Post', 'SuperClass', 'MockRecord'] }
@@ -41,22 +41,22 @@ describe 'indexing fixed fields', :type => :indexer do
   end
 
   it 'commits immediately after index! called' do
-    connection.should_receive(:add).ordered
-    connection.should_receive(:commit).ordered
+    expect(connection).to receive(:add).ordered
+    expect(connection).to receive(:commit).ordered
     session.index!(post)
   end
 
   it 'raises an ArgumentError if an attempt is made to index an object that has no configuration' do
-    lambda { session.index(Blog.new) }.should raise_error(Sunspot::NoSetupError)
+    expect { session.index(Blog.new) }.to raise_error(Sunspot::NoSetupError)
   end
 
   it 'raises a NoAdapterError if class without adapter is indexed' do
-    lambda { session.index(User.new) }.should raise_error(Sunspot::NoAdapterError)
+    expect { session.index(User.new) }.to raise_error(Sunspot::NoAdapterError)
   end
 
   it 'raises an ArgumentError if a non-word character is included in the field name' do
-    lambda do
+    expect do
       Sunspot.setup(Post) { string :"bad name" }
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 end

--- a/sunspot/spec/api/indexer/fulltext_spec.rb
+++ b/sunspot/spec/api/indexer/fulltext_spec.rb
@@ -3,41 +3,41 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe 'indexing fulltext fields' do
   it 'indexes text field' do
     session.index(post(:title => 'A Title'))
-    connection.should have_add_with(:title_text => 'A Title')
+    expect(connection).to have_add_with(:title_text => 'A Title')
   end
 
   it 'indexes stored text field' do
     session.index(post(:body => 'Test body'))
-    connection.should have_add_with(:body_textsv => 'Test body')
+    expect(connection).to have_add_with(:body_textsv => 'Test body')
   end
 
   it 'indexes text field with boost' do
     session.index(post(:title => 'A Title'))
-    connection.adds.last.first.field_by_name(:title_text).attrs[:boost].should == 2
+    expect(connection.adds.last.first.field_by_name(:title_text).attrs[:boost]).to eq(2)
   end
 
   it 'indexes multiple values for a text field' do
     session.index(post(:body => %w(some title)))
-    connection.should have_add_with(:body_textsv => %w(some title))
+    expect(connection).to have_add_with(:body_textsv => %w(some title))
   end
 
   it 'indexes text via a block accessor' do
     session.index(post(:title => 'backwards'))
-    connection.should have_add_with(:backwards_title_text => 'sdrawkcab')
+    expect(connection).to have_add_with(:backwards_title_text => 'sdrawkcab')
   end
 
   it 'indexes document level boost using block' do
     session.index(post(:ratings_average => 4.0))
-    connection.adds.last.first.attrs[:boost].should == 1.25
+    expect(connection.adds.last.first.attrs[:boost]).to eq(1.25)
   end
 
   it 'indexes document level boost using attribute' do
     session.index(Namespaced::Comment.new(:boost => 1.5))
-    connection.adds.last.first.attrs[:boost].should == 1.5
+    expect(connection.adds.last.first.attrs[:boost]).to eq(1.5)
   end
 
   it 'indexes document level boost defined statically' do
     session.index(Photo.new)
-    connection.adds.last.first.attrs[:boost].should == 0.75
+    expect(connection.adds.last.first.attrs[:boost]).to eq(0.75)
   end
 end

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -3,54 +3,54 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe 'document removal', :type => :indexer do
   it 'removes an object from the index' do
     session.remove(post)
-    connection.should have_delete("Post #{post.id}")
+    expect(connection).to have_delete("Post #{post.id}")
   end
 
   it 'removes an object by type and id' do
     session.remove_by_id(Post, 1)
-    connection.should have_delete('Post 1')
+    expect(connection).to have_delete('Post 1')
   end
 
   it 'removes an object by type and ids' do
     session.remove_by_id(Post, 1, 2)
-    connection.should have_delete('Post 1', 'Post 2')
+    expect(connection).to have_delete('Post 1', 'Post 2')
   end
 
   it 'removes an object by type and ids array' do
     session.remove_by_id(Post, [1, 2])
-    connection.should have_delete('Post 1', 'Post 2')
+    expect(connection).to have_delete('Post 1', 'Post 2')
   end
 
   it 'removes an object by type and ids and immediately commits' do
-    connection.should_receive(:delete_by_id).with(['Post 1', 'Post 2', 'Post 3']).ordered
-    connection.should_receive(:commit).ordered
+    expect(connection).to receive(:delete_by_id).with(['Post 1', 'Post 2', 'Post 3']).ordered
+    expect(connection).to receive(:commit).ordered
     session.remove_by_id!(Post, 1, 2, 3)
   end
 
   it 'removes an object from the index and immediately commits' do
-    connection.should_receive(:delete_by_id).ordered
-    connection.should_receive(:commit).ordered
+    expect(connection).to receive(:delete_by_id).ordered
+    expect(connection).to receive(:commit).ordered
     session.remove!(post)
   end
 
   it 'removes everything from the index' do
     session.remove_all
-    connection.should have_delete_by_query("*:*")
+    expect(connection).to have_delete_by_query("*:*")
   end
 
   it 'removes everything from the index and immediately commits' do
-    connection.should_receive(:delete_by_query).ordered
-    connection.should_receive(:commit).ordered
+    expect(connection).to receive(:delete_by_query).ordered
+    expect(connection).to receive(:commit).ordered
     session.remove_all!
   end
 
   it 'removes everything of a given class from the index' do
     session.remove_all(Post)
-    connection.should have_delete_by_query("type:Post")
+    expect(connection).to have_delete_by_query("type:Post")
   end
 
   it 'correctly escapes namespaced classes when removing everything from the index' do
-    connection.should_receive(:delete_by_query).with('type:Namespaced\:\:Comment')
+    expect(connection).to receive(:delete_by_query).with('type:Namespaced\:\:Comment')
     session.remove_all(Namespaced::Comment)
   end
 
@@ -58,6 +58,6 @@ describe 'document removal', :type => :indexer do
     session.remove(Post) do
       with(:title, 'monkeys')
     end
-    connection.should have_delete_by_query("(type:Post AND title_ss:monkeys)")
+    expect(connection).to have_delete_by_query("(type:Post AND title_ss:monkeys)")
   end
 end

--- a/sunspot/spec/api/indexer_spec.rb
+++ b/sunspot/spec/api/indexer_spec.rb
@@ -7,8 +7,8 @@ describe 'indexer', :type => :indexer do
     Object.class_eval { remove_const(:ReloadableClass) }
     Object::ReloadableClass = Class.new(MockRecord)
     Sunspot.setup(ReloadableClass) {}
-    lambda do
+    expect do
       Sunspot.search(ReloadableClass) { with(:title, 'title') }
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 end

--- a/sunspot/spec/api/query/advanced_manipulation_examples.rb
+++ b/sunspot/spec/api/query/advanced_manipulation_examples.rb
@@ -12,11 +12,11 @@ shared_examples_for "query with advanced manipulation" do
     end
 
     it "modifies existing param" do
-      connection.should have_last_search_with(:rows  => 40)
+      expect(connection).to have_last_search_with(:rows  => 40)
     end
 
     it "adds new param" do
-      connection.should have_last_search_with(:qt => 'complicated')
+      expect(connection).to have_last_search_with(:qt => 'complicated')
     end
   end
 
@@ -29,7 +29,7 @@ shared_examples_for "query with advanced manipulation" do
     end
 
     it 'should use specified request handler' do
-      connection.should have_last_search_with({})
+      expect(connection).to have_last_search_with({})
     end
   end
 end

--- a/sunspot/spec/api/query/connectives_examples.rb
+++ b/sunspot/spec/api/query/connectives_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for "query with connective scope" do
         with :blog_id, 2
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(category_ids_im:1 OR blog_id_i:2)'
     )
   end
@@ -21,7 +21,7 @@ shared_examples_for "query with connective scope" do
         end
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq,
       '(blog_id_i:2 OR (category_ids_im:1 AND average_rating_ft:{3\.0 TO *}))'
     )
@@ -37,7 +37,7 @@ shared_examples_for "query with connective scope" do
         end
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(category_ids_im:1 OR (-average_rating_ft:{3\.0 TO *} AND blog_id_i:1))'
     )
   end
@@ -49,7 +49,7 @@ shared_examples_for "query with connective scope" do
         with :category_ids, 1
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, 'blog_id_i:2', 'category_ids_im:1'
     )
   end
@@ -61,7 +61,7 @@ shared_examples_for "query with connective scope" do
         without(:average_rating).greater_than(3.0)
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '-(-category_ids_im:1 AND average_rating_ft:{3\.0 TO *})'
     )
   end
@@ -79,7 +79,7 @@ shared_examples_for "query with connective scope" do
         end
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '-(title_ss:Yes AND -(blog_id_i:1 AND -(-category_ids_im:4 AND average_rating_ft:2\.0)))'
     )
   end
@@ -96,7 +96,7 @@ shared_examples_for "query with connective scope" do
         end
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(title_ss:Yes OR (blog_id_i:1 AND -(-category_ids_im:4 AND average_rating_ft:2\.0)))'
     )
   end
@@ -123,7 +123,7 @@ shared_examples_for "query with connective scope" do
         end
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(title_ss:Yes OR blog_id_i:1 OR category_ids_im:4)'
     )
   end
@@ -136,7 +136,7 @@ shared_examples_for "query with connective scope" do
         with(:category_ids, 1)
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, "-(id:(Post\\ #{post.id}) AND -category_ids_im:1)"
     )
   end
@@ -148,7 +148,7 @@ shared_examples_for "query with connective scope" do
         with(:average_rating).greater_than(3.0)
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '-(average_rating_ft:[* TO *] AND -average_rating_ft:{3\.0 TO *})'
     )
   end
@@ -161,7 +161,7 @@ shared_examples_for "query with connective scope" do
         with(:average_rating).greater_than(3.0)
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, "(id:(Post\\ #{post.id}) OR average_rating_ft:{3\\.0 TO *})"
     )
   end
@@ -175,7 +175,7 @@ shared_examples_for "query with connective scope" do
         with(:blog_id, 1)
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(title_text:test* OR blog_id_i:1)'
     )
   end
@@ -184,7 +184,7 @@ shared_examples_for "query with connective scope" do
     search do
       any_of {}
     end
-    connection.should_not have_last_search_including(:fq, '')
+    expect(connection).not_to have_last_search_including(:fq, '')
   end
 
   it 'creates a conjunction of in_radius queries' do
@@ -194,7 +194,7 @@ shared_examples_for "query with connective scope" do
         with(:coordinates_new).in_radius(42, 56, 50)
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(_query_:"{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}" OR _query_:"{!geofilt sfield=coordinates_new_ll pt=42,56 d=50}")'
     )
   end
@@ -206,7 +206,7 @@ shared_examples_for "query with connective scope" do
         with(:coordinates_new).in_bounding_box([42, 56], [43, 58])
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])'
     )
   end

--- a/sunspot/spec/api/query/dsl_spec.rb
+++ b/sunspot/spec/api/query/dsl_spec.rb
@@ -7,8 +7,8 @@ describe 'query DSL', :type => :query do
       query.field_list [:blog_id, :title]
       query.with(:blog_id, @blog_id)
     end
-    connection.should have_last_search_including(:fq, 'blog_id_i:1')
-    connection.should have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
+    expect(connection).to have_last_search_including(:fq, 'blog_id_i:1')
+    expect(connection).to have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
   end
 
   it 'should allow field_list specified as arguments' do
@@ -17,12 +17,12 @@ describe 'query DSL', :type => :query do
       query.field_list :blog_id, :title
       query.with(:blog_id, @blog_id)
     end
-    connection.should have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
+    expect(connection).to have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
   end
 
   it 'should accept a block in the #new_search method' do
     search = session.new_search(Post) { with(:blog_id, 1) }
     search.execute
-    connection.should have_last_search_including(:fq, 'blog_id_i:1')
+    expect(connection).to have_last_search_including(:fq, 'blog_id_i:1')
   end
 end

--- a/sunspot/spec/api/query/dynamic_fields_examples.rb
+++ b/sunspot/spec/api/query/dynamic_fields_examples.rb
@@ -5,7 +5,7 @@ shared_examples_for "query with dynamic field support" do
         with :test, 'string'
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_string\:test_ss:string')
+    expect(connection).to have_last_search_including(:fq, 'custom_string\:test_ss:string')
   end
 
   it 'restricts by dynamic integer field with less than restriction' do
@@ -14,7 +14,7 @@ shared_examples_for "query with dynamic field support" do
         with(:test).less_than(1)
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_integer\:test_i:{* TO 1}')
+    expect(connection).to have_last_search_including(:fq, 'custom_integer\:test_i:{* TO 1}')
   end
 
   it 'restricts by dynamic float field with between restriction' do
@@ -23,7 +23,7 @@ shared_examples_for "query with dynamic field support" do
         with(:test).between(2.2..3.3)
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_float\:test_fm:[2\.2 TO 3\.3]')
+    expect(connection).to have_last_search_including(:fq, 'custom_float\:test_fm:[2\.2 TO 3\.3]')
   end
 
   it 'restricts by dynamic time field with any of restriction' do
@@ -33,7 +33,7 @@ shared_examples_for "query with dynamic field support" do
                             Time.parse('2009-02-13 18:00:00 UTC')])
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_time\:test_d:(2009\-02\-10T14\:00\:00Z OR 2009\-02\-13T18\:00\:00Z)')
+    expect(connection).to have_last_search_including(:fq, 'custom_time\:test_d:(2009\-02\-10T14\:00\:00Z OR 2009\-02\-13T18\:00\:00Z)')
   end
 
   it 'restricts by dynamic boolean field with equality restriction' do
@@ -42,7 +42,7 @@ shared_examples_for "query with dynamic field support" do
         with :test, false
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_boolean\:test_b:false')
+    expect(connection).to have_last_search_including(:fq, 'custom_boolean\:test_b:false')
   end
 
   it 'negates a dynamic field restriction' do
@@ -51,7 +51,7 @@ shared_examples_for "query with dynamic field support" do
         without :test, 'foo'
       end
     end
-    connection.should have_last_search_including(:fq, '-custom_string\:test_ss:foo')
+    expect(connection).to have_last_search_including(:fq, '-custom_string\:test_ss:foo')
   end
 
   it 'scopes by a dynamic field inside a disjunction' do
@@ -63,7 +63,7 @@ shared_examples_for "query with dynamic field support" do
         with :title, 'bar'
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, '(custom_string\:test_ss:foo OR title_ss:bar)'
     )
   end
@@ -74,7 +74,7 @@ shared_examples_for "query with dynamic field support" do
         order_by :test, :desc
       end
     end
-    connection.should have_last_search_with(:sort => 'custom_integer:test_i desc')
+    expect(connection).to have_last_search_with(:sort => 'custom_integer:test_i desc')
   end
 
   it 'orders by a dynamic field and static field, with given precedence' do
@@ -84,25 +84,25 @@ shared_examples_for "query with dynamic field support" do
       end
       order_by :sort_title, :asc
     end
-    connection.should have_last_search_with(:sort => 'custom_integer:test_i desc, sort_title_s asc')
+    expect(connection).to have_last_search_with(:sort => 'custom_integer:test_i desc, sort_title_s asc')
   end
 
   it 'raises an UnrecognizedFieldError if an unknown dynamic field is searched by' do
-    lambda do
+    expect do
       search do
         dynamic(:bogus) { with :some, 'value' }
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'raises a NoMethodError if pagination is attempted in a dynamic query' do
-    lambda do
+    expect do
       search do
         dynamic :custom_string do
           paginate :page => 3, :per_page => 10
         end
       end
-    end.should raise_error(NoMethodError)
+    end.to raise_error(NoMethodError)
   end
 
   it 'requests field facet on dynamic field' do
@@ -111,7 +111,7 @@ shared_examples_for "query with dynamic field support" do
         facet(:test)
       end
     end
-    connection.should have_last_search_including(:"facet.field", 'custom_string:test_ss')
+    expect(connection).to have_last_search_including(:"facet.field", 'custom_string:test_ss')
   end
 
   it 'requests named field facet on dynamic field' do
@@ -120,7 +120,7 @@ shared_examples_for "query with dynamic field support" do
         facet(:test, :name => :bogus)
       end
     end
-    connection.should have_last_search_including(:"facet.field", '{!key=bogus}custom_string:test_ss')
+    expect(connection).to have_last_search_including(:"facet.field", '{!key=bogus}custom_string:test_ss')
   end
 
   it 'requests query facet with internal dynamic field' do
@@ -133,7 +133,7 @@ shared_examples_for "query with dynamic field support" do
         end
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"facet.query" => 'custom_string\:test_ss:foo'
     )
   end
@@ -148,7 +148,7 @@ shared_examples_for "query with dynamic field support" do
         end
       end
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :"facet.query",
       'custom_string\:test_ss:foo'
     )
@@ -160,6 +160,6 @@ shared_examples_for "query with dynamic field support" do
         with(:test, 1.23)
       end
     end
-    connection.should have_last_search_including(:fq, 'custom_float\\:test_fm:1\\.23')
+    expect(connection).to have_last_search_including(:fq, 'custom_float\\:test_fm:1\\.23')
   end
 end

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -2,114 +2,114 @@ shared_examples_for "facetable query" do
   describe 'on fields' do
     it 'does not turn faceting on if no facet requested' do
       search
-      connection.should_not have_last_search_with('facet')
+      expect(connection).not_to have_last_search_with('facet')
     end
 
     it 'turns faceting on if facet is requested' do
       search do
         facet :category_ids
       end
-      connection.should have_last_search_with(:facet => 'true')
+      expect(connection).to have_last_search_with(:facet => 'true')
     end
 
     it 'requests single field facet' do
       search do
         facet :category_ids
       end
-      connection.should have_last_search_with(:"facet.field" => %w(category_ids_im))
+      expect(connection).to have_last_search_with(:"facet.field" => %w(category_ids_im))
     end
 
     it 'requests multiple field facets' do
       search do
         facet :category_ids, :blog_id
       end
-      connection.should have_last_search_with(:"facet.field" => %w(category_ids_im blog_id_i))
+      expect(connection).to have_last_search_with(:"facet.field" => %w(category_ids_im blog_id_i))
     end
 
     it 'sets facet sort by count' do
       search do
         facet :category_ids, :sort => :count
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.sort" => 'true')
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.sort" => 'true')
     end
 
     it 'sets facet sort by index' do
       search do
         facet :category_ids, :sort => :index
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.sort" => 'false')
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.sort" => 'false')
     end
 
     it 'raises ArgumentError if bogus facet sort provided' do
-      lambda do
+      expect do
         search do
           facet :category_ids, :sort => :sideways
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it 'sets the facet limit' do
       search do
         facet :category_ids, :limit => 10
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.limit" => 10)
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.limit" => 10)
     end
     
     it 'sets the facet offset' do
       search do
         facet :category_ids, :offset => 10
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.offset" => 10)
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.offset" => 10)
     end
 
     it 'sets the facet minimum count' do
       search do
         facet :category_ids, :minimum_count => 5
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.mincount" => 5)
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.mincount" => 5)
     end
 
     it 'sets the facet minimum count to zero if zeros are allowed' do
       search do
         facet :category_ids, :zeros => true
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.mincount" => 0)
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.mincount" => 0)
     end
 
     it 'sets the facet minimum count to one by default' do
       search do
         facet :category_ids
       end
-      connection.should have_last_search_with(:"f.category_ids_im.facet.mincount" => 1)
+      expect(connection).to have_last_search_with(:"f.category_ids_im.facet.mincount" => 1)
     end
 
     it 'sets the facet prefix' do
       search do
         facet :title, :prefix => 'Test'
       end
-      connection.should have_last_search_with(:"f.title_ss.facet.prefix" => 'Test')
+      expect(connection).to have_last_search_with(:"f.title_ss.facet.prefix" => 'Test')
     end
     
     it 'sends a query facet for :any extra' do
       search do
         facet :category_ids, :extra => :any
       end
-      connection.should have_last_search_with(:"facet.query" => "category_ids_im:[* TO *]")
+      expect(connection).to have_last_search_with(:"facet.query" => "category_ids_im:[* TO *]")
     end
 
     it 'sends a query facet for :none extra' do
       search do
         facet :category_ids, :extra => :none
       end
-      connection.should have_last_search_with(:"facet.query" => "-category_ids_im:[* TO *]")
+      expect(connection).to have_last_search_with(:"facet.query" => "-category_ids_im:[* TO *]")
     end
 
     it 'raises an ArgumentError if bogus extra is passed' do
-      lambda do
+      expect do
         search do
           facet :category_ids, :extra => :bogus
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it 'tags and excludes a geofilt in a field facet' do
@@ -126,7 +126,7 @@ shared_examples_for "facetable query" do
       else
         filter_tag = get_filter_tag('{!geofilt sfield=coordinates_new_ll pt=32,-68 d=1}')
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => "{!ex=#{filter_tag}}_query_:\"{!geofilt sfield=coordinates_new_ll pt=32,-68 d=10}\""
       )
     end
@@ -137,7 +137,7 @@ shared_examples_for "facetable query" do
         facet(:blog_id, :exclude => blog_filter)
       end
       filter_tag = get_filter_tag('blog_id_i:1')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.field" => %W({!ex=#{filter_tag}}blog_id_i)
       )
     end
@@ -151,7 +151,7 @@ shared_examples_for "facetable query" do
         facet(:blog_id, :exclude => blog_filter)
       end
       filter_tag = get_filter_tag('(blog_id_i:1 OR blog_id_i:2)')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.field" => %W({!ex=#{filter_tag}}blog_id_i)
       )
     end
@@ -165,7 +165,7 @@ shared_examples_for "facetable query" do
       filter_tags = %w(blog_id_i:1 category_ids_im:2).map do |phrase|
         get_filter_tag(phrase)
       end.join(',')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.field" => %W({!ex=#{filter_tags}}blog_id_i)
       )
     end
@@ -174,39 +174,39 @@ shared_examples_for "facetable query" do
       search do
         with(:blog_id, 1)
       end
-      connection.should have_last_search_including(:fq, "blog_id_i:1")
+      expect(connection).to have_last_search_including(:fq, "blog_id_i:1")
     end
 
     it 'names a field facet' do
       search do
         facet(:blog_id, :name => :blog)
       end
-      connection.should have_last_search_including(:"facet.field", "{!key=blog}blog_id_i")
+      expect(connection).to have_last_search_including(:"facet.field", "{!key=blog}blog_id_i")
     end
 
     it 'uses the custom field facet name in facet option parameters' do
       search do
         facet(:blog_id, :name => :blog, :sort => :count)
       end
-      connection.should have_last_search_with(:"f.blog.facet.sort" => 'true')
+      expect(connection).to have_last_search_with(:"f.blog.facet.sort" => 'true')
     end
 
     it 'raises an ArgumentError if exclusion attempted on a restricted field facet' do
-      lambda do
+      expect do
         search do
           blog_filter = with(:blog_id, 1)
           facet(:blog_id, :only => 1, :exclude => blog_filter)
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it 'raises an ArgumentError if exclusion attempted on a facet with :extra' do
-      lambda do
+      expect do
         search do
           blog_filter = with(:blog_id, 1)
           facet(:blog_id, :extra => :all, :exclude => blog_filter)
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 
@@ -220,21 +220,21 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :published_at
       end
-      connection.should_not have_last_search_with(:"facet.date")
+      expect(connection).not_to have_last_search_with(:"facet.date")
     end
 
     it 'sets the facet to a date facet if time range is specified' do
       search do |query|
         query.facet :published_at, :time_range => @time_range
       end
-      connection.should have_last_search_with(:"facet.date" => ['published_at_dt'])
+      expect(connection).to have_last_search_with(:"facet.date" => ['published_at_dt'])
     end
 
     it 'sets the facet start and end' do
       search do |query|
         query.facet :published_at, :time_range => @time_range
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"f.published_at_dt.facet.date.start" => '2009-06-01T04:00:00Z',
         :"f.published_at_dt.facet.date.end" => '2009-07-01T04:00:00Z'
       )
@@ -244,22 +244,22 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :published_at, :time_range => @time_range
       end
-      connection.should have_last_search_with(:"f.published_at_dt.facet.date.gap" => "+86400SECONDS")
+      expect(connection).to have_last_search_with(:"f.published_at_dt.facet.date.gap" => "+86400SECONDS")
     end
 
     it 'uses custom time interval' do
       search do |query|
         query.facet :published_at, :time_range => @time_range, :time_interval => 3600
       end
-      connection.should have_last_search_with(:"f.published_at_dt.facet.date.gap" => "+3600SECONDS")
+      expect(connection).to have_last_search_with(:"f.published_at_dt.facet.date.gap" => "+3600SECONDS")
     end
 
     it 'does not allow date faceting on a non-date field' do
-      lambda do
+      expect do
         search do |query|
           query.facet :blog_id, :time_range => @time_range
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 
@@ -272,21 +272,21 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :average_rating
       end
-      connection.should_not have_last_search_with(:"facet.range")
+      expect(connection).not_to have_last_search_with(:"facet.range")
     end
 
     it 'sets the facet to a range facet if the range is specified' do
       search do |query|
         query.facet :average_rating, :range => @range
       end
-      connection.should have_last_search_with(:"facet.range" => ['average_rating_ft'])
+      expect(connection).to have_last_search_with(:"facet.range" => ['average_rating_ft'])
     end
 
     it 'sets the facet start and end' do
       search do |query|
         query.facet :average_rating, :range => @range
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"f.average_rating_ft.facet.range.start" => '2.0',
         :"f.average_rating_ft.facet.range.end" => '4.0'
       )
@@ -296,14 +296,14 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :average_rating, :range => @range
       end
-      connection.should have_last_search_with(:"f.average_rating_ft.facet.range.gap" => "10")
+      expect(connection).to have_last_search_with(:"f.average_rating_ft.facet.range.gap" => "10")
     end
 
     it 'uses custom range interval' do
       search do |query|
         query.facet :average_rating, :range => @range, :range_interval => 1
       end
-      connection.should have_last_search_with(:"f.average_rating_ft.facet.range.gap" => "1")
+      expect(connection).to have_last_search_with(:"f.average_rating_ft.facet.range.gap" => "1")
     end
 
     it 'tags and excludes a scope filter in a range facet' do
@@ -312,7 +312,7 @@ shared_examples_for "facetable query" do
         query.facet(:average_rating, :range => @range, :exclude => blog_filter)
       end
       filter_tag = get_filter_tag('blog_id_i:1')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.range" => %W({!ex=#{filter_tag}}average_rating_ft)
       )
     end
@@ -321,15 +321,15 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :average_rating, :range => @range, :include => :edge
       end
-      connection.should have_last_search_with(:"f.average_rating_ft.facet.range.include" => "edge")
+      expect(connection).to have_last_search_with(:"f.average_rating_ft.facet.range.include" => "edge")
     end
 
     it 'does not allow date faceting on a non-continuous field' do
-      lambda do
+      expect do
         search do |query|
           query.facet :title, :range => @range
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 
@@ -342,7 +342,7 @@ shared_examples_for "facetable query" do
           end
         end
       end
-      connection.should have_last_search_with(:facet => 'true')
+      expect(connection).to have_last_search_with(:facet => 'true')
     end
 
     it 'facets by query' do
@@ -353,7 +353,7 @@ shared_examples_for "facetable query" do
           end
         end
       end
-      connection.should have_last_search_with(:"facet.query" => 'average_rating_ft:[4\.0 TO 5\.0]')
+      expect(connection).to have_last_search_with(:"facet.query" => 'average_rating_ft:[4\.0 TO 5\.0]')
     end
 
     it 'requests multiple query facets' do
@@ -367,7 +367,7 @@ shared_examples_for "facetable query" do
           end
         end
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => [
           'average_rating_ft:[3\.0 TO 4\.0]',
           'average_rating_ft:[4\.0 TO 5\.0]'
@@ -384,7 +384,7 @@ shared_examples_for "facetable query" do
           end
         end
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => '(category_ids_im:1 AND blog_id_i:2)'
       )
     end
@@ -400,7 +400,7 @@ shared_examples_for "facetable query" do
           end
         end
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => '(category_ids_im:1 OR blog_id_i:2)'
       )
     end
@@ -409,7 +409,7 @@ shared_examples_for "facetable query" do
       search do
         facet :category_ids, :only => [1, 3]
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => ['category_ids_im:1', 'category_ids_im:3']
       )
     end
@@ -418,7 +418,7 @@ shared_examples_for "facetable query" do
       search do
         facet :published_at, :only => [Time.utc(2009, 8, 28, 15, 33), Time.utc(2008,8, 28, 15, 33)]
       end
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => [
           'published_at_dt:2009\-08\-28T15\:33\:00Z',
           'published_at_dt:2008\-08\-28T15\:33\:00Z'
@@ -430,7 +430,7 @@ shared_examples_for "facetable query" do
       search do
         facet(:foo) {}
       end
-      connection.should_not have_last_search_with(:"facet.query")
+      expect(connection).not_to have_last_search_with(:"facet.query")
     end
 
     it 'ignores facet query row with no restrictions' do
@@ -442,7 +442,7 @@ shared_examples_for "facetable query" do
           row(:baz) {}
         end
       end
-      connection.searches.last[:"facet.query"].should be_a(String)
+      expect(connection.searches.last[:"facet.query"]).to be_a(String)
     end
 
     it 'tags and excludes a scope filter in a query facet' do
@@ -455,7 +455,7 @@ shared_examples_for "facetable query" do
         end
       end
       filter_tag = get_filter_tag('blog_id_i:1')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => "{!ex=#{filter_tag}}category_ids_im:1"
       )
     end
@@ -473,7 +473,7 @@ shared_examples_for "facetable query" do
         end
       end
       filter_tag = get_filter_tag('(blog_id_i:1 OR blog_id_i:2)')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => "{!ex=#{filter_tag}}category_ids_im:1"
       )
     end
@@ -491,7 +491,7 @@ shared_examples_for "facetable query" do
       filter_tags = %w(blog_id_i:1 category_ids_im:2).map do |phrase|
         get_filter_tag(phrase)
       end.join(',')
-      connection.should have_last_search_with(
+      expect(connection).to have_last_search_with(
         :"facet.query" => "{!ex=#{filter_tags}}category_ids_im:1"
       )
     end
@@ -503,25 +503,25 @@ shared_examples_for "facetable query" do
           row(:bar) {}
         end
       end
-      connection.should_not have_last_search_with(:"facet.query")
+      expect(connection).not_to have_last_search_with(:"facet.query")
     end
 
     it 'does not allow 0 arguments to facet method with block' do
-      lambda do
+      expect do
         search do
           facet do
           end
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it 'does not allow more than 1 argument to facet method with block' do
-      lambda do
+      expect do
         search do
           facet :foo, :bar do
           end
         end
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 end

--- a/sunspot/spec/api/query/fulltext_examples.rb
+++ b/sunspot/spec/api/query/fulltext_examples.rb
@@ -3,28 +3,28 @@ shared_examples_for 'fulltext query' do
     search do
       keywords 'keyword search'
     end
-    connection.should have_last_search_with(:q => 'keyword search')
+    expect(connection).to have_last_search_with(:q => 'keyword search')
   end
 
   it 'ignores keywords if empty' do
     search do
       keywords ''
     end
-    connection.should_not have_last_search_with(:defType => 'edismax')
+    expect(connection).not_to have_last_search_with(:defType => 'edismax')
   end
 
   it 'ignores keywords if nil' do
     search do
       keywords nil
     end
-    connection.should_not have_last_search_with(:defType => 'edismax')
+    expect(connection).not_to have_last_search_with(:defType => 'edismax')
   end
 
   it 'ignores keywords with only whitespace' do
     search do
       keywords "  \t"
     end
-    connection.should_not have_last_search_with(:defType => 'edismax')
+    expect(connection).not_to have_last_search_with(:defType => 'edismax')
   end
 
   it 'gracefully ignores keywords block if keywords ignored' do
@@ -37,14 +37,14 @@ shared_examples_for 'fulltext query' do
     search do
       keywords 'keyword search'
     end
-    connection.should have_last_search_with(:defType => 'edismax')
+    expect(connection).to have_last_search_with(:defType => 'edismax')
   end
 
   it 'searches types in filter query if keywords used' do
     search do
       keywords 'keyword search'
     end
-    connection.should have_last_search_with(:fq => ['type:Post'])
+    expect(connection).to have_last_search_with(:fq => ['type:Post'])
   end
 
   describe 'with multiple keyword components' do
@@ -56,20 +56,21 @@ shared_examples_for 'fulltext query' do
     end
 
     it 'puts specified keywords in subquery' do
-      subqueries(:q).map { |subquery| subquery[:v] }.should ==
+      expect(subqueries(:q).map { |subquery| subquery[:v] }).to eq(
         ['first search', 'second search']
+      )
     end
 
     it 'puts specified dismax parameters in subquery' do
-      subqueries(:q).first[:qf].should == 'title_text'
+      expect(subqueries(:q).first[:qf]).to eq('title_text')
     end
 
     it 'puts default dismax parameters in subquery' do
-      subqueries(:q).last[:qf].split(' ').sort.should == %w(backwards_title_text body_textsv tags_textv title_text)
+      expect(subqueries(:q).last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text))
     end
 
     it 'puts field list in main query' do
-      connection.should have_last_search_with(:fl => '* score')
+      expect(connection).to have_last_search_with(:fl => '* score')
     end
   end
 
@@ -77,21 +78,21 @@ shared_examples_for 'fulltext query' do
     search = search do
       keywords 'keyword search'
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(backwards_title_text body_textsv tags_textv title_text)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text))
   end
 
   it 'searches both stored and unstored text fields' do
     search Post, Namespaced::Comment do
       keywords 'keyword search'
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(author_name_text backwards_title_text body_text body_textsv tags_textv title_text)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(author_name_text backwards_title_text body_text body_textsv tags_textv title_text))
   end
 
   it 'searches only specified text fields when specified' do
     search do
       keywords 'keyword search', :fields => [:title, :body]
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(body_textsv title_text)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(body_textsv title_text))
   end
 
   it 'excludes text fields when instructed' do
@@ -100,7 +101,7 @@ shared_examples_for 'fulltext query' do
         exclude_fields :backwards_title, :body_mlt
       end
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(body_textsv tags_textv title_text)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(body_textsv tags_textv title_text))
   end
 
   it 'assigns boost to fields when specified' do
@@ -109,7 +110,7 @@ shared_examples_for 'fulltext query' do
         fields :title => 2.0, :body => 0.75
       end
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(body_textsv^0.75 title_text^2.0)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(body_textsv^0.75 title_text^2.0))
   end
 
   it 'allows assignment of boosted and unboosted fields' do
@@ -124,19 +125,19 @@ shared_examples_for 'fulltext query' do
     search Post, Namespaced::Comment do
       keywords 'keyword search', :fields => [:body]
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(body_text body_textsv)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(body_text body_textsv))
   end
 
   it 'requests score when keywords used' do
     search do
       keywords 'keyword search'
     end
-    connection.should have_last_search_with(:fl => '* score')
+    expect(connection).to have_last_search_with(:fl => '* score')
   end
 
   it 'does not request score when keywords not used' do
     search Post
-    connection.should_not have_last_search_with(:fl)
+    expect(connection).not_to have_last_search_with(:fl)
   end
 
   it 'sets phrase fields' do
@@ -145,7 +146,7 @@ shared_examples_for 'fulltext query' do
         phrase_fields :title => 2.0
       end
     end
-    connection.should have_last_search_with(:pf => 'title_text^2.0')
+    expect(connection).to have_last_search_with(:pf => 'title_text^2.0')
   end
 
   it 'sets phrase fields with boost' do
@@ -154,7 +155,7 @@ shared_examples_for 'fulltext query' do
         phrase_fields :title => 1.5
       end
     end
-    connection.should have_last_search_with(:pf => 'title_text^1.5')
+    expect(connection).to have_last_search_with(:pf => 'title_text^1.5')
   end
 
   it 'sets phrase slop from DSL' do
@@ -163,7 +164,7 @@ shared_examples_for 'fulltext query' do
         phrase_slop 2
       end
     end
-    connection.should have_last_search_with(:ps => 2)
+    expect(connection).to have_last_search_with(:ps => 2)
   end
 
   it 'sets boost for certain fields without restricting fields' do
@@ -172,7 +173,7 @@ shared_examples_for 'fulltext query' do
         boost_fields :title => 1.5
       end
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(backwards_title_text body_textsv tags_textv title_text^1.5)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text^1.5))
   end
 
   it 'ignores boost fields that do not apply' do
@@ -181,7 +182,7 @@ shared_examples_for 'fulltext query' do
         boost_fields :bogus => 1.2, :title => 1.5
       end
     end
-    connection.searches.last[:qf].split(' ').sort.should == %w(backwards_title_text body_textsv tags_textv title_text^1.5)
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text^1.5))
   end
 
   it 'sets default boost with default fields' do
@@ -189,14 +190,14 @@ shared_examples_for 'fulltext query' do
       keywords 'great pizza'
     end
     # Hashes in 1.8 aren't ordered
-    connection.searches.last[:qf].split(" ").sort.join(" ").should eq 'caption_text^1.5 description_text'
+    expect(connection.searches.last[:qf].split(" ").sort.join(" ")).to eq 'caption_text^1.5 description_text'
   end
 
   it 'sets default boost with fields specified in options' do
     search Photo do
       keywords 'great pizza', :fields => [:caption]
     end
-    connection.should have_last_search_with(:qf => 'caption_text^1.5')
+    expect(connection).to have_last_search_with(:qf => 'caption_text^1.5')
   end
 
   it 'sets default boost with fields specified in DSL' do
@@ -205,7 +206,7 @@ shared_examples_for 'fulltext query' do
         fields :caption
       end
     end
-    connection.should have_last_search_with(:qf => 'caption_text^1.5')
+    expect(connection).to have_last_search_with(:qf => 'caption_text^1.5')
   end
 
   it 'overrides default boost when specified in DSL' do
@@ -214,7 +215,7 @@ shared_examples_for 'fulltext query' do
         fields :caption => 2.0
       end
     end
-    connection.should have_last_search_with(:qf => 'caption_text^2.0')
+    expect(connection).to have_last_search_with(:qf => 'caption_text^2.0')
   end
 
   it 'creates boost query' do
@@ -225,7 +226,7 @@ shared_examples_for 'fulltext query' do
         end
       end
     end
-    connection.should have_last_search_with(:bq => ['average_rating_ft:{2\.0 TO *}^2.0'])
+    expect(connection).to have_last_search_with(:bq => ['average_rating_ft:{2\.0 TO *}^2.0'])
   end
 
   it 'creates multiple boost queries' do
@@ -239,7 +240,7 @@ shared_examples_for 'fulltext query' do
         end
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :bq => [
         'average_rating_ft:{2\.0 TO *}^2.0',
         'featured_bs:true^1.5'
@@ -251,65 +252,65 @@ shared_examples_for 'fulltext query' do
     search do
       keywords 'great pizza', :minimum_match => 2
     end
-    connection.should have_last_search_with(:mm => 2)
+    expect(connection).to have_last_search_with(:mm => 2)
   end
 
   it 'sends minimum match parameter from DSL' do
     search do
       keywords('great pizza') { minimum_match(2) }
     end
-    connection.should have_last_search_with(:mm => 2)
+    expect(connection).to have_last_search_with(:mm => 2)
   end
 
   it 'sends tiebreaker parameter from options' do
     search do
       keywords 'great pizza', :tie => 0.1
     end
-    connection.should have_last_search_with(:tie => 0.1)
+    expect(connection).to have_last_search_with(:tie => 0.1)
   end
 
   it 'sends tiebreaker parameter from DSL' do
     search do
       keywords('great pizza') { tie(0.1) }
     end
-    connection.should have_last_search_with(:tie => 0.1)
+    expect(connection).to have_last_search_with(:tie => 0.1)
   end
 
   it 'sends query phrase slop from options' do
     search do
       keywords 'great pizza', :query_phrase_slop => 2
     end
-    connection.should have_last_search_with(:qs => 2)
+    expect(connection).to have_last_search_with(:qs => 2)
   end
 
   it 'sends query phrase slop from DSL' do
     search do
       keywords('great pizza') { query_phrase_slop(2) }
     end
-    connection.should have_last_search_with(:qs => 2)
+    expect(connection).to have_last_search_with(:qs => 2)
   end
 
   it 'allows specification of a text field that only exists in one type' do
     search Post, Namespaced::Comment do
       keywords 'keywords', :fields => :author_name
     end
-    connection.searches.last[:qf].should == 'author_name_text'
+    expect(connection.searches.last[:qf]).to eq('author_name_text')
   end
 
   it 'raises Sunspot::UnrecognizedFieldError for nonexistant fields in keywords' do
-    lambda do
+    expect do
       search do
         keywords :text, :fields => :bogus
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'raises Sunspot::UnrecognizedFieldError if a text field that does not exist for any type is specified' do
-    lambda do
+    expect do
       search Post, Namespaced::Comment do
         keywords 'fulltext', :fields => :bogus
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   describe 'connective examples' do
@@ -321,7 +322,7 @@ shared_examples_for 'fulltext query' do
         end
       end
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='title_text'}keywords1\" OR _query_:\"{!edismax qf='body_textsv'}keyword2\")"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='title_text'}keywords1\" OR _query_:\"{!edismax qf='body_textsv'}keyword2\")"
     end
 
     it 'creates a conjunction inside of a disjunction' do
@@ -336,7 +337,7 @@ shared_examples_for 'fulltext query' do
         end
       end
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='body_textsv'}keywords1\" OR (_query_:\"{!edismax qf='body_textsv'}keyword2\" AND _query_:\"{!edismax qf='body_textsv'}keyword3\"))"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='body_textsv'}keywords1\" OR (_query_:\"{!edismax qf='body_textsv'}keyword2\" AND _query_:\"{!edismax qf='body_textsv'}keyword3\"))"
     end
 
     it 'does nothing special if #all/#any called from the top level or called multiple times' do
@@ -347,7 +348,7 @@ shared_examples_for 'fulltext query' do
         end
       end
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='title_text'}keywords1\" AND _query_:\"{!edismax qf='body_textsv'}keyword2\")"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='title_text'}keywords1\" AND _query_:\"{!edismax qf='body_textsv'}keyword2\")"
     end
 
     it 'does nothing special if #all/#any are mixed and called multiple times' do
@@ -362,7 +363,7 @@ shared_examples_for 'fulltext query' do
         end
       end
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='title_text'}keywords1\" AND _query_:\"{!edismax qf='body_textsv'}keyword2\")"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='title_text'}keywords1\" AND _query_:\"{!edismax qf='body_textsv'}keyword2\")"
 
       search Post do
         any do
@@ -375,7 +376,7 @@ shared_examples_for 'fulltext query' do
         end
       end
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='title_text'}keywords1\" OR _query_:\"{!edismax qf='body_textsv'}keyword2\")"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='title_text'}keywords1\" OR _query_:\"{!edismax qf='body_textsv'}keyword2\")"
     end
 
     it "does not add empty parentheses" do
@@ -392,7 +393,7 @@ shared_examples_for 'fulltext query' do
         end
       end
 
-      connection.searches.last[:q].should eq "_query_:\"{!edismax qf='title_text'}keywords1\""
+      expect(connection.searches.last[:q]).to eq "_query_:\"{!edismax qf='title_text'}keywords1\""
     end
   end
 
@@ -409,9 +410,9 @@ shared_examples_for 'fulltext query' do
       q_name = "qPhoto#{obj_id}"
       fq_name = "f#{q_name}"
 
-      connection.searches.last[:q].should eq "(_query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\" OR _query_:\"{!edismax qf='description_text^1.2'}keyword2\")"
-      connection.searches.last[q_name].should eq "_query_:\"{!edismax qf='caption_text'}keyword1\""
-      connection.searches.last[fq_name].should eq "type:Photo"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\" OR _query_:\"{!edismax qf='description_text^1.2'}keyword2\")"
+      expect(connection.searches.last[q_name]).to eq "_query_:\"{!edismax qf='caption_text'}keyword1\""
+      expect(connection.searches.last[fq_name]).to eq "type:Photo"
     end
 
     it "should be able to resolve name conflicts with the :prefix option" do
@@ -426,9 +427,9 @@ shared_examples_for 'fulltext query' do
       q_name = "qPhoto#{obj_id}"
       fq_name = "f#{q_name}"
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='description_text^1.2'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\")"
-      connection.searches.last[q_name].should eq "_query_:\"{!edismax qf='description_text'}keyword2\""
-      connection.searches.last[fq_name].should eq "type:Photo"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='description_text^1.2'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\")"
+      expect(connection.searches.last[q_name]).to eq "_query_:\"{!edismax qf='description_text'}keyword2\""
+      expect(connection.searches.last[fq_name]).to eq "type:Photo"
     end
 
     it "should recognize fields when adding from DSL, e.g. when calling boost_fields" do
@@ -444,9 +445,9 @@ shared_examples_for 'fulltext query' do
       q_name = "qPhoto#{obj_id}"
       fq_name = "f#{q_name}"
 
-      connection.searches.last[:q].should eq "(_query_:\"{!edismax qf='description_text^1.5'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\")"
-      connection.searches.last[q_name].should eq "_query_:\"{!edismax qf='description_text^1.3'}keyword1\""
-      connection.searches.last[fq_name].should eq "type:Photo"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='description_text^1.5'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\")"
+      expect(connection.searches.last[q_name]).to eq "_query_:\"{!edismax qf='description_text^1.3'}keyword1\""
+      expect(connection.searches.last[fq_name]).to eq "type:Photo"
     end
 
     private

--- a/sunspot/spec/api/query/function_spec.rb
+++ b/sunspot/spec/api/query/function_spec.rb
@@ -7,7 +7,7 @@ describe 'function query' do
         boost(function { :average_rating })
       end
     end
-    connection.should have_last_search_including(:bf, 'average_rating_ft')
+    expect(connection).to have_last_search_including(:bf, 'average_rating_ft')
   end
 
   it "should send query to solr with boost function and boost amount" do
@@ -16,7 +16,7 @@ describe 'function query' do
         boost(function { :average_rating }^5)
       end
     end
-    connection.should have_last_search_including(:bf, 'average_rating_ft^5')
+    expect(connection).to have_last_search_including(:bf, 'average_rating_ft^5')
   end
 
   it "should handle boost function with constant float" do
@@ -25,7 +25,7 @@ describe 'function query' do
         boost(function { 10.5 })
       end
     end
-    connection.should have_last_search_including(:bf, '10.5')
+    expect(connection).to have_last_search_including(:bf, '10.5')
   end
 
   it "should handle boost function with constant float and boost amount" do
@@ -34,7 +34,7 @@ describe 'function query' do
         boost(function { 10.5 }^5)
       end
     end
-    connection.should have_last_search_including(:bf, '10.5^5')
+    expect(connection).to have_last_search_including(:bf, '10.5^5')
   end
 
   it "should handle boost function with time literal" do
@@ -43,7 +43,7 @@ describe 'function query' do
         boost(function { Time.parse('2010-03-25 14:13:00 EDT') })
       end
     end
-    connection.should have_last_search_including(:bf, '2010-03-25T18:13:00Z')
+    expect(connection).to have_last_search_including(:bf, '2010-03-25T18:13:00Z')
   end
  
   it "should handle arbitrary functions in a function query block" do
@@ -52,7 +52,7 @@ describe 'function query' do
         boost(function { product(:average_rating, 10) })
       end
     end
-    connection.should have_last_search_including(:bf, 'product(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:bf, 'product(average_rating_ft,10)')
   end
 
   it "should handle the sub function in a function query block" do
@@ -61,7 +61,7 @@ describe 'function query' do
         boost(function { sub(:average_rating, 10) })
       end
     end
-    connection.should have_last_search_including(:bf, 'sub(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:bf, 'sub(average_rating_ft,10)')
   end
 
   it "should handle boost amounts on function query block" do
@@ -70,7 +70,7 @@ describe 'function query' do
         boost(function { sub(:average_rating, 10)^5 })
       end
     end
-    connection.should have_last_search_including(:bf, 'sub(average_rating_ft,10)^5')
+    expect(connection).to have_last_search_including(:bf, 'sub(average_rating_ft,10)^5')
   end
  
   it "should handle nested functions in a function query block" do
@@ -79,28 +79,28 @@ describe 'function query' do
         boost(function { product(:average_rating, sum(:average_rating, 20)) })
       end
     end
-    connection.should have_last_search_including(:bf, 'product(average_rating_ft,sum(average_rating_ft,20))')
+    expect(connection).to have_last_search_including(:bf, 'product(average_rating_ft,sum(average_rating_ft,20))')
   end
 
   # TODO SOLR 1.5
   it "should raise ArgumentError if string literal passed" do
-    lambda do
+    expect do
       session.search Post do
         keywords('pizza') do
           boost(function { "hello world" })
         end
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it "should raise UnrecognizedFieldError if bogus field name passed" do
-    lambda do
+    expect do
       session.search Post do
         keywords('pizza') do
           boost(function { :bogus })
         end
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it "should send query to solr with multiplicative boost function" do
@@ -109,7 +109,7 @@ describe 'function query' do
         multiplicative_boost(function { :average_rating })
       end
     end
-    connection.should have_last_search_including(:boost, 'average_rating_ft')
+    expect(connection).to have_last_search_including(:boost, 'average_rating_ft')
   end
 
   it "should send query to solr with multiplicative boost function and boost amount" do
@@ -118,7 +118,7 @@ describe 'function query' do
         multiplicative_boost(function { :average_rating }^5)
       end
     end
-    connection.should have_last_search_including(:boost, 'average_rating_ft^5')
+    expect(connection).to have_last_search_including(:boost, 'average_rating_ft^5')
   end
 
   it "should handle multiplicative boost function with constant float" do
@@ -127,7 +127,7 @@ describe 'function query' do
         multiplicative_boost(function { 10.5 })
       end
     end
-    connection.should have_last_search_including(:boost, '10.5')
+    expect(connection).to have_last_search_including(:boost, '10.5')
   end
 
   it "should handle multiplicative boost function with constant float and boost amount" do
@@ -136,7 +136,7 @@ describe 'function query' do
         multiplicative_boost(function { 10.5 }^5)
       end
     end
-    connection.should have_last_search_including(:boost, '10.5^5')
+    expect(connection).to have_last_search_including(:boost, '10.5^5')
   end
 
   it "should handle multiplicative boost function with time literal" do
@@ -145,7 +145,7 @@ describe 'function query' do
         multiplicative_boost(function { Time.parse('2010-03-25 14:13:00 EDT') })
       end
     end
-    connection.should have_last_search_including(:boost, '2010-03-25T18:13:00Z')
+    expect(connection).to have_last_search_including(:boost, '2010-03-25T18:13:00Z')
   end
  
   it "should handle arbitrary functions in a function query block" do
@@ -154,7 +154,7 @@ describe 'function query' do
         multiplicative_boost(function { product(:average_rating, 10) })
       end
     end
-    connection.should have_last_search_including(:boost, 'product(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:boost, 'product(average_rating_ft,10)')
   end
 
   it "should handle the sub function in a multiplicative boost function query block" do
@@ -163,7 +163,7 @@ describe 'function query' do
         multiplicative_boost(function { sub(:average_rating, 10) })
       end
     end
-    connection.should have_last_search_including(:boost, 'sub(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:boost, 'sub(average_rating_ft,10)')
   end
 
   it "should handle boost amounts on multiplicative boost function query block" do
@@ -172,7 +172,7 @@ describe 'function query' do
         multiplicative_boost(function { sub(:average_rating, 10)^5 })
       end
     end
-    connection.should have_last_search_including(:boost, 'sub(average_rating_ft,10)^5')
+    expect(connection).to have_last_search_including(:boost, 'sub(average_rating_ft,10)^5')
   end
  
   it "should handle nested functions in a multiplicative boost function query block" do
@@ -181,28 +181,28 @@ describe 'function query' do
         multiplicative_boost(function { product(:average_rating, sum(:average_rating, 20)) })
       end
     end
-    connection.should have_last_search_including(:boost, 'product(average_rating_ft,sum(average_rating_ft,20))')
+    expect(connection).to have_last_search_including(:boost, 'product(average_rating_ft,sum(average_rating_ft,20))')
   end
 
   # TODO SOLR 1.5
   it "should raise ArgumentError if string literal passed to multiplicative boost" do
-    lambda do
+    expect do
       session.search Post do
         keywords('pizza') do
           multiplicative_boost(function { "hello world" })
         end
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it "should raise UnrecognizedFieldError if bogus field name passed to multiplicative boost" do
-    lambda do
+    expect do
       session.search Post do
         keywords('pizza') do
           multiplicative_boost(function { :bogus })
         end
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
 end

--- a/sunspot/spec/api/query/geo_examples.rb
+++ b/sunspot/spec/api/query/geo_examples.rb
@@ -5,35 +5,35 @@ shared_examples_for 'geohash query' do
     search do
       with(:coordinates).near(40.7, -73.5)
     end
-    connection.should have_last_search_including(:q, build_geo_query)
+    expect(connection).to have_last_search_including(:q, build_geo_query)
   end
 
   it 'searches for nearby points with non-Float arguments' do
     search do
       with(:coordinates).near(BigDecimal.new('40.7'), BigDecimal.new('-73.5'))
     end
-    connection.should have_last_search_including(:q, build_geo_query)
+    expect(connection).to have_last_search_including(:q, build_geo_query)
   end
 
   it 'searches for nearby points with given precision' do
     search do
       with(:coordinates).near(40.7, -73.5, :precision => 10)
     end
-    connection.should have_last_search_including(:q, build_geo_query(:precision => 10))
+    expect(connection).to have_last_search_including(:q, build_geo_query(:precision => 10))
   end
 
   it 'searches for nearby points with given precision factor' do
     search do
       with(:coordinates).near(40.7, -73.5, :precision_factor => 1.5)
     end
-    connection.should have_last_search_including(:q, build_geo_query(:precision_factor => 1.5))
+    expect(connection).to have_last_search_including(:q, build_geo_query(:precision_factor => 1.5))
   end
 
   it 'searches for nearby points with given boost' do
     search do
       with(:coordinates).near(40.7, -73.5, :boost => 2.0)
     end
-    connection.should have_last_search_including(:q, build_geo_query(:boost => 2.0))
+    expect(connection).to have_last_search_including(:q, build_geo_query(:boost => 2.0))
   end
 
   it 'performs both dismax search and location search' do
@@ -42,7 +42,7 @@ shared_examples_for 'geohash query' do
       with(:coordinates).near(40.7, -73.5)
     end
     expected = %Q((_query_:"{!edismax qf='title_text'}pizza" AND (#{build_geo_query})))
-    connection.should have_last_search_including(:q, expected)
+    expect(connection).to have_last_search_including(:q, expected)
   end
 
   private

--- a/sunspot/spec/api/query/group_spec.rb
+++ b/sunspot/spec/api/query/group_spec.rb
@@ -6,8 +6,8 @@ describe "grouping" do
       group :title
     end
 
-    connection.should have_last_search_including(:group, "true")
-    connection.should have_last_search_including(:"group.field", "title_ss")
+    expect(connection).to have_last_search_including(:group, "true")
+    expect(connection).to have_last_search_including(:"group.field", "title_ss")
   end
 
   it "sends grouping limit parameters to solr" do
@@ -17,7 +17,7 @@ describe "grouping" do
       end
     end
 
-    connection.should have_last_search_including(:"group.limit", 2)
+    expect(connection).to have_last_search_including(:"group.limit", 2)
   end
 
   it "sends grouping sort parameters to solr" do
@@ -27,7 +27,7 @@ describe "grouping" do
       end
     end
 
-    connection.should have_last_search_including(:"group.sort", "average_rating_ft asc")
+    expect(connection).to have_last_search_including(:"group.sort", "average_rating_ft asc")
   end
 
   it "sends grouping field parameters to solr" do
@@ -37,7 +37,7 @@ describe "grouping" do
       end
     end
 
-    connection.should have_last_search_including(:"group.field", "title_ss")
+    expect(connection).to have_last_search_including(:"group.field", "title_ss")
   end
 
   it "sends grouping query parameters to solr" do
@@ -49,6 +49,6 @@ describe "grouping" do
       end
     end
 
-    connection.should have_last_search_including(:"group.query", "category_ids_im:1")
+    expect(connection).to have_last_search_including(:"group.query", "category_ids_im:1")
   end
 end

--- a/sunspot/spec/api/query/highlighting_examples.rb
+++ b/sunspot/spec/api/query/highlighting_examples.rb
@@ -3,21 +3,21 @@ shared_examples_for "query with highlighting support" do
     search do
       keywords 'test'
     end
-    connection.should_not have_last_search_with(:hl)
+    expect(connection).not_to have_last_search_with(:hl)
   end
 
   it 'should enable highlighting when highlighting requested as keywords argument' do
     search do
       keywords 'test', :highlight => true
     end
-    connection.should have_last_search_with(:hl => 'on')
+    expect(connection).to have_last_search_with(:hl => 'on')
   end
 
   it 'should not set highlight fields parameter if highlight fields are not passed' do
     search do
       keywords 'test', :highlight => true, :fields => [:title]
     end
-    connection.should_not have_last_search_with(:'hl.fl')
+    expect(connection).not_to have_last_search_with(:'hl.fl')
   end
 
   it 'should enable highlighting on multiple fields when highlighting requested as array of fields via keywords argument' do
@@ -25,15 +25,15 @@ shared_examples_for "query with highlighting support" do
       keywords 'test', :highlight => [:title, :body]
     end
 
-    connection.should have_last_search_with(:hl => 'on', :'hl.fl' => %w(title_text body_textsv))
+    expect(connection).to have_last_search_with(:hl => 'on', :'hl.fl' => %w(title_text body_textsv))
   end
 
   it 'should raise UnrecognizedFieldError if try to highlight unexisting field via keywords argument' do
-    lambda {
+    expect {
       search do
         keywords 'test', :highlight => [:unknown_field]
       end
-    }.should raise_error(Sunspot::UnrecognizedFieldError)
+    }.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'should enable highlighting on multiple fields when highlighting requested as list of fields via block call' do
@@ -43,7 +43,7 @@ shared_examples_for "query with highlighting support" do
       end
     end
 
-    connection.should have_last_search_with(:hl => 'on', :'hl.fl' => %w(title_text body_textsv))
+    expect(connection).to have_last_search_with(:hl => 'on', :'hl.fl' => %w(title_text body_textsv))
   end
 
   it 'should enable highlighting on multiple fields for multiple search types' do
@@ -52,24 +52,24 @@ shared_examples_for "query with highlighting support" do
         highlight :body
       end
     end
-    connection.searches.last[:'hl.fl'].to_set.should == Set['body_text', 'body_textsv']
+    expect(connection.searches.last[:'hl.fl'].to_set).to eq(Set['body_text', 'body_textsv'])
   end
 
   it 'should raise UnrecognizedFieldError if try to highlight unexisting field via block call' do
-    lambda {
+    expect {
       search do
         keywords 'test' do
           highlight :unknown_field
         end
       end
-    }.should raise_error(Sunspot::UnrecognizedFieldError)
+    }.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'should set internal formatting' do
     search do
       keywords 'test', :highlight => true
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.simple.pre" => '@@@hl@@@',
       :"hl.simple.post" => '@@@endhl@@@'
     )
@@ -81,7 +81,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.fl" => %w(title_text)
     )
   end
@@ -90,7 +90,7 @@ shared_examples_for "query with highlighting support" do
     search do
       keywords 'test', :highlight => :body
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.simple.pre" => '@@@hl@@@',
       :"hl.simple.post" => '@@@endhl@@@'
     )
@@ -102,7 +102,7 @@ shared_examples_for "query with highlighting support" do
         highlight :max_snippets => 3
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.snippets" => 3
     )
   end
@@ -113,7 +113,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :max_snippets => 3
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.fl"       => %w(title_text),
       :"f.title_text.hl.snippets" => 3
     )
@@ -125,7 +125,7 @@ shared_examples_for "query with highlighting support" do
         highlight :fragment_size => 200
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.fragsize" => 200
     )
   end
@@ -136,7 +136,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :fragment_size => 200
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.title_text.hl.fragsize" => 200
     )
   end
@@ -147,7 +147,7 @@ shared_examples_for "query with highlighting support" do
         highlight :merge_contiguous_fragments => true
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.mergeContiguous" => 'true'
     )
   end
@@ -158,7 +158,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :merge_contiguous_fragments => true
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.title_text.hl.mergeContiguous" => 'true'
     )
   end
@@ -169,7 +169,7 @@ shared_examples_for "query with highlighting support" do
         highlight :phrase_highlighter => true
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.usePhraseHighlighter" => 'true'
     )
   end
@@ -180,7 +180,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :phrase_highlighter => true
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.title_text.hl.usePhraseHighlighter" => 'true'
     )
   end
@@ -191,7 +191,7 @@ shared_examples_for "query with highlighting support" do
         highlight :phrase_highlighter => true, :require_field_match => true
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.requireFieldMatch" => 'true'
     )
   end
@@ -202,7 +202,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :phrase_highlighter => true, :require_field_match => true
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.title_text.hl.requireFieldMatch" => 'true'
     )
   end
@@ -214,7 +214,7 @@ shared_examples_for "query with highlighting support" do
         highlight :body, :max_snippets => 1
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"hl.fl" => %w(title_text body_textsv),
       :"f.title_text.hl.snippets" => 2,
       :"f.body_textsv.hl.snippets" => 1
@@ -227,7 +227,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :formatter => 'formatter'
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.title_text.hl.formatter" => 'formatter'
     )
   end
@@ -238,7 +238,7 @@ shared_examples_for "query with highlighting support" do
         highlight :title, :fragmenter => 'example_fragmenter'
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.title_text.hl.fragmenter" => 'example_fragmenter'
     )
   end

--- a/sunspot/spec/api/query/join_spec.rb
+++ b/sunspot/spec/api/query/join_spec.rb
@@ -5,7 +5,7 @@ describe 'join' do
     session.search PhotoContainer do
       with(:caption, 'blah')
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, "{!join from=photo_container_id_i to=id_i}caption_s:blah")
   end
 
@@ -13,7 +13,7 @@ describe 'join' do
     session.search PhotoContainer do
       with(:photo_rating).greater_than(3)
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, "{!join from=photo_container_id_i to=id_i}average_rating_ft:{3\\.0 TO *}")
   end
 end

--- a/sunspot/spec/api/query/more_like_this_spec.rb
+++ b/sunspot/spec/api/query/more_like_this_spec.rb
@@ -16,42 +16,42 @@ describe 'more_like_this' do
   it 'should query passed in object' do
     p = Post.new
     session.more_like_this(p)
-    connection.should have_last_search_with(:q => "id:Post\\ #{p.id}")
+    expect(connection).to have_last_search_with(:q => "id:Post\\ #{p.id}")
   end
 
   it 'should use more_like_this fields if no fields specified' do
     session.more_like_this(Post.new)
-    connection.searches.last[:"mlt.fl"].split(',').sort.should == %w(body_textsv tags_textv)
+    expect(connection.searches.last[:"mlt.fl"].split(',').sort).to eq(%w(body_textsv tags_textv))
   end
 
   it 'should use more_like_this fields if specified' do
     session.more_like_this(Post.new) do
       fields :body
     end
-    connection.should have_last_search_with(:"mlt.fl" => "body_textsv")
+    expect(connection).to have_last_search_with(:"mlt.fl" => "body_textsv")
   end
 
   it 'assigns boosts to fields when specified' do
     session.more_like_this(Post.new) do
       fields :body, :tags => 8
     end
-    connection.searches.last[:"mlt.fl"].split(',').sort.should == %w(body_textsv tags_textv)
-    connection.should have_last_search_with(:"mlt.qf" => "tags_textv^8")
+    expect(connection.searches.last[:"mlt.fl"].split(',').sort).to eq(%w(body_textsv tags_textv))
+    expect(connection).to have_last_search_with(:"mlt.qf" => "tags_textv^8")
   end
 
   it 'doesn\'t assign boosts to fields when not specified' do
     session.more_like_this(Post.new) do
       fields :body
     end
-    connection.should_not have_last_search_with(:qf)
+    expect(connection).not_to have_last_search_with(:qf)
   end
 
   it 'should raise ArgumentError if a field is not setup for more_like_this' do
-    lambda do
+    expect do
       session.more_like_this(Post.new) do
         fields :title
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'should accept options' do
@@ -63,12 +63,12 @@ describe 'more_like_this' do
       maximum_query_terms 5
       boost_by_relevance false
     end
-    connection.should have_last_search_with(:"mlt.mintf" => 1)
-    connection.should have_last_search_with(:"mlt.mindf" => 2)
-    connection.should have_last_search_with(:"mlt.minwl" => 3)
-    connection.should have_last_search_with(:"mlt.maxwl" => 4)
-    connection.should have_last_search_with(:"mlt.maxqt" => 5)
-    connection.should have_last_search_with(:"mlt.boost" => false)
+    expect(connection).to have_last_search_with(:"mlt.mintf" => 1)
+    expect(connection).to have_last_search_with(:"mlt.mindf" => 2)
+    expect(connection).to have_last_search_with(:"mlt.minwl" => 3)
+    expect(connection).to have_last_search_with(:"mlt.maxwl" => 4)
+    expect(connection).to have_last_search_with(:"mlt.maxqt" => 5)
+    expect(connection).to have_last_search_with(:"mlt.boost" => false)
   end
 
   it 'should accept short options' do
@@ -80,45 +80,45 @@ describe 'more_like_this' do
       maxqt 5
       boost true
     end
-    connection.should have_last_search_with(:"mlt.mintf" => 1)
-    connection.should have_last_search_with(:"mlt.mindf" => 2)
-    connection.should have_last_search_with(:"mlt.minwl" => 3)
-    connection.should have_last_search_with(:"mlt.maxwl" => 4)
-    connection.should have_last_search_with(:"mlt.maxqt" => 5)
-    connection.should have_last_search_with(:"mlt.boost" => true)
+    expect(connection).to have_last_search_with(:"mlt.mintf" => 1)
+    expect(connection).to have_last_search_with(:"mlt.mindf" => 2)
+    expect(connection).to have_last_search_with(:"mlt.minwl" => 3)
+    expect(connection).to have_last_search_with(:"mlt.maxwl" => 4)
+    expect(connection).to have_last_search_with(:"mlt.maxqt" => 5)
+    expect(connection).to have_last_search_with(:"mlt.boost" => true)
   end
 
   it 'paginates using default per_page when page not provided' do
     session.more_like_this(Post.new)
-    connection.should have_last_search_with(:rows => 30)
+    expect(connection).to have_last_search_with(:rows => 30)
   end
 
   it 'paginates using default per_page when page provided' do
     session.more_like_this(Post.new) do
       paginate :page => 2
     end
-    connection.should have_last_search_with(:rows => 30, :start => 30)
+    expect(connection).to have_last_search_with(:rows => 30, :start => 30)
   end
 
   it 'paginates using provided per_page' do
     session.more_like_this(Post.new) do
       paginate :page => 4, :per_page => 15
     end
-    connection.should have_last_search_with(:rows => 15, :start => 45)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 45)
   end
 
   it 'defaults to page 1 if no :page argument given' do
     session.more_like_this(Post.new) do
       paginate :per_page => 15
     end
-    connection.should have_last_search_with(:rows => 15, :start => 0)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 0)
   end
 
   it 'paginates from string argument' do
     session.more_like_this(Post.new) do
       paginate :page => '3', :per_page => '15'
     end
-    connection.should have_last_search_with(:rows => 15, :start => 30)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 30)
   end
 
   it "should send query to solr with adjusted parameters (keyword example)" do
@@ -128,8 +128,8 @@ describe 'more_like_this' do
         params[:some] = 'param'
       end
     end
-    connection.should have_last_search_with(:q    => 'new search')
-    connection.should have_last_search_with(:some => 'param')
+    expect(connection).to have_last_search_with(:q    => 'new search')
+    expect(connection).to have_last_search_with(:some => 'param')
   end
 
   it "should send query to solr with adjusted parameters in multiple blocks" do
@@ -141,8 +141,8 @@ describe 'more_like_this' do
         params[:some] = 'param'
       end
     end
-    connection.should have_last_search_with(:q    => 'new search')
-    connection.should have_last_search_with(:some => 'param')
+    expect(connection).to have_last_search_with(:q    => 'new search')
+    expect(connection).to have_last_search_with(:some => 'param')
   end
 
   private

--- a/sunspot/spec/api/query/ordering_pagination_examples.rb
+++ b/sunspot/spec/api/query/ordering_pagination_examples.rb
@@ -1,70 +1,70 @@
 shared_examples_for 'sortable query' do
   it 'paginates using default per_page when page not provided' do
     search
-    connection.should have_last_search_with(:rows => 30)
+    expect(connection).to have_last_search_with(:rows => 30)
   end
 
   it 'paginates using default per_page when page provided' do
     search do
       paginate :page => 2
     end
-    connection.should have_last_search_with(:rows => 30, :start => 30)
+    expect(connection).to have_last_search_with(:rows => 30, :start => 30)
   end
 
   it 'paginates using provided per_page' do
     search do
       paginate :page => 4, :per_page => 15
     end
-    connection.should have_last_search_with(:rows => 15, :start => 45)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 45)
   end
 
   it 'defaults to page 1 if no :page argument given' do
     search do
       paginate :per_page => 15
     end
-    connection.should have_last_search_with(:rows => 15, :start => 0)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 0)
   end
 
   it 'paginates with an offset' do
     search do
       paginate :per_page => 15, :offset => 3
     end
-    connection.should have_last_search_with(:rows => 15, :start => 3)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 3)
   end
 
   it 'paginates with an offset as a string' do
     search do
       paginate :per_page => 15, :offset => '3'
     end
-    connection.should have_last_search_with(:rows => 15, :start => 3)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 3)
   end
 
   it 'paginates from string argument' do
     search do
       paginate :page => '3', :per_page => '15'
     end
-    connection.should have_last_search_with(:rows => 15, :start => 30)
+    expect(connection).to have_last_search_with(:rows => 15, :start => 30)
   end
 
   it 'paginates with initial cursor' do
     search do
       paginate :cursor => '*', :per_page => 15
     end
-    connection.should have_last_search_with(:rows => 15, :cursorMark => '*')
+    expect(connection).to have_last_search_with(:rows => 15, :cursorMark => '*')
   end
 
   it 'paginates with given cursor' do
     search do
       paginate :cursor => 'AoIIP4AAACxQcm9maWxlIDEwMTk='
     end
-    connection.should have_last_search_with(:cursorMark => 'AoIIP4AAACxQcm9maWxlIDEwMTk=')
+    expect(connection).to have_last_search_with(:cursorMark => 'AoIIP4AAACxQcm9maWxlIDEwMTk=')
   end
 
   it 'orders by a single field' do
     search do
       order_by :average_rating, :desc
     end
-    connection.should have_last_search_with(:sort => 'average_rating_ft desc')
+    expect(connection).to have_last_search_with(:sort => 'average_rating_ft desc')
   end
 
   it 'orders by multiple fields' do
@@ -72,80 +72,80 @@ shared_examples_for 'sortable query' do
       order_by :average_rating, :desc
       order_by :sort_title, :asc
     end
-    connection.should have_last_search_with(:sort => 'average_rating_ft desc, sort_title_s asc')
+    expect(connection).to have_last_search_with(:sort => 'average_rating_ft desc, sort_title_s asc')
   end
 
   it 'orders by random' do
     search do
       order_by :random
     end
-    connection.searches.last[:sort].should =~ /^random_\d+ asc$/
+    expect(connection.searches.last[:sort]).to match(/^random_\d+ asc$/)
   end
 
   it 'orders by random with declared direction' do
     search do
       order_by :random, :desc
     end
-    connection.searches.last[:sort].should =~ /^random_\d+ desc$/
+    expect(connection.searches.last[:sort]).to match(/^random_\d+ desc$/)
   end
 
   it 'orders by random with provided seed value' do
     search do
       order_by :random, :seed => 9001
     end
-    connection.searches.last[:sort].should =~ /^random_9001 asc$/
+    expect(connection.searches.last[:sort]).to match(/^random_9001 asc$/)
   end
 
   it 'orders by random with provided seed value and direction' do
     search do
       order_by :random, :seed => 12345, :direction => :desc
     end
-    connection.searches.last[:sort].should =~ /^random_12345 desc$/
+    expect(connection.searches.last[:sort]).to match(/^random_12345 desc$/)
   end
 
   it 'orders by score' do
     search do
       order_by :score, :desc
     end
-    connection.should have_last_search_with(:sort => 'score desc')
+    expect(connection).to have_last_search_with(:sort => 'score desc')
   end
 
   it 'orders by geodist' do
     search do
       order_by_geodist :coordinates_new, 32, -68, :desc
     end
-    connection.should have_last_search_with(:sort => 'geodist(coordinates_new_ll,32,-68) desc')
+    expect(connection).to have_last_search_with(:sort => 'geodist(coordinates_new_ll,32,-68) desc')
   end
 
   it 'throws an ArgumentError if a bogus order direction is given' do
-    lambda do
+    expect do
       search do
         order_by :sort_title, :sideways
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'throws an UnrecognizedFieldError if :distance is given for sort' do
-    lambda do
+    expect do
       search do
         order_by :distance, :asc
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'does not allow ordering by multiple-value fields' do
-    lambda do
+    expect do
       search do
         order_by :category_ids
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'raises ArgumentError if bogus argument given to paginate' do
-    lambda do
+    expect do
       search do
         paginate :page => 4, :ugly => :puppy
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 end

--- a/sunspot/spec/api/query/scope_examples.rb
+++ b/sunspot/spec/api/query/scope_examples.rb
@@ -3,14 +3,14 @@ shared_examples_for "scoped query" do
     search do
       with :title, 'My Pet Post'
     end
-    connection.should have_last_search_including(:fq, 'title_ss:My\ Pet\ Post')
+    expect(connection).to have_last_search_including(:fq, 'title_ss:My\ Pet\ Post')
   end
 
   it 'scopes by exact match with a special string' do
     search do
       with :title, 'OR'
     end
-    connection.should have_last_search_including(:fq, 'title_ss:"OR"')
+    expect(connection).to have_last_search_including(:fq, 'title_ss:"OR"')
   end
 
   it 'scopes by exact match with time' do
@@ -18,7 +18,7 @@ shared_examples_for "scoped query" do
     search do
       with :published_at, time
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq,
       'published_at_dt:1983\-07\-08T09\:00\:00Z'
     )
@@ -29,7 +29,7 @@ shared_examples_for "scoped query" do
     search do
       with :expire_date, date
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq,
       'expire_date_d:1983\-07\-08T00\:00\:00Z'
     )
@@ -39,133 +39,133 @@ shared_examples_for "scoped query" do
     search do
       with :featured, false
     end
-    connection.should have_last_search_including(:fq, 'featured_bs:false')
+    expect(connection).to have_last_search_including(:fq, 'featured_bs:false')
   end
 
   it 'scopes by less than match with float' do
     search do
       with(:average_rating).less_than 3.0
     end
-    connection.should have_last_search_including(:fq, 'average_rating_ft:{* TO 3\.0}')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:{* TO 3\.0}')
   end
 
   it 'should quote string with space in a less than match' do
     search do
       with(:title).less_than('test value')
     end
-    connection.should have_last_search_including(:fq, 'title_ss:{* TO "test\ value"}')
+    expect(connection).to have_last_search_including(:fq, 'title_ss:{* TO "test\ value"}')
   end
 
   it 'scopes by greater than match with float' do
     search do
       with(:average_rating).greater_than 3.0
     end
-    connection.should have_last_search_including(:fq, 'average_rating_ft:{3\.0 TO *}')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:{3\.0 TO *}')
   end
 
   it 'scopes by short-form between match with integers' do
     search do
       with :blog_id, 2..4
     end
-    connection.should have_last_search_including(:fq, 'blog_id_i:[2 TO 4]')
+    expect(connection).to have_last_search_including(:fq, 'blog_id_i:[2 TO 4]')
   end
 
   it 'scopes by between match with float' do
     search do
       with(:average_rating).between 2.0..4.0
     end
-    connection.should have_last_search_including(:fq, 'average_rating_ft:[2\.0 TO 4\.0]')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:[2\.0 TO 4\.0]')
   end
 
   it 'scopes by any match with integer' do
     search do
       with(:category_ids).any_of [2, 7, 12]
     end
-    connection.should have_last_search_including(:fq, 'category_ids_im:(2 OR 7 OR 12)')
+    expect(connection).to have_last_search_including(:fq, 'category_ids_im:(2 OR 7 OR 12)')
   end
 
   it 'scopes by short-form any-of match with integers' do
     search do
       with :category_ids, [2, 7, 12]
     end
-    connection.should have_last_search_including(:fq, 'category_ids_im:(2 OR 7 OR 12)')
+    expect(connection).to have_last_search_including(:fq, 'category_ids_im:(2 OR 7 OR 12)')
   end
 
   it 'scopes by all match with integer' do
     search do
       with(:category_ids).all_of [2, 7, 12]
     end
-    connection.should have_last_search_including(:fq, 'category_ids_im:(2 AND 7 AND 12)')
+    expect(connection).to have_last_search_including(:fq, 'category_ids_im:(2 AND 7 AND 12)')
   end
 
   it 'scopes by prefix match with string' do
     search do
       with(:title).starting_with('tes')
     end
-    connection.should have_last_search_including(:fq, 'title_ss:tes*')
+    expect(connection).to have_last_search_including(:fq, 'title_ss:tes*')
   end
 
   it 'scopes by not equal match with string' do
     search do
       without :title, 'Bad Post'
     end
-    connection.should have_last_search_including(:fq, '-title_ss:Bad\ Post')
+    expect(connection).to have_last_search_including(:fq, '-title_ss:Bad\ Post')
   end
 
   it 'scopes by not less than match with float' do
     search do
       without(:average_rating).less_than 3.0
     end
-    connection.should have_last_search_including(:fq, '-average_rating_ft:{* TO 3\.0}')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:{* TO 3\.0}')
   end
 
   it 'scopes by not greater than match with float' do
     search do
       without(:average_rating).greater_than 3.0
     end
-    connection.should have_last_search_including(:fq, '-average_rating_ft:{3\.0 TO *}')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:{3\.0 TO *}')
   end
   
   it 'scopes by not between match with shorthand' do
     search do
       without(:blog_id, 2..4)
     end
-    connection.should have_last_search_including(:fq, '-blog_id_i:[2 TO 4]')
+    expect(connection).to have_last_search_including(:fq, '-blog_id_i:[2 TO 4]')
   end
 
   it 'scopes by not between match with float' do
     search do
       without(:average_rating).between 2.0..4.0
     end
-    connection.should have_last_search_including(:fq, '-average_rating_ft:[2\.0 TO 4\.0]')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:[2\.0 TO 4\.0]')
   end
 
   it 'scopes by not any match with integer' do
     search do
       without(:category_ids).any_of [2, 7, 12]
     end
-    connection.should have_last_search_including(:fq, '-category_ids_im:(2 OR 7 OR 12)')
+    expect(connection).to have_last_search_including(:fq, '-category_ids_im:(2 OR 7 OR 12)')
   end
 
   it 'scopes by not all match with integer' do
     search do
       without(:category_ids).all_of [2, 7, 12]
     end
-    connection.should have_last_search_including(:fq, '-category_ids_im:(2 AND 7 AND 12)')
+    expect(connection).to have_last_search_including(:fq, '-category_ids_im:(2 AND 7 AND 12)')
   end
 
   it 'scopes by empty field' do
     search do
       with :average_rating, nil
     end
-    connection.should have_last_search_including(:fq, '-average_rating_ft:[* TO *]')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:[* TO *]')
   end
 
   it 'scopes by non-empty field' do
     search do
       without :average_rating, nil
     end
-    connection.should have_last_search_including(:fq, 'average_rating_ft:[* TO *]')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:[* TO *]')
   end
 
   it 'includes by object identity' do
@@ -173,7 +173,7 @@ shared_examples_for "scoped query" do
     search do
       with post
     end
-    connection.should have_last_search_including(:fq, "id:(Post\\ #{post.id})")
+    expect(connection).to have_last_search_including(:fq, "id:(Post\\ #{post.id})")
   end
 
   it 'includes multiple objects passed as varargs by object identity' do
@@ -181,7 +181,7 @@ shared_examples_for "scoped query" do
     search do
       with post1, post2
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, "id:(Post\\ #{post1.id} OR Post\\ #{post2.id})"
     )
   end
@@ -191,7 +191,7 @@ shared_examples_for "scoped query" do
     search do
       with posts
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq, "id:(Post\\ #{posts.first.id} OR Post\\ #{posts.last.id})"
     )
   end
@@ -201,7 +201,7 @@ shared_examples_for "scoped query" do
     search do
       without post
     end
-    connection.should have_last_search_including(:fq, "-id:(Post\\ #{post.id})")
+    expect(connection).to have_last_search_including(:fq, "-id:(Post\\ #{post.id})")
   end
 
   it 'excludes multiple objects passed as varargs by object identity' do
@@ -209,7 +209,7 @@ shared_examples_for "scoped query" do
     search do
       without post1, post2
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq,
       "-id:(Post\\ #{post1.id} OR Post\\ #{post2.id})"
     )
@@ -220,7 +220,7 @@ shared_examples_for "scoped query" do
     search do
       without posts
     end
-    connection.should have_last_search_including(
+    expect(connection).to have_last_search_including(
       :fq,
       "-id:(Post\\ #{posts.first.id} OR Post\\ #{posts.last.id})"
     )
@@ -231,45 +231,45 @@ shared_examples_for "scoped query" do
     search Post, Namespaced::Comment do
       with :published_at, time
     end
-    connection.should have_last_search_including(:fq, 'published_at_dt:1983\-07\-08T09\:00\:00Z')
+    expect(connection).to have_last_search_including(:fq, 'published_at_dt:1983\-07\-08T09\:00\:00Z')
   end
 
   it 'allows scoping on field not common to all types' do
     search Post, Namespaced::Comment do
       with :blog_id, 1
     end
-    connection.should have_last_search_including(:fq, 'blog_id_i:1')
+    expect(connection).to have_last_search_including(:fq, 'blog_id_i:1')
   end
 
   it 'raises Sunspot::UnrecognizedFieldError if search scoped to field configured differently between types' do
-    lambda do
+    expect do
       search Post, Namespaced::Comment do
         with :average_rating, 2.2 # this is a float in Post but an integer in Comment
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'raises Sunspot::UnrecognizedFieldError for nonexistant fields in block scope' do
-    lambda do
+    expect do
       search do
         with :bogus, 'Field'
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'raises NoMethodError if bogus operator referenced' do
-    lambda do
+    expect do
       search do
         with(:category_ids).resembling :bogus_condition
       end
-    end.should raise_error(NoMethodError)
+    end.to raise_error(NoMethodError)
   end
 
   it 'should raise ArgumentError if more than two arguments passed to scope method' do
-    lambda do
+    expect do
       search do
         with(:category_ids, 4, 5)
       end
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 end

--- a/sunspot/spec/api/query/spatial_examples.rb
+++ b/sunspot/spec/api/query/spatial_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for "spatial query" do
       with(:coordinates_new).in_radius(23, -46, 100)
     end
 
-    connection.should have_last_search_including(:fq, "{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}")
+    expect(connection).to have_last_search_including(:fq, "{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}")
   end
 
   it 'filters by radius via bbox (inexact)' do
@@ -14,7 +14,7 @@ shared_examples_for "spatial query" do
       with(:coordinates_new).in_radius(23, -46, 100, :bbox => true)
     end
 
-    connection.should have_last_search_including(:fq, "{!bbox sfield=coordinates_new_ll pt=23,-46 d=100}")
+    expect(connection).to have_last_search_including(:fq, "{!bbox sfield=coordinates_new_ll pt=23,-46 d=100}")
   end
 
   it 'filters by bounding box' do
@@ -22,6 +22,6 @@ shared_examples_for "spatial query" do
       with(:coordinates_new).in_bounding_box([45, -94], [46, -93])
     end
 
-    connection.should have_last_search_including(:fq, "coordinates_new_ll:[45,-94 TO 46,-93]")
+    expect(connection).to have_last_search_including(:fq, "coordinates_new_ll:[45,-94 TO 46,-93]")
   end
 end

--- a/sunspot/spec/api/query/spellcheck_examples.rb
+++ b/sunspot/spec/api/query/spellcheck_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for 'spellcheck query' do
     search do
       spellcheck
     end
-    connection.should have_last_search_including(:spellcheck, true)
+    expect(connection).to have_last_search_including(:spellcheck, true)
   end
 
 
@@ -14,7 +14,7 @@ shared_examples_for 'spellcheck query' do
     search do
       spellcheck :only_more_popular => true, :count => 5
     end
-    connection.should have_last_search_including('spellcheck.onlyMorePopular', true)
-    connection.should have_last_search_including('spellcheck.count', 5)
+    expect(connection).to have_last_search_including('spellcheck.onlyMorePopular', true)
+    expect(connection).to have_last_search_including('spellcheck.count', 5)
   end
 end

--- a/sunspot/spec/api/query/standard_spec.rb
+++ b/sunspot/spec/api/query/standard_spec.rb
@@ -19,7 +19,7 @@ describe 'standard query', :type => :query do
     session.search Post do
       with :title, 'My Pet Post'
     end
-    connection.should have_last_search_with(:q => '*:*')
+    expect(connection).to have_last_search_with(:q => '*:*')
   end
 
   private

--- a/sunspot/spec/api/query/stats_examples.rb
+++ b/sunspot/spec/api/query/stats_examples.rb
@@ -1,28 +1,28 @@
 shared_examples_for 'stats query' do
   it 'does not use stats unless requested' do
     search
-    connection.should_not have_last_search_with(:stats)
+    expect(connection).not_to have_last_search_with(:stats)
   end
 
   it 'uses stats when requested' do
     search do
       stats :average_rating
     end
-    connection.should have_last_search_with(:stats => true)
+    expect(connection).to have_last_search_with(:stats => true)
   end
 
   it 'requests single field stats' do
     search do
       stats :average_rating
     end
-    connection.should have_last_search_with(:"stats.field" => %w{average_rating_ft})
+    expect(connection).to have_last_search_with(:"stats.field" => %w{average_rating_ft})
   end
 
   it 'requests multiple field stats' do
     search do
       stats :average_rating, :published_at
     end
-    connection.should have_last_search_with(:"stats.field" => %w{average_rating_ft published_at_dt})
+    expect(connection).to have_last_search_with(:"stats.field" => %w{average_rating_ft published_at_dt})
   end
 
   it 'facets on a stats field' do
@@ -31,14 +31,14 @@ shared_examples_for 'stats query' do
         facet :featured
       end
     end
-    connection.should have_last_search_with(:"f.average_rating_ft.stats.facet" => %w{featured_bs})
+    expect(connection).to have_last_search_with(:"f.average_rating_ft.stats.facet" => %w{featured_bs})
   end
 
   it 'only facets on a stats field when requested' do
     search do
       stats :average_rating
     end
-    connection.should_not have_last_search_with(:"f.average_rating_ft.stats.facet")
+    expect(connection).not_to have_last_search_with(:"f.average_rating_ft.stats.facet")
   end
 
   it 'facets on multiple stats fields' do
@@ -47,7 +47,7 @@ shared_examples_for 'stats query' do
         facet :featured
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.average_rating_ft.stats.facet" => %w{featured_bs},
       :"f.published_at_dt.stats.facet" => %w{featured_bs}
     )
@@ -59,7 +59,7 @@ shared_examples_for 'stats query' do
         facet :featured, :primary_category_id
       end
     end
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :"f.average_rating_ft.stats.facet" => %w{featured_bs primary_category_id_i}
     )
   end

--- a/sunspot/spec/api/query/text_field_scoping_examples.rb
+++ b/sunspot/spec/api/query/text_field_scoping_examples.rb
@@ -5,26 +5,26 @@ shared_examples_for 'query with text field scoping' do
         with(:body, 'test')
       end
     end
-    connection.should have_last_search_including(:fq, 'body_textsv:test')
+    expect(connection).to have_last_search_including(:fq, 'body_textsv:test')
   end
 
   it 'should raise an UnrecognizedFieldError if differently configured text field is used' do
-    lambda do
+    expect do
       search(Post, Namespaced::Comment) do
         text_fields do
           with(:body, 'test')
         end
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 
   it 'should raise an UnrecognizedFieldError if no field exists' do
-    lambda do
+    expect do
       search do
         text_fields do
           with(:bogus, 'test')
         end
       end
-    end.should raise_error(Sunspot::UnrecognizedFieldError)
+    end.to raise_error(Sunspot::UnrecognizedFieldError)
   end
 end

--- a/sunspot/spec/api/query/types_spec.rb
+++ b/sunspot/spec/api/query/types_spec.rb
@@ -1,20 +1,20 @@
 describe 'typed query' do
   it 'properly escapes namespaced type names' do
     session.search(Namespaced::Comment)
-    connection.should have_last_search_with(:fq => ['type:Namespaced\:\:Comment'])
+    expect(connection).to have_last_search_with(:fq => ['type:Namespaced\:\:Comment'])
   end
 
   it 'builds search for multiple types' do
     session.search(Post, Namespaced::Comment)
-    connection.should have_last_search_with(:fq => ['type:(Post OR Namespaced\:\:Comment)'])
+    expect(connection).to have_last_search_with(:fq => ['type:(Post OR Namespaced\:\:Comment)'])
   end
 
   it 'searches type of subclass when superclass is configured' do
     session.search PhotoPost
-    connection.should have_last_search_with(:fq => ['type:PhotoPost'])
+    expect(connection).to have_last_search_with(:fq => ['type:PhotoPost'])
   end
 
   it 'raises an ArgumentError if no types given to search' do
-    lambda { session.search }.should raise_error(ArgumentError)
+    expect { session.search }.to raise_error(ArgumentError)
   end
 end

--- a/sunspot/spec/api/search/cursor_paginated_collection_spec.rb
+++ b/sunspot/spec/api/search/cursor_paginated_collection_spec.rb
@@ -13,7 +13,7 @@ describe "CursorPaginatedCollection" do
 
   describe "#respond_to?" do
     it 'should return true for current_cursor' do
-      subject.respond_to?(:current_cursor).should be_true
+      subject.respond_to?(:current_cursor).should be(true)
     end
   end
 
@@ -29,7 +29,7 @@ describe "CursorPaginatedCollection" do
     it { subject.total_count.should eql(20) }
     it { subject.num_pages.should eql(2) }
     it { subject.limit_value.should eql(10) }
-    it { subject.first_page?.should be_true }
-    it { subject.last_page?.should be_true }
+    it { subject.first_page?.should be(true) }
+    it { subject.last_page?.should be(true) }
   end
 end

--- a/sunspot/spec/api/search/cursor_paginated_collection_spec.rb
+++ b/sunspot/spec/api/search/cursor_paginated_collection_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe "CursorPaginatedCollection" do
   subject { Sunspot::Search::CursorPaginatedCollection.new [], 10, 20, '*', 'AoIIP4AAACxQcm9maWxlIDEwMTk=' }
 
-  it { subject.should be_an(Array) }
+  it { expect(subject).to be_an(Array) }
 
   describe "#send" do
     it 'should allow send' do
@@ -13,23 +13,23 @@ describe "CursorPaginatedCollection" do
 
   describe "#respond_to?" do
     it 'should return true for current_cursor' do
-      subject.respond_to?(:current_cursor).should be(true)
+      expect(subject.respond_to?(:current_cursor)).to be(true)
     end
   end
 
   context "behaves like a WillPaginate::Collection" do
-    it { subject.total_entries.should eql(20) }
-    it { subject.total_pages.should eql(2) }
-    it { subject.current_cursor.should eql('*') }
-    it { subject.per_page.should eql(10) }
-    it { subject.next_page_cursor.should eql('AoIIP4AAACxQcm9maWxlIDEwMTk=') }
+    it { expect(subject.total_entries).to eql(20) }
+    it { expect(subject.total_pages).to eql(2) }
+    it { expect(subject.current_cursor).to eql('*') }
+    it { expect(subject.per_page).to eql(10) }
+    it { expect(subject.next_page_cursor).to eql('AoIIP4AAACxQcm9maWxlIDEwMTk=') }
   end
 
   context "behaves like Kaminari" do
-    it { subject.total_count.should eql(20) }
-    it { subject.num_pages.should eql(2) }
-    it { subject.limit_value.should eql(10) }
-    it { subject.first_page?.should be(true) }
-    it { subject.last_page?.should be(true) }
+    it { expect(subject.total_count).to eql(20) }
+    it { expect(subject.num_pages).to eql(2) }
+    it { expect(subject.limit_value).to eql(10) }
+    it { expect(subject.first_page?).to be(true) }
+    it { expect(subject.last_page?).to be(true) }
   end
 end

--- a/sunspot/spec/api/search/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/search/dynamic_fields_spec.rb
@@ -4,13 +4,13 @@ describe 'search with dynamic fields' do
   it 'returns dynamic string facet' do
     stub_facet(:"custom_string:test_ss", 'two' => 2, 'one' => 1)
     result = session.search(Post) { dynamic(:custom_string) { facet(:test) }}
-    result.facet(:custom_string, :test).rows.map { |row| row.value }.should == ['two', 'one']
+    expect(result.facet(:custom_string, :test).rows.map { |row| row.value }).to eq(['two', 'one'])
   end
 
   it 'returns dynamic field facet with custom label' do
     stub_facet(:"bogus", 'two' => 2, 'one' => 1)
     result = session.search(Post) { dynamic(:custom_string) { facet(:test, :name => :bogus) }}
-    result.facet(:bogus).rows.map { |row| row.value }.should == ['two', 'one']
+    expect(result.facet(:bogus).rows.map { |row| row.value }).to eq(['two', 'one'])
   end
 
   it 'returns query facet specified in dynamic call' do
@@ -27,7 +27,7 @@ describe 'search with dynamic fields' do
       end
     end
     facet = search.facet(:test)
-    facet.rows.first.value.should == :foo_bar
-    facet.rows.first.count.should == 3
+    expect(facet.rows.first.value).to eq(:foo_bar)
+    expect(facet.rows.first.count).to eq(3)
   end
 end

--- a/sunspot/spec/api/search/faceting_spec.rb
+++ b/sunspot/spec/api/search/faceting_spec.rb
@@ -6,7 +6,7 @@ describe 'faceting', :type => :search do
     result = session.search Post do
       facet :title
     end
-    result.facet(:title).field_name.should == :title
+    expect(result.facet(:title).field_name).to eq(:title)
   end
 
   it 'returns facet specified by string' do
@@ -14,7 +14,7 @@ describe 'faceting', :type => :search do
     result = session.search Post do
       facet :title
     end
-    result.facet('title').field_name.should == :title
+    expect(result.facet('title').field_name).to eq(:title)
   end
 
   it 'returns all facets specified by search' do
@@ -24,8 +24,8 @@ describe 'faceting', :type => :search do
       facet :title
       facet :blog_id
     end
-    result.facets.first.field_name.should == :title
-    result.facets.last.field_name.should == :blog_id
+    expect(result.facets.first.field_name).to eq(:title)
+    expect(result.facets.last.field_name).to eq(:blog_id)
   end
 
   it 'returns string facet' do
@@ -33,7 +33,7 @@ describe 'faceting', :type => :search do
     result = session.search Post do
       facet :title
     end
-    facet_values(result, :title).should == ['Author 1', 'Author 2']
+    expect(facet_values(result, :title)).to eq(['Author 1', 'Author 2'])
   end
 
   it 'returns counts for facet' do
@@ -41,7 +41,7 @@ describe 'faceting', :type => :search do
     result = session.search Post do
       facet :title
     end
-    facet_counts(result, :title).should == [2, 1]
+    expect(facet_counts(result, :title)).to eq([2, 1])
   end
 
   it 'returns integer facet' do
@@ -49,7 +49,7 @@ describe 'faceting', :type => :search do
     result = session.search Post do
       facet :blog_id
     end
-    facet_values(result, :blog_id).should == [3, 1]
+    expect(facet_values(result, :blog_id)).to eq([3, 1])
   end
 
   it 'returns float facet' do
@@ -57,7 +57,7 @@ describe 'faceting', :type => :search do
     result = session.search Post do
       facet :average_rating
     end
-    facet_values(result, :average_rating).should == [9.3, 1.1]
+    expect(facet_values(result, :average_rating)).to eq([9.3, 1.1])
   end
 
   it 'returns time facet' do
@@ -77,10 +77,11 @@ describe 'faceting', :type => :search do
       rescue ArgumentError
         DateTime.civil(2050, 4, 7, 20, 27, 15)
       end
-    facet_values(result, :published_at).should ==
+    expect(facet_values(result, :published_at)).to eq(
       [Time.gm(2009, 4, 7, 20, 25, 23),
        Time.gm(2009, 4, 7, 20, 26, 19),
        future_time]
+    )
   end
 
   it 'returns date facet' do
@@ -92,9 +93,10 @@ describe 'faceting', :type => :search do
     result = session.search(Post) do
       facet :expire_date
     end
-    facet_values(result, :expire_date).should ==
+    expect(facet_values(result, :expire_date)).to eq(
       [Date.new(2009, 07, 13),
        Date.new(2009, 04, 01)]
+    )
   end
 
   it 'returns trie integer facet' do
@@ -102,7 +104,7 @@ describe 'faceting', :type => :search do
     result = session.search Photo do
       facet :size
     end
-    facet_values(result, :size).should == [3, 1]
+    expect(facet_values(result, :size)).to eq([3, 1])
   end
 
   it 'returns float facet' do
@@ -110,7 +112,7 @@ describe 'faceting', :type => :search do
     result = session.search Photo do
       facet :average_rating
     end
-    facet_values(result, :average_rating).should == [9.3, 1.1]
+    expect(facet_values(result, :average_rating)).to eq([9.3, 1.1])
   end
 
   it 'returns time facet' do
@@ -122,15 +124,16 @@ describe 'faceting', :type => :search do
     result = session.search Photo do
       facet :created_at
     end
-    facet_values(result, :created_at).should ==
+    expect(facet_values(result, :created_at)).to eq(
       [Time.gm(2009, 04, 07, 20, 25, 23),
        Time.gm(2009, 04, 07, 20, 26, 19)]
+    )
   end
 
   it 'returns boolean facet' do
     stub_facet(:featured_bs, 'true' => 3, 'false' => 1)
     result = session.search(Post) { facet(:featured) }
-    facet_values(result, :featured).should == [true, false]
+    expect(facet_values(result, :featured)).to eq([true, false])
   end
 
 
@@ -138,26 +141,26 @@ describe 'faceting', :type => :search do
     it "returns field facet with #{type} custom name" do
       stub_facet(:blog, '2' => 1, '1' => 4)
       result = session.search(Post) { facet(:blog_id, :name => name) }
-      facet_values(result, :blog).should == [1, 2]
+      expect(facet_values(result, :blog)).to eq([1, 2])
     end
 
     it "assigns #{type} custom name to field facet" do
       stub_facet(:blog, '2' => 1)
       result = session.search(Post) { facet(:blog_id, :name => name) }
-      result.facet(:blog).name.should == :blog
+      expect(result.facet(:blog).name).to eq(:blog)
     end
 
     it "retains field name for #{type} custom-named field facet" do
       stub_facet(:blog, '2' => 1)
       result = session.search(Post) { facet(:blog_id, :name => name) }
-      result.facet(:blog).field_name.should == :blog_id
+      expect(result.facet(:blog).field_name).to eq(:blog_id)
     end
   end
 
   it 'returns class facet' do
     stub_facet(:class_name, 'Post' => 3, 'Namespaced::Comment' => 1)
     result = session.search(Post) { facet(:class) }
-    facet_values(result, :class).should == [Post, Namespaced::Comment]
+    expect(facet_values(result, :class)).to eq([Post, Namespaced::Comment])
   end
 
   it 'returns special :any facet' do
@@ -166,8 +169,8 @@ describe 'faceting', :type => :search do
     )
     search = session.search(Post) { facet(:category_ids, :extra => :any) }
     row = search.facet(:category_ids).rows.first
-    row.value.should == :any
-    row.count.should == 3
+    expect(row.value).to eq(:any)
+    expect(row.count).to eq(3)
   end
 
   it 'returns special :none facet' do
@@ -176,8 +179,8 @@ describe 'faceting', :type => :search do
     )
     search = session.search(Post) { facet(:category_ids, :extra => :none) }
     row = search.facet(:category_ids).rows.first
-    row.value.should == :none
-    row.count.should == 3
+    expect(row.value).to eq(:none)
+    expect(row.count).to eq(3)
   end
 
   it 'returns date range facet' do
@@ -186,8 +189,8 @@ describe 'faceting', :type => :search do
     end_time = start_time + 2*24*60*60
     result = session.search(Post) { facet(:published_at, :time_range => start_time..end_time) }
     facet = result.facet(:published_at)
-    facet.rows.first.value.should == (start_time..(start_time+24*60*60))
-    facet.rows.last.value.should == ((start_time+24*60*60)..end_time)
+    expect(facet.rows.first.value).to eq(start_time..(start_time+24*60*60))
+    expect(facet.rows.last.value).to eq((start_time+24*60*60)..end_time)
   end
 
   it 'returns date range facet sorted by count' do
@@ -196,8 +199,8 @@ describe 'faceting', :type => :search do
     end_time = start_time + 2*24*60*60
     result = session.search(Post) { facet(:published_at, :time_range => start_time..end_time, :sort => :count) }
     facet = result.facet(:published_at)
-    facet.rows.first.value.should == ((start_time+24*60*60)..end_time)
-    facet.rows.last.value.should == (start_time..(start_time+24*60*60))
+    expect(facet.rows.first.value).to eq((start_time+24*60*60)..end_time)
+    expect(facet.rows.last.value).to eq(start_time..(start_time+24*60*60))
   end
 
   it 'returns query facet' do
@@ -216,10 +219,10 @@ describe 'faceting', :type => :search do
       end
     end
     facet = search.facet(:average_rating)
-    facet.rows.first.value.should == (3.0..5.0)
-    facet.rows.first.count.should == 3
-    facet.rows.last.value.should == (1.0..3.0)
-    facet.rows.last.count.should == 1
+    expect(facet.rows.first.value).to eq(3.0..5.0)
+    expect(facet.rows.first.count).to eq(3)
+    expect(facet.rows.last.value).to eq(1.0..3.0)
+    expect(facet.rows.last.count).to eq(1)
   end
 
   describe 'query facet option handling' do
@@ -244,43 +247,43 @@ describe 'faceting', :type => :search do
     end
 
     it 'sorts in order of specification if no limit is given' do
-      facet_values_from_options.should == [1, 3, 2]
+      expect(facet_values_from_options).to eq([1, 3, 2])
     end
 
     it 'sorts lexically if lexical option is specified' do
-      facet_values_from_options(:sort => :index).should == [1, 2, 3]
+      expect(facet_values_from_options(:sort => :index)).to eq([1, 2, 3])
     end
 
     it 'sorts by count by default if limit is given' do
-      facet_values_from_options(:limit => 2).should == [2, 1]
+      expect(facet_values_from_options(:limit => 2)).to eq([2, 1])
     end
 
     it 'sorts by count if count option is specified' do
-      facet_values_from_options(:sort => :count).should == [2, 1, 3]
+      expect(facet_values_from_options(:sort => :count)).to eq([2, 1, 3])
     end
 
     it 'sorts lexically if lexical option is specified even if limit is given' do
-      facet_values_from_options(:sort => :index, :limit => 2).should == [1, 2]
+      expect(facet_values_from_options(:sort => :index, :limit => 2)).to eq([1, 2])
     end
 
     it 'limits facets if limit option is given' do
-      facet_values_from_options(:limit => 1).should == [2]
+      expect(facet_values_from_options(:limit => 1)).to eq([2])
     end
 
     it 'does not limit facets if limit option is negative' do
-      facet_values_from_options(:limit => -2).should == [1, 3, 2]
+      expect(facet_values_from_options(:limit => -2)).to eq([1, 3, 2])
     end
 
     it 'returns all facets if limit greater than number of facets' do
-      facet_values_from_options(:limit => 10).should == [2, 1, 3]
+      expect(facet_values_from_options(:limit => 10)).to eq([2, 1, 3])
     end
 
     it 'allows zero count if specified' do
-      facet_values_from_options(:zeros => true).should == [1, 3, 2, 4]
+      expect(facet_values_from_options(:zeros => true)).to eq([1, 3, 2, 4])
     end
 
     it 'sets minimum count' do
-      facet_values_from_options(:minimum_count => 2).should == [1, 2]
+      expect(facet_values_from_options(:minimum_count => 2)).to eq([1, 2])
     end
   end
 
@@ -293,17 +296,17 @@ describe 'faceting', :type => :search do
       facet :category_ids, :only => [1, 3, 5]
     end
     facet = search.facet(:category_ids)
-    facet.rows.first.value.should == 1
-    facet.rows.first.count.should == 3
-    facet.rows.last.value.should == 3
-    facet.rows.last.count.should == 1
+    expect(facet.rows.first.value).to eq(1)
+    expect(facet.rows.first.count).to eq(3)
+    expect(facet.rows.last.value).to eq(3)
+    expect(facet.rows.last.count).to eq(1)
   end
 
   it 'returns instantiated facet values' do
     blogs = Array.new(2) { Blog.new }
     stub_facet(:blog_id_i, blogs[0].id.to_s => 2, blogs[1].id.to_s => 1)
     search = session.search(Post) { facet(:blog_id) }
-    search.facet(:blog_id).rows.map { |row| row.instance }.should == blogs
+    expect(search.facet(:blog_id).rows.map { |row| row.instance }).to eq(blogs)
   end
 
   it 'returns all instantiated facet rows, whether or not the instances exist' do
@@ -311,7 +314,7 @@ describe 'faceting', :type => :search do
     blogs.last.destroy
     stub_facet(:blog_id_i, blogs[0].id.to_s => 2, blogs[1].id.to_s => 1)
     search = session.search(Post) { facet(:blog_id) }
-    search.facet(:blog_id).rows.map { |row| row.instance }.should == [blogs.first, nil]
+    expect(search.facet(:blog_id).rows.map { |row| row.instance }).to eq([blogs.first, nil])
   end
 
   it 'returns only rows with available instances if specified' do
@@ -319,7 +322,7 @@ describe 'faceting', :type => :search do
     blogs.last.destroy
     stub_facet(:blog_id_i, blogs[0].id.to_s => 2, blogs[1].id.to_s => 1)
     search = session.search(Post) { facet(:blog_id) }
-    search.facet(:blog_id).rows(:verify => true).map { |row| row.instance }.should == blogs[0..0]
+    expect(search.facet(:blog_id).rows(:verify => true).map { |row| row.instance }).to eq(blogs[0..0])
   end
 
   it 'returns both verified and unverified rows from the same facet' do
@@ -327,14 +330,14 @@ describe 'faceting', :type => :search do
     blogs.last.destroy
     stub_facet(:blog_id_i, blogs[0].id.to_s => 2, blogs[1].id.to_s => 1)
     search = session.search(Post) { facet(:blog_id) }
-    search.facet(:blog_id).rows(:verify => true).map { |row| row.instance }.should == blogs[0..0]
-    search.facet(:blog_id).rows.map { |row| row.instance }.should == [blogs.first, nil]
+    expect(search.facet(:blog_id).rows(:verify => true).map { |row| row.instance }).to eq(blogs[0..0])
+    expect(search.facet(:blog_id).rows.map { |row| row.instance }).to eq([blogs.first, nil])
   end
 
   it 'ignores :verify option if facet not a reference facet' do
     stub_facet(:category_ids_im, '1' => 2, '2' => 1)
     search = session.search(Post) { facet(:category_ids) }
-    search.facet(:category_ids).should have(2).rows(:verify => true)
+    expect(search.facet(:category_ids).rows(:verify => true).size).to eq(2)
   end
 
   it 'returns instantiated facet values for limited field facet' do
@@ -346,7 +349,7 @@ describe 'faceting', :type => :search do
     search = session.search(Post) do
       facet(:blog_id, :only => blogs.map { |blog| blog.id })
     end
-    search.facet(:blog_id).rows.map { |row| row.instance }.should == blogs
+    expect(search.facet(:blog_id).rows.map { |row| row.instance }).to eq(blogs)
   end
 
   it 'only queries the persistent store once for an instantiated facet' do
@@ -355,6 +358,6 @@ describe 'faceting', :type => :search do
     stub_facet(:blog_id_i, blogs[0].id.to_s => 2, blogs[1].id.to_s => 1)
     result = session.search(Post) { facet(:blog_id) }
     result.facet(:blog_id).rows.each { |row| row.instance }
-    (Blog.query_count - query_count).should == 1
+    expect(Blog.query_count - query_count).to eq(1)
   end
 end

--- a/sunspot/spec/api/search/highlighting_spec.rb
+++ b/sunspot/spec/api/search/highlighting_spec.rb
@@ -14,38 +14,38 @@ describe 'search with highlighting results', :type => :search do
   end
 
   it 'returns all highlights' do
-    @search.hits.last.should have(3).highlights
+    expect(@search.hits.last.highlights.size).to eq(3)
   end
 
   it 'returns all highlights for a specified field' do
-    @search.hits.last.should have(2).highlights(:body)
+    expect(@search.hits.last.highlights(:body).size).to eq(2)
   end
 
   it 'returns first highlight for a specified field' do
-    @search.hits.first.highlight(:title).format.should == 'one <em>two</em> three'
+    expect(@search.hits.first.highlight(:title).format).to eq('one <em>two</em> three')
   end
 
   it 'returns an empty array if a given field does not have a highlight' do
-    @search.hits.first.highlights(:body).should == []
+    expect(@search.hits.first.highlights(:body)).to eq([])
   end
 
   it 'formats hits with <em> by default' do
     highlight = @search.hits.first.highlights(:title).first.formatted
-    highlight.should == 'one <em>two</em> three'
+    expect(highlight).to eq('one <em>two</em> three')
   end
 
   it 'formats hits with provided block' do
     highlight = @search.hits.first.highlights(:title).first.format do |word|
       "<i>#{word}</i>"
     end
-    highlight.should == 'one <i>two</i> three'
+    expect(highlight).to eq('one <i>two</i> three')
   end
 
   it 'handles multiple highlighted words' do
     highlight = @search.hits.last.highlights(:body).last.format do |word|
       "<b>#{word}</b>"
     end
-    highlight.should == '<b>eight</b> nine <b>ten</b>'
+    expect(highlight).to eq('<b>eight</b> nine <b>ten</b>')
   end
 
   private

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -5,37 +5,37 @@ describe 'hits', :type => :search do
     post_1, post_2 = Array.new(2) { Post.new }
     stub_results(post_1, post_2)
     %w(load load_all).each do |message|
-      MockAdapter::DataAccessor.should_not_receive(message)
+      expect(MockAdapter::DataAccessor).not_to receive(message)
     end
-    session.search(Post).hits.map do |hit|
+    expect(session.search(Post).hits.map do |hit|
       [hit.class_name, hit.primary_key]
-    end.should == [['Post', post_1.id.to_s], ['Post', post_2.id.to_s]]
+    end).to eq([['Post', post_1.id.to_s], ['Post', post_2.id.to_s]])
   end
 
   it 'returns search total as attribute of hits' do
     stub_results(Post.new, 4)
-    session.search(Post) do
+    expect(session.search(Post) do
       paginate(:page => 1)
-    end.hits.total_entries.should == 4
+    end.hits.total_entries).to eq(4)
   end
 
   it 'returns search total as attribute of verified hits' do
     stub_results(Post.new, 4)
-    session.search(Post) do
+    expect(session.search(Post) do
       paginate(:page => 1)
-    end.hits(:verify => true).total_entries.should == 4
+    end.hits(:verify => true).total_entries).to eq(4)
   end
 
   it 'should return instance from hit' do
     posts = Array.new(2) { Post.new }
     stub_results(*posts)
-    session.search(Post).hits.first.instance.should == posts.first
+    expect(session.search(Post).hits.first.instance).to eq(posts.first)
   end
 
   it 'should return the instance primary key when you use it as a param' do
     posts = Array.new(2) { Post.new }
     stub_results(*posts)
-    session.search(Post).hits.first.to_param.should == posts.first.id.to_s
+    expect(session.search(Post).hits.first.to_param).to eq(posts.first.id.to_s)
   end
 
   it 'should provide iterator over hits with instances' do
@@ -49,8 +49,8 @@ describe 'hits', :type => :search do
       results << result
     end
 
-    hits.should have(2).hits
-    results.should have(2).results
+    expect(hits.size).to eq(2)
+    expect(results.size).to eq(2)
   end
 
   it 'should provide an Enumerator over hits with instances' do
@@ -59,9 +59,9 @@ describe 'hits', :type => :search do
     search = session.search(Post)
     hits, results = [], []
     search.each_hit_with_result.with_index do |(hit, result), index|
-      hit.should be_kind_of(Sunspot::Search::Hit)
-      result.should be_kind_of(Post)
-      index.should be_kind_of(Integer)
+      expect(hit).to be_kind_of(Sunspot::Search::Hit)
+      expect(result).to be_kind_of(Post)
+      expect(index).to be_kind_of(Integer)
     end
   end
 
@@ -71,9 +71,9 @@ describe 'hits', :type => :search do
     search = session.search(Post)
     search.hits.first.instance
     %w(load load_all).each do |message|
-      MockAdapter::DataAccessor.should_not_receive(message)
+      expect(MockAdapter::DataAccessor).not_to receive(message)
     end
-    search.hits.last.instance.should == posts.last
+    expect(search.hits.last.instance).to eq(posts.last)
   end
 
   it 'should return only hits whose referenced object exists in the data store if :verify option passed' do
@@ -81,7 +81,7 @@ describe 'hits', :type => :search do
     posts.last.destroy
     stub_results(*posts)
     search = session.search(Post)
-    search.hits(:verify => true).map { |hit| hit.instance }.should == posts[0..0]
+    expect(search.hits(:verify => true).map { |hit| hit.instance }).to eq(posts[0..0])
   end
 
   it 'should return verified and unverified hits from the same search' do
@@ -89,59 +89,59 @@ describe 'hits', :type => :search do
     posts.last.destroy
     stub_results(*posts)
     search = session.search(Post)
-    search.hits(:verify => true).map { |hit| hit.instance }.should == posts[0..0]
-    search.hits.map { |hit| hit.instance }.should == [posts.first, nil]
+    expect(search.hits(:verify => true).map { |hit| hit.instance }).to eq(posts[0..0])
+    expect(search.hits.map { |hit| hit.instance }).to eq([posts.first, nil])
   end
 
   it 'should attach score to hits' do
     stub_full_results('instance' => Post.new, 'score' => 1.23)
-    session.search(Post).hits.first.score.should == 1.23
+    expect(session.search(Post).hits.first.score).to eq(1.23)
   end
 
   it 'should return stored field values in hits' do
     stub_full_results('instance' => Post.new, 'title_ss' => 'Title')
-    session.search(Post).hits.first.stored(:title).should == 'Title'
+    expect(session.search(Post).hits.first.stored(:title)).to eq('Title')
   end
 
   it 'should return stored field values for searches against multiple types' do
     stub_full_results('instance' => Post.new, 'title_ss' => 'Title')
-    session.search(Post, Namespaced::Comment).hits.first.stored(:title).should == 'Title'
+    expect(session.search(Post, Namespaced::Comment).hits.first.stored(:title)).to eq('Title')
   end
 
   it 'should return stored field values for searches against base type when subtype matches' do
     class SubclassedPost < Post; end;
     stub_full_results('instance' => SubclassedPost.new, 'title_ss' => 'Title')
-    session.search(Post).hits.first.stored(:title).should == 'Title'
+    expect(session.search(Post).hits.first.stored(:title)).to eq('Title')
   end
 
   it 'should return stored text fields' do
     stub_full_results('instance' => Post.new, 'body_textsv' => 'Body')
-    session.search(Post, Namespaced::Comment).hits.first.stored(:body).should == 'Body'
+    expect(session.search(Post, Namespaced::Comment).hits.first.stored(:body)).to eq('Body')
   end
 
   it 'should return stored boolean fields' do
     stub_full_results('instance' => Post.new, 'featured_bs' => true)
-    session.search(Post, Namespaced::Comment).hits.first.stored(:featured).should be(true)
+    expect(session.search(Post, Namespaced::Comment).hits.first.stored(:featured)).to be(true)
   end
 
   it 'should return stored boolean fields that evaluate to false' do
     stub_full_results('instance' => Post.new, 'featured_bs' => false)
-    session.search(Post, Namespaced::Comment).hits.first.stored(:featured).should == false
+    expect(session.search(Post, Namespaced::Comment).hits.first.stored(:featured)).to eq(false)
   end
 
   it 'should return stored dynamic fields' do
     stub_full_results('instance' => Post.new, 'custom_string:test_ss' => 'Custom')
-    session.search(Post, Namespaced::Comment).hits.first.stored(:custom_string, :test).should == 'Custom'
+    expect(session.search(Post, Namespaced::Comment).hits.first.stored(:custom_string, :test)).to eq('Custom')
   end
 
   it 'should typecast stored field values in hits' do
     time = Time.utc(2008, 7, 8, 2, 45)
     stub_full_results('instance' => Post.new, 'last_indexed_at_ds' => time.xmlschema)
-    session.search(Post).hits.first.stored(:last_indexed_at).should == time
+    expect(session.search(Post).hits.first.stored(:last_indexed_at)).to eq(time)
   end
 
   it 'should return stored values for multi-valued fields' do
     stub_full_results('instance' => User.new, 'role_ids_ims' => %w(1 4 5))
-    session.search(User).hits.first.stored(:role_ids).should == [1, 4, 5]
+    expect(session.search(User).hits.first.stored(:role_ids)).to eq([1, 4, 5])
   end
 end

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -121,7 +121,7 @@ describe 'hits', :type => :search do
 
   it 'should return stored boolean fields' do
     stub_full_results('instance' => Post.new, 'featured_bs' => true)
-    session.search(Post, Namespaced::Comment).hits.first.stored(:featured).should be_true
+    session.search(Post, Namespaced::Comment).hits.first.stored(:featured).should be(true)
   end
 
   it 'should return stored boolean fields that evaluate to false' do

--- a/sunspot/spec/api/search/paginated_collection_spec.rb
+++ b/sunspot/spec/api/search/paginated_collection_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe "PaginatedCollection" do
   subject { Sunspot::Search::PaginatedCollection.new [], 1, 10, 20 }
 
-  it { subject.should be_an(Array) }
+  it { expect(subject).to be_an(Array) }
 
   describe "#send" do
     it 'should allow send' do
@@ -13,37 +13,37 @@ describe "PaginatedCollection" do
 
   describe "#respond_to?" do
     it 'should return true for current_page' do
-      subject.respond_to?(:current_page).should be(true)
+      expect(subject.respond_to?(:current_page)).to be(true)
     end
   end
 
   context "behaves like a WillPaginate::Collection" do
-    it { subject.total_entries.should eql(20) }
-    it { subject.total_pages.should eql(2) }
-    it { subject.current_page.should eql(1) }
-    it { subject.per_page.should eql(10) }
-    it { subject.previous_page.should be_nil }
-    it { subject.prev_page.should be_nil }
-    it { subject.next_page.should eql(2) }
-    it { subject.out_of_bounds?.should_not be(true) }
-    it { subject.offset.should eql(0) }
+    it { expect(subject.total_entries).to eql(20) }
+    it { expect(subject.total_pages).to eql(2) }
+    it { expect(subject.current_page).to eql(1) }
+    it { expect(subject.per_page).to eql(10) }
+    it { expect(subject.previous_page).to be_nil }
+    it { expect(subject.prev_page).to be_nil }
+    it { expect(subject.next_page).to eql(2) }
+    it { expect(subject.out_of_bounds?).not_to be(true) }
+    it { expect(subject.offset).to eql(0) }
 
     it 'should allow setting total_count' do
       subject.total_count = 1
-      subject.total_count.should eql(1)
+      expect(subject.total_count).to eql(1)
     end
 
     it 'should allow setting total_entries' do
       subject.total_entries = 1
-      subject.total_entries.should eql(1)
+      expect(subject.total_entries).to eql(1)
     end
   end
 
   context "behaves like Kaminari" do
-    it { subject.total_count.should eql(20) }
-    it { subject.num_pages.should eql(2) }
-    it { subject.limit_value.should eql(10) }
-    it { subject.first_page?.should be(true) }
-    it { subject.last_page?.should_not be(true) }
+    it { expect(subject.total_count).to eql(20) }
+    it { expect(subject.num_pages).to eql(2) }
+    it { expect(subject.limit_value).to eql(10) }
+    it { expect(subject.first_page?).to be(true) }
+    it { expect(subject.last_page?).not_to be(true) }
   end
 end

--- a/sunspot/spec/api/search/paginated_collection_spec.rb
+++ b/sunspot/spec/api/search/paginated_collection_spec.rb
@@ -13,7 +13,7 @@ describe "PaginatedCollection" do
 
   describe "#respond_to?" do
     it 'should return true for current_page' do
-      subject.respond_to?(:current_page).should be_true
+      subject.respond_to?(:current_page).should be(true)
     end
   end
 
@@ -25,7 +25,7 @@ describe "PaginatedCollection" do
     it { subject.previous_page.should be_nil }
     it { subject.prev_page.should be_nil }
     it { subject.next_page.should eql(2) }
-    it { subject.out_of_bounds?.should_not be_true }
+    it { subject.out_of_bounds?.should_not be(true) }
     it { subject.offset.should eql(0) }
 
     it 'should allow setting total_count' do
@@ -43,7 +43,7 @@ describe "PaginatedCollection" do
     it { subject.total_count.should eql(20) }
     it { subject.num_pages.should eql(2) }
     it { subject.limit_value.should eql(10) }
-    it { subject.first_page?.should be_true }
-    it { subject.last_page?.should_not be_true }
+    it { subject.first_page?.should be(true) }
+    it { subject.last_page?.should_not be(true) }
   end
 end

--- a/sunspot/spec/api/search/results_spec.rb
+++ b/sunspot/spec/api/search/results_spec.rb
@@ -4,15 +4,15 @@ describe 'search results', :type => :search do
   it 'loads single result' do
     post = Post.new
     stub_results(post)
-    session.search(Post).results.should == [post]
+    expect(session.search(Post).results).to eq([post])
   end
 
   it 'loads multiple results in order' do
     post_1, post_2 = Post.new, Post.new
     stub_results(post_1, post_2)
-    session.search(Post).results.should == [post_1, post_2]
+    expect(session.search(Post).results).to eq([post_1, post_2])
     stub_results(post_2, post_1)
-    session.search(Post).results.should == [post_2, post_1]
+    expect(session.search(Post).results).to eq([post_2, post_1])
   end
 
   # This is a reduction of a crazy bug I found in production where some hits
@@ -22,42 +22,42 @@ describe 'search results', :type => :search do
     Namespaced::Comment.reset!
     results = [Post.new, Namespaced::Comment.new]
     stub_results(*results)
-    session.search(Post, Namespaced::Comment).results.should == results
+    expect(session.search(Post, Namespaced::Comment).results).to eq(results)
   end
 
   it 'gracefully returns empty results when response is nil' do
     stub_nil_results
-    session.search(Post).results.should == []
+    expect(session.search(Post).results).to eq([])
   end
 
   it 'returns search total as attribute of results' do
     stub_results(Post.new, 4)
-    session.search(Post) do
+    expect(session.search(Post) do
       paginate(:page => 1)
-    end.results.total_entries.should == 4
+    end.results.total_entries).to eq(4)
   end
 
   it 'returns total' do
     stub_results(Post.new, Post.new, 4)
-    session.search(Post) { paginate(:page => 1) }.total.should == 4
+    expect(session.search(Post) { paginate(:page => 1) }.total).to eq(4)
   end
 
   it 'returns query time' do
     stub_nil_results
     connection.response['responseHeader'] = { 'QTime' => 42 }
-    session.search(Post) { paginate(:page => 1) }.query_time.should == 42
+    expect(session.search(Post) { paginate(:page => 1) }.query_time).to eq(42)
   end
 
   it 'returns total for nil search' do
     stub_nil_results
-    session.search(Post).total.should == 0
+    expect(session.search(Post).total).to eq(0)
   end
 
   it 'returns available results if some results are not available from data store' do
     posts = [Post.new, Post.new]
     posts.last.destroy
     stub_results(*posts)
-    session.search(Post).results.should == posts[0..0]
+    expect(session.search(Post).results).to eq(posts[0..0])
   end
 
   it 'does not attempt to query the data store more than once when results are unavailable' do
@@ -67,6 +67,6 @@ describe 'search results', :type => :search do
     search = session.search(Post) do
       data_accessor_for(Post).should_receive(:load_all).once.and_return([])
     end
-    search.results.should == []
+    expect(search.results).to eq([])
   end
 end

--- a/sunspot/spec/api/search/results_spec.rb
+++ b/sunspot/spec/api/search/results_spec.rb
@@ -65,7 +65,7 @@ describe 'search results', :type => :search do
     posts.each { |post| post.destroy }
     stub_results(*posts)
     search = session.search(Post) do
-      data_accessor_for(Post).should_receive(:load_all).once.and_return([])
+      expect(data_accessor_for(Post)).to receive(:load_all).once.and_return([])
     end
     expect(search.results).to eq([])
   end

--- a/sunspot/spec/api/search/search_spec.rb
+++ b/sunspot/spec/api/search/search_spec.rb
@@ -6,7 +6,7 @@ describe Sunspot::Search do
     search = session.search Post do
       data_accessor_for(Post).custom_title = 'custom title'
     end
-    search.results.first.title.should == 'custom title'
+    expect(search.results.first.title).to eq('custom title')
   end
   
   it 'should re-execute search' do
@@ -14,10 +14,10 @@ describe Sunspot::Search do
     
     stub_results(post_1)
     search = session.search Post
-    search.results.should == [post_1]
+    expect(search.results).to eq([post_1])
     
     stub_results(post_2)
     search.execute!
-    search.results.should == [post_2]
+    expect(search.results).to eq([post_2])
   end
 end

--- a/sunspot/spec/api/search/stats_spec.rb
+++ b/sunspot/spec/api/search/stats_spec.rb
@@ -6,7 +6,7 @@ describe 'stats', :type => :search do
     result = session.search Post do
       stats :average_rating
     end
-    result.stats(:average_rating).field_name.should == :average_rating
+    expect(result.stats(:average_rating).field_name).to eq(:average_rating)
   end
 
   it 'returns min for stats field' do
@@ -14,7 +14,7 @@ describe 'stats', :type => :search do
     result = session.search Post do
       stats :average_rating
     end
-    result.stats(:average_rating).min.should == 1.0
+    expect(result.stats(:average_rating).min).to eq(1.0)
   end
 
   it 'returns max for stats field' do
@@ -22,7 +22,7 @@ describe 'stats', :type => :search do
     result = session.search Post do
       stats :average_rating
     end
-    result.stats(:average_rating).max.should == 5.0
+    expect(result.stats(:average_rating).max).to eq(5.0)
   end
 
   it 'returns count for stats field' do
@@ -30,7 +30,7 @@ describe 'stats', :type => :search do
     result = session.search Post do
       stats :average_rating
     end
-    result.stats(:average_rating).count.should == 120
+    expect(result.stats(:average_rating).count).to eq(120)
   end
 
   it 'returns sum for stats field' do
@@ -38,7 +38,7 @@ describe 'stats', :type => :search do
     result = session.search Post do
       stats :average_rating
     end
-    result.stats(:average_rating).sum.should == 2200.0
+    expect(result.stats(:average_rating).sum).to eq(2200.0)
   end
 
   it 'returns facet rows for stats field' do
@@ -51,7 +51,7 @@ describe 'stats', :type => :search do
         facet :featured
       end
     end
-    stats_facet_values(result, :average_rating, :featured).should == [false, true]
+    expect(stats_facet_values(result, :average_rating, :featured)).to eq([false, true])
   end
 
   it 'returns facet stats for stats field' do
@@ -63,8 +63,8 @@ describe 'stats', :type => :search do
         facet :featured
       end
     end
-    stats_facet_stats(result, :average_rating, :featured, true).min.should == 2.0
-    stats_facet_stats(result, :average_rating, :featured, true).max.should == 4.0
+    expect(stats_facet_stats(result, :average_rating, :featured, true).min).to eq(2.0)
+    expect(stats_facet_stats(result, :average_rating, :featured, true).max).to eq(4.0)
   end
 
   it 'returns instantiated stats facet values' do
@@ -76,7 +76,7 @@ describe 'stats', :type => :search do
         facet :blog_id
       end
     end
-    search.stats(:average_rating).facet(:blog_id).rows.map { |row| row.instance }.should == blogs
+    expect(search.stats(:average_rating).facet(:blog_id).rows.map { |row| row.instance }).to eq(blogs)
   end
 
   it 'only returns verified instances when requested' do
@@ -89,6 +89,6 @@ describe 'stats', :type => :search do
         facet :blog_id
       end
     end
-    search.stats(:average_rating).facet(:blog_id).rows(:verified => true).map { |row| row.instance }.should == [blog]
+    expect(search.stats(:average_rating).facet(:blog_id).rows(:verified => true).map { |row| row.instance }).to eq([blog])
   end
 end

--- a/sunspot/spec/api/session_proxy/class_sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/class_sharding_session_proxy_spec.rb
@@ -9,8 +9,8 @@ describe Sunspot::SessionProxy::ClassShardingSessionProxy do
     it "should delegate #{method} to appropriate shard" do
       post = Post.new
       photo = Photo.new
-      @proxy.post_session.should_receive(method).with([post])
-      @proxy.photo_session.should_receive(method).with([photo])
+      expect(@proxy.post_session).to receive(method).with([post])
+      expect(@proxy.photo_session).to receive(method).with([photo])
       @proxy.send(method, post)
       @proxy.send(method, photo)
     end
@@ -18,14 +18,14 @@ describe Sunspot::SessionProxy::ClassShardingSessionProxy do
 
   [:remove_by_id, :remove_by_id!].each do |method|
     it "should delegate #{method} to appropriate shard" do
-      @proxy.post_session.should_receive(method).with(Post, [1])
-      @proxy.photo_session.should_receive(method).with(Photo, [1])
+      expect(@proxy.post_session).to receive(method).with(Post, [1])
+      expect(@proxy.photo_session).to receive(method).with(Photo, [1])
       @proxy.send(method, Post, 1)
       @proxy.send(method, Photo, 1)
     end
     it "should delegate #{method} to appropriate shard given ids" do
-      @proxy.post_session.should_receive(method).with(Post, [1, 2])
-      @proxy.photo_session.should_receive(method).with(Photo, [1, 2])
+      expect(@proxy.post_session).to receive(method).with(Post, [1, 2])
+      expect(@proxy.photo_session).to receive(method).with(Photo, [1, 2])
       @proxy.send(method, Post, 1, 2)
       @proxy.send(method, Photo, [1, 2])
     end
@@ -33,15 +33,15 @@ describe Sunspot::SessionProxy::ClassShardingSessionProxy do
 
   [:remove_all, :remove_all!].each do |method|
     it "should delegate #{method} with argument to appropriate shard" do
-      @proxy.post_session.should_receive(method).with(Post)
-      @proxy.photo_session.should_receive(method).with(Photo)
+      expect(@proxy.post_session).to receive(method).with(Post)
+      expect(@proxy.photo_session).to receive(method).with(Photo)
       @proxy.send(method, Post)
       @proxy.send(method, Photo)
     end
 
     it "should delegate #{method} without argument to all shards" do
-      @proxy.post_session.should_receive(method)
-      @proxy.photo_session.should_receive(method)
+      expect(@proxy.post_session).to receive(method)
+      expect(@proxy.photo_session).to receive(method)
       @proxy.send(method)
     end
   end
@@ -49,42 +49,43 @@ describe Sunspot::SessionProxy::ClassShardingSessionProxy do
   [:commit, :commit_if_dirty, :commit_if_delete_dirty, :optimize].each do |method|
     it "should delegate #{method} to all sessions" do
       [@proxy.post_session, @proxy.photo_session].each do |session|
-        session.should_receive(method)
+        expect(session).to receive(method)
       end
       @proxy.send(method)
     end
   end
 
   it "should not support the :batch method" do
-    lambda { @proxy.batch }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
+    expect { @proxy.batch }.to raise_error(Sunspot::SessionProxy::NotSupportedError)
   end
 
   it "should delegate new_search to search session, adding in shards parameter" do
     search = @proxy.new_search(Post)
-    search.query[:shards].should ==
+    expect(search.query[:shards]).to eq(
       'http://photos.solr.local/solr,http://posts.solr.local/solr'
+    )
   end
 
   it "should delegate search to search session, adding in shards parameter" do
     @proxy.search(Post)
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :shards => 'http://photos.solr.local/solr,http://posts.solr.local/solr'
     )
   end
 
   [:dirty, :delete_dirty].each do |method|
     it "should be dirty if any of the sessions are dirty" do
-      @proxy.post_session.stub(:"#{method}?").and_return(true)
-      @proxy.should send("be_#{method}")
+      allow(@proxy.post_session).to receive(:"#{method}?").and_return(true)
+      expect(@proxy).to send("be_#{method}")
     end
 
     it "should not be dirty if none of the sessions are dirty" do
-      @proxy.should_not send("be_#{method}")
+      expect(@proxy).not_to send("be_#{method}")
     end
   end
 
   it "should raise a NotSupportedError when :config is called" do
-    lambda { @proxy.config }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
+    expect { @proxy.config }.to raise_error(Sunspot::SessionProxy::NotSupportedError)
   end
 
   it_should_behave_like 'session proxy'

--- a/sunspot/spec/api/session_proxy/id_sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/id_sharding_session_proxy_spec.rb
@@ -10,8 +10,8 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
   [:index, :index!, :remove, :remove!].each do |method|
     it "should delegate #{method} to appropriate shard" do
       posts = [Post.new(:id => 2), Post.new(:id => 1)]
-      @proxy.sessions[0].should_receive(method).with([posts[0]])
-      @proxy.sessions[1].should_receive(method).with([posts[1]])
+      expect(@proxy.sessions[0]).to receive(method).with([posts[0]])
+      expect(@proxy.sessions[1]).to receive(method).with([posts[1]])
       @proxy.send(method, posts[0])
       @proxy.send(method, posts[1])
     end
@@ -19,21 +19,21 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
 
   [:remove_by_id, :remove_by_id!].each do |method|
     it "should delegate #{method} to appropriate session" do
-      @proxy.sessions[1].should_receive(method).with(Post, [3])
-      @proxy.sessions[0].should_receive(method).with(Post, [2])
-      @proxy.sessions[1].should_receive(method).with(Post, [1])
+      expect(@proxy.sessions[1]).to receive(method).with(Post, [3])
+      expect(@proxy.sessions[0]).to receive(method).with(Post, [2])
+      expect(@proxy.sessions[1]).to receive(method).with(Post, [1])
       @proxy.send(method, Post, 1)
       @proxy.send(method, Post, 2)
       @proxy.send(method, Post, 3)
     end
     it "should delegate #{method} to appropriate session given splatted index ids" do
-      @proxy.sessions[0].should_receive(method).with(Post, [2])
-      @proxy.sessions[1].should_receive(method).with(Post, [1, 3])
+      expect(@proxy.sessions[0]).to receive(method).with(Post, [2])
+      expect(@proxy.sessions[1]).to receive(method).with(Post, [1, 3])
       @proxy.send(method, Post, 1, 2, 3)
     end
     it "should delegate #{method} to appropriate session given array of index ids" do
-      @proxy.sessions[0].should_receive(method).with(Post, [2])
-      @proxy.sessions[1].should_receive(method).with(Post, [1, 3])
+      expect(@proxy.sessions[0]).to receive(method).with(Post, [2])
+      expect(@proxy.sessions[1]).to receive(method).with(Post, [1, 3])
       @proxy.send(method, Post, [1, 2, 3])
     end
   end

--- a/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
@@ -15,26 +15,26 @@ describe Sunspot::SessionProxy::MasterSlaveSessionProxy do
         args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
           double('arg')
         end
-        instance_variable_get(:"@#{delegate}").should_receive(method).with(*args)
+        expect(instance_variable_get(:"@#{delegate}")).to receive(method).with(*args)
         @proxy.send(method, *args)
       end
     end
   end
 
   it 'should return master session config by default' do
-    @proxy.config.should eql(@master_session.config)
+    expect(@proxy.config).to eql(@master_session.config)
   end
 
   it 'should return master session config when specified' do
-    @proxy.config(:master).should eql(@master_session.config)
+    expect(@proxy.config(:master)).to eql(@master_session.config)
   end
 
   it 'should return slave session config when specified' do
-    @proxy.config(:slave).should eql(@slave_session.config)
+    expect(@proxy.config(:slave)).to eql(@slave_session.config)
   end
 
   it 'should raise ArgumentError when bogus config specified' do
-    lambda { @proxy.config(:bogus) }.should raise_error
+    expect { @proxy.config(:bogus) }.to raise_error
   end
 
   it_should_behave_like 'session proxy'

--- a/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
@@ -13,7 +13,7 @@ describe Sunspot::SessionProxy::MasterSlaveSessionProxy do
     methods.each do |method|
       it "should delegate #{method} to #{delegate}" do
         args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
-          stub('arg')
+          double('arg')
         end
         instance_variable_get(:"@#{delegate}").should_receive(method).with(*args)
         @proxy.send(method, *args)

--- a/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
@@ -15,7 +15,11 @@ describe Sunspot::SessionProxy::MasterSlaveSessionProxy do
         args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
           double('arg')
         end
-        expect(instance_variable_get(:"@#{delegate}")).to receive(method).with(*args)
+        if args.empty?
+          expect(instance_variable_get(:"@#{delegate}")).to receive(method).with(no_args)
+        else
+          expect(instance_variable_get(:"@#{delegate}")).to receive(method).with(*args)
+        end
         @proxy.send(method, *args)
       end
     end

--- a/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
@@ -33,14 +33,14 @@ describe Sunspot::SessionProxy::Retry5xxSessionProxy do
   end
 
   it "should behave normally without a stubbed exception" do
-    @sunspot_session.should_receive(:index).and_return(double)
+    expect(@sunspot_session).to receive(:index).and_return(double)
     Sunspot.index(post)
   end
 
   it "should be successful with a single exception followed by a sucess" do
     e = FakeRSolrErrorHttp.new(fake_rsolr_request, fake_rsolr_response(503))
-    @sunspot_session.should_receive(:index).and_return do
-      @sunspot_session.should_receive(:index).and_return(double)
+    expect(@sunspot_session).to receive(:index) do
+      expect(@sunspot_session).to receive(:index).and_return(double)
       raise e
     end
     Sunspot.index(post)
@@ -51,23 +51,23 @@ describe Sunspot::SessionProxy::Retry5xxSessionProxy do
     e = FakeRSolrErrorHttp.new(fake_rsolr_request, fake_response)
     fake_success = double('success')
 
-    @sunspot_session.should_receive(:index).and_return do
-      @sunspot_session.should_receive(:index).and_return do
-        @sunspot_session.stub(:index).and_return(fake_success)
+    expect(@sunspot_session).to receive(:index) do
+      expect(@sunspot_session).to receive(:index) do
+        allow(@sunspot_session).to receive(:index).and_return(fake_success)
         raise e
       end
       raise e
     end
 
     response = Sunspot.index(post)
-    response.should_not == fake_success
-    response.should == fake_response
+    expect(response).not_to eq(fake_success)
+    expect(response).to eq(fake_response)
   end
 
   it "should not retry a 4xx" do
     e = FakeRSolrErrorHttp.new(fake_rsolr_request, fake_rsolr_response(400))
-    @sunspot_session.should_receive(:index).and_raise(e)
-    lambda { Sunspot.index(post) }.should raise_error
+    expect(@sunspot_session).to receive(:index).and_raise(e)
+    expect { Sunspot.index(post) }.to raise_error
   end
 
   # TODO: try against more than just Sunspot.index? but that's just testing the

--- a/sunspot/spec/api/session_proxy/sharding_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/sharding_session_proxy_spec.rb
@@ -8,8 +8,8 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
   [:index, :index!, :remove, :remove!].each do |method|
     it "should delegate #{method} to appropriate shard" do
       posts = [Post.new(:blog_id => 2), Post.new(:blog_id => 3)]
-      @proxy.sessions[0].should_receive(method).with([posts[0]])
-      @proxy.sessions[1].should_receive(method).with([posts[1]])
+      expect(@proxy.sessions[0]).to receive(method).with([posts[0]])
+      expect(@proxy.sessions[1]).to receive(method).with([posts[1]])
       @proxy.send(method, posts[0])
       @proxy.send(method, posts[1])
     end
@@ -17,17 +17,17 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
 
   [:remove_by_id, :remove_by_id!, :atomic_update, :atomic_update!].each do |method|
     it "should raise NotSupportedError when #{method} called" do
-      lambda { @proxy.send(method, Post, 1) }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
+      expect { @proxy.send(method, Post, 1) }.to raise_error(Sunspot::SessionProxy::NotSupportedError)
     end
   end
 
   [:remove_all, :remove_all!].each do |method|
     it "should raise NotSupportedError when #{method} called with argument" do
-      lambda { @proxy.send(method, Post) }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
+      expect { @proxy.send(method, Post) }.to raise_error(Sunspot::SessionProxy::NotSupportedError)
     end
 
     it "should delegate #{method} without argument to all shards" do
-      @proxy.sessions.each { |session| session.should_receive(method) }
+      @proxy.sessions.each { |session| expect(session).to receive(method) }
       @proxy.send(method)
     end
   end
@@ -35,42 +35,43 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
   [:commit, :commit_if_dirty, :commit_if_delete_dirty, :optimize].each do |method|
     it "should delegate #{method} to all sessions" do
       @proxy.sessions.each do |session|
-        session.should_receive(method)
+        expect(session).to receive(method)
       end
       @proxy.send(method)
     end
   end
 
   it "should not support the :batch method" do
-    lambda { @proxy.batch }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
+    expect { @proxy.batch }.to raise_error(Sunspot::SessionProxy::NotSupportedError)
   end
 
   it "should delegate new_search to search session, adding in shards parameter" do
     search = @proxy.new_search(Post)
-    search.query[:shards].should ==
+    expect(search.query[:shards]).to eq(
       'http://localhost:8980/solr,http://localhost:8981/solr'
+    )
   end
 
   it "should delegate search to search session, adding in shards parameter" do
     @proxy.search(Post)
-    connection.should have_last_search_with(
+    expect(connection).to have_last_search_with(
       :shards => 'http://localhost:8980/solr,http://localhost:8981/solr'
     )
   end
 
   [:dirty, :delete_dirty].each do |method|
     it "should be dirty if any of the sessions are dirty" do
-      @proxy.sessions[0].stub(:"#{method}?").and_return(true)
-      @proxy.should send("be_#{method}")
+      allow(@proxy.sessions[0]).to receive(:"#{method}?").and_return(true)
+      expect(@proxy).to send("be_#{method}")
     end
 
     it "should not be dirty if none of the sessions are dirty" do
-      @proxy.should_not send("be_#{method}")
+      expect(@proxy).not_to send("be_#{method}")
     end
   end
 
   it "should raise a NotSupportedError when :config is called" do
-    lambda { @proxy.config }.should raise_error(Sunspot::SessionProxy::NotSupportedError)
+    expect { @proxy.config }.to raise_error(Sunspot::SessionProxy::NotSupportedError)
   end
 
   it_should_behave_like 'session proxy'

--- a/sunspot/spec/api/session_proxy/silent_fail_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/silent_fail_session_proxy_spec.rb
@@ -13,8 +13,8 @@ describe Sunspot::SessionProxy::ShardingSessionProxy do
   it "should call rescued_exception when an exception is caught" do
     SUPPORTED_METHODS.each do |method|
       e = FakeException.new(method)
-      @search_session.stub(method).and_raise(e)
-      @proxy.should_receive(:rescued_exception).with(method, e)
+      allow(@search_session).to receive(method).and_raise(e)
+      expect(@proxy).to receive(:rescued_exception).with(method, e)
       @proxy.send(method)
     end
   end

--- a/sunspot/spec/api/session_proxy/spec_helper.rb
+++ b/sunspot/spec/api/session_proxy/spec_helper.rb
@@ -3,7 +3,7 @@ require File.expand_path('spec_helper', File.join(File.dirname(__FILE__), '..'))
 shared_examples_for 'session proxy' do
   Sunspot::Session.public_instance_methods(false).each do |method|
     it "should respond to #{method.inspect}" do
-      @proxy.should respond_to(method)
+      expect(@proxy).to respond_to(method)
     end
   end
 end

--- a/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
@@ -39,7 +39,11 @@ describe Sunspot::SessionProxy::ThreadLocalSessionProxy do
         args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
           double('arg')
         end
-        expect(@proxy.session).to receive(method).with(*args)
+        if args.empty?
+          expect(@proxy.session).to receive(method).with(no_args)
+        else
+          expect(@proxy.session).to receive(method).with(*args)
+        end
         @proxy.send(method, *args)
       end
     end

--- a/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
@@ -17,7 +17,7 @@ describe Sunspot::SessionProxy::ThreadLocalSessionProxy do
     end
 
     it 'should have the same session for the same thread' do
-      @proxy.session.should eql(@proxy.session)
+      expect(@proxy.session).to eql(@proxy.session)
     end
 
     it 'should not have the same session for different threads' do
@@ -26,12 +26,12 @@ describe Sunspot::SessionProxy::ThreadLocalSessionProxy do
       Thread.new do
         session2 = @proxy.session
       end.join
-      session1.should_not eql(session2)
+      expect(session1).not_to eql(session2)
     end
 
     it 'should not have the same session for the same thread in different proxy instances' do
       proxy2 = Sunspot::SessionProxy::ThreadLocalSessionProxy.new(@config)
-      @proxy.session.should_not eql(proxy2.session)
+      expect(@proxy.session).not_to eql(proxy2.session)
     end
 
     (Sunspot::Session.public_instance_methods(false) - ['config', :config]).each do |method|
@@ -39,7 +39,7 @@ describe Sunspot::SessionProxy::ThreadLocalSessionProxy do
         args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
           double('arg')
         end
-        @proxy.session.should_receive(method).with(*args)
+        expect(@proxy.session).to receive(method).with(*args)
         @proxy.send(method, *args)
       end
     end

--- a/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/thread_local_session_proxy_spec.rb
@@ -37,7 +37,7 @@ describe Sunspot::SessionProxy::ThreadLocalSessionProxy do
     (Sunspot::Session.public_instance_methods(false) - ['config', :config]).each do |method|
       it "should delegate #{method.inspect} to its session" do
         args = Array.new(Sunspot::Session.instance_method(method).arity.abs) do
-          stub('arg')
+          double('arg')
         end
         @proxy.session.should_receive(method).with(*args)
         @proxy.send(method, *args)

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -7,7 +7,7 @@ shared_examples_for 'all sessions' do
     end
 
     it 'should add document to connection' do
-      connection.should have(1).adds
+      expect(connection.adds.size).to eq(1)
     end
   end
 
@@ -17,11 +17,11 @@ shared_examples_for 'all sessions' do
     end
 
     it 'should add document to connection' do
-      connection.should have(1).adds
+      expect(connection.adds.size).to eq(1)
     end
 
     it 'should commit' do
-      connection.should have(1).commits
+      expect(connection.commits.size).to eq(1)
     end
   end
 
@@ -31,27 +31,27 @@ shared_examples_for 'all sessions' do
     end
 
     it 'should commit' do
-      connection.should have(1).commits
+      expect(connection.commits.size).to eq(1)
     end
   end
 
   context '#commit(bool)' do
     it 'should soft-commit if bool=true' do
       @session.commit(true)
-      connection.should have(1).commits
-      connection.should have(1).soft_commits
+      expect(connection.commits.size).to eq(1)
+      expect(connection.soft_commits.size).to eq(1)
     end
 
     it 'should hard-commit if bool=false' do
       @session.commit(false)
-      connection.should have(1).commits
-      connection.should have(0).soft_commits
+      expect(connection.commits.size).to eq(1)
+      expect(connection.soft_commits.size).to eq(0)
     end
 
     it 'should hard-commit if bool is not specified' do
       @session.commit
-      connection.should have(1).commits
-      connection.should have(0).soft_commits
+      expect(connection.commits.size).to eq(1)
+      expect(connection.soft_commits.size).to eq(0)
     end
   end
 
@@ -61,7 +61,7 @@ shared_examples_for 'all sessions' do
     end
 
     it 'should optimize' do
-      connection.should have(1).optims
+      expect(connection.optims.size).to eq(1)
     end
   end
 
@@ -71,7 +71,7 @@ shared_examples_for 'all sessions' do
     end
 
     it 'should search' do
-      connection.should have(1).searches
+      expect(connection.searches.size).to eq(1)
     end
   end
 end
@@ -97,31 +97,31 @@ describe 'Session' do
 
     it 'should open connection with defaults if nothing specified' do
       Sunspot.commit
-      connection.opts[:url].should == 'http://127.0.0.1:8983/solr/default'
+      expect(connection.opts[:url]).to eq('http://127.0.0.1:8983/solr/default')
     end
 
     it 'should open a connection with custom host' do
       Sunspot.config.solr.url = 'http://127.0.0.1:8981/solr'
       Sunspot.commit
-      connection.opts[:url].should == 'http://127.0.0.1:8981/solr'
+      expect(connection.opts[:url]).to eq('http://127.0.0.1:8981/solr')
     end
 
     it 'should open a connection with custom read timeout' do
       Sunspot.config.solr.read_timeout = 0.5
       Sunspot.commit
-      connection.opts[:read_timeout].should == 0.5
+      expect(connection.opts[:read_timeout]).to eq(0.5)
     end
 
     it 'should open a connection with custom open timeout' do
       Sunspot.config.solr.open_timeout = 0.5
       Sunspot.commit
-      connection.opts[:open_timeout].should == 0.5
+      expect(connection.opts[:open_timeout]).to eq(0.5)
     end
 
     it 'should open a connection through a provided proxy' do
       Sunspot.config.solr.proxy = 'http://proxy.com:1234'
       Sunspot.commit
-      connection.opts[:proxy].should == 'http://proxy.com:1234'
+      expect(connection.opts[:proxy]).to eq('http://proxy.com:1234')
     end
   end
 
@@ -137,7 +137,7 @@ describe 'Session' do
         config.solr.url = 'http://127.0.0.1:8982/solr'
       end
       session.commit
-      connection.opts[:url].should == 'http://127.0.0.1:8982/solr'
+      expect(connection.opts[:url]).to eq('http://127.0.0.1:8982/solr')
     end
   end
 
@@ -147,111 +147,111 @@ describe 'Session' do
     end
 
     it 'should start out not dirty' do
-      @session.dirty?.should be(false)
+      expect(@session.dirty?).to be(false)
     end
 
     it 'should start out not delete_dirty' do
-      @session.delete_dirty?.should be(false)
+      expect(@session.delete_dirty?).to be(false)
     end
 
     it 'should be dirty after adding an item' do
       @session.index(Post.new)
-      @session.dirty?.should be(true)
+      expect(@session.dirty?).to be(true)
     end
 
     it 'should be not be delete_dirty after adding an item' do
       @session.index(Post.new)
-      @session.delete_dirty?.should be(false)
+      expect(@session.delete_dirty?).to be(false)
     end
 
     it 'should be dirty after deleting an item' do
       @session.remove(Post.new)
-      @session.dirty?.should be(true)
+      expect(@session.dirty?).to be(true)
     end
 
     it 'should be delete_dirty after deleting an item' do
       @session.remove(Post.new)
-      @session.delete_dirty?.should be(true)
+      expect(@session.delete_dirty?).to be(true)
     end
 
     it 'should be dirty after a remove_all for a class' do
       @session.remove_all(Post)
-      @session.dirty?.should be(true)
+      expect(@session.dirty?).to be(true)
     end
 
     it 'should be delete_dirty after a remove_all for a class' do
       @session.remove_all(Post)
-      @session.delete_dirty?.should be(true)
+      expect(@session.delete_dirty?).to be(true)
     end
 
     it 'should be dirty after a global remove_all' do
       @session.remove_all
-      @session.dirty?.should be(true)
+      expect(@session.dirty?).to be(true)
     end
 
     it 'should be delete_dirty after a global remove_all' do
       @session.remove_all
-      @session.delete_dirty?.should be(true)
+      expect(@session.delete_dirty?).to be(true)
     end
 
     it 'should not be dirty after a commit' do
       @session.index(Post.new)
       @session.commit
-      @session.dirty?.should be(false)
+      expect(@session.dirty?).to be(false)
     end
 
     it 'should not be dirty after an optimize' do
       @session.index(Post.new)
       @session.optimize
-      @session.dirty?.should be(false)
+      expect(@session.dirty?).to be(false)
     end
 
     it 'should not be delete_dirty after a commit' do
       @session.remove(Post.new)
       @session.commit
-      @session.delete_dirty?.should be(false)
+      expect(@session.delete_dirty?).to be(false)
     end
 
     it 'should not be delete_dirty after an optimize' do
       @session.remove(Post.new)
       @session.optimize
-      @session.delete_dirty?.should be(false)
+      expect(@session.delete_dirty?).to be(false)
     end
 
     it 'should not commit when commit_if_dirty called on clean session' do
       @session.commit_if_dirty
-      connection.should have(0).commits
+      expect(connection.commits.size).to eq(0)
     end
 
     it 'should not commit when commit_if_delete_dirty called on clean session' do
       @session.commit_if_delete_dirty
-      connection.should have(0).commits
+      expect(connection.commits.size).to eq(0)
     end
 
     it 'should hard commit when commit_if_dirty called on dirty session' do
       @session.index(Post.new)
       @session.commit_if_dirty
-      connection.should have(1).commits
+      expect(connection.commits.size).to eq(1)
     end
 
     it 'should soft commit when commit_if_dirty called on dirty session' do
       @session.index(Post.new)
       @session.commit_if_dirty(true)
-      connection.should have(1).commits
-      connection.should have(1).soft_commits
+      expect(connection.commits.size).to eq(1)
+      expect(connection.soft_commits.size).to eq(1)
     end
 
     it 'should hard commit when commit_if_delete_dirty called on delete_dirty session' do
       @session.remove(Post.new)
       @session.commit_if_delete_dirty
-      connection.should have(1).commits
+      expect(connection.commits.size).to eq(1)
     end
 
     it 'should soft commit when commit_if_delete_dirty called on delete_dirty session' do
       @session.remove(Post.new)
       @session.commit_if_delete_dirty(true)
-      connection.should have(1).commits
-      connection.should have(1).soft_commits
+      expect(connection.commits.size).to eq(1)
+      expect(connection.soft_commits.size).to eq(1)
     end
   end
 
@@ -260,7 +260,7 @@ describe 'Session' do
       stub_session = double('session')
       Sunspot.session = stub_session
       post = Post.new
-      stub_session.should_receive(:index).with(post)
+      expect(stub_session).to receive(:index).with(post)
       Sunspot.index(post)
       Sunspot.reset!
     end

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -147,75 +147,75 @@ describe 'Session' do
     end
 
     it 'should start out not dirty' do
-      @session.dirty?.should be_false
+      @session.dirty?.should be(false)
     end
 
     it 'should start out not delete_dirty' do
-      @session.delete_dirty?.should be_false
+      @session.delete_dirty?.should be(false)
     end
 
     it 'should be dirty after adding an item' do
       @session.index(Post.new)
-      @session.dirty?.should be_true
+      @session.dirty?.should be(true)
     end
 
     it 'should be not be delete_dirty after adding an item' do
       @session.index(Post.new)
-      @session.delete_dirty?.should be_false
+      @session.delete_dirty?.should be(false)
     end
 
     it 'should be dirty after deleting an item' do
       @session.remove(Post.new)
-      @session.dirty?.should be_true
+      @session.dirty?.should be(true)
     end
 
     it 'should be delete_dirty after deleting an item' do
       @session.remove(Post.new)
-      @session.delete_dirty?.should be_true
+      @session.delete_dirty?.should be(true)
     end
 
     it 'should be dirty after a remove_all for a class' do
       @session.remove_all(Post)
-      @session.dirty?.should be_true
+      @session.dirty?.should be(true)
     end
 
     it 'should be delete_dirty after a remove_all for a class' do
       @session.remove_all(Post)
-      @session.delete_dirty?.should be_true
+      @session.delete_dirty?.should be(true)
     end
 
     it 'should be dirty after a global remove_all' do
       @session.remove_all
-      @session.dirty?.should be_true
+      @session.dirty?.should be(true)
     end
 
     it 'should be delete_dirty after a global remove_all' do
       @session.remove_all
-      @session.delete_dirty?.should be_true
+      @session.delete_dirty?.should be(true)
     end
 
     it 'should not be dirty after a commit' do
       @session.index(Post.new)
       @session.commit
-      @session.dirty?.should be_false
+      @session.dirty?.should be(false)
     end
 
     it 'should not be dirty after an optimize' do
       @session.index(Post.new)
       @session.optimize
-      @session.dirty?.should be_false
+      @session.dirty?.should be(false)
     end
 
     it 'should not be delete_dirty after a commit' do
       @session.remove(Post.new)
       @session.commit
-      @session.delete_dirty?.should be_false
+      @session.delete_dirty?.should be(false)
     end
 
     it 'should not be delete_dirty after an optimize' do
       @session.remove(Post.new)
       @session.optimize
-      @session.delete_dirty?.should be_false
+      @session.delete_dirty?.should be(false)
     end
 
     it 'should not commit when commit_if_dirty called on clean session' do
@@ -257,7 +257,7 @@ describe 'Session' do
 
   context 'session proxy' do
     it 'should send messages to manually assigned session proxy' do
-      stub_session = stub('session')
+      stub_session = double('session')
       Sunspot.session = stub_session
       post = Post.new
       stub_session.should_receive(:index).with(post)

--- a/sunspot/spec/api/sunspot_spec.rb
+++ b/sunspot/spec/api/sunspot_spec.rb
@@ -7,8 +7,8 @@ describe Sunspot do
       Sunspot.setup(User) do
         text :name
       end
-      Sunspot.searchable.should_not be_empty
-      Sunspot.searchable.should include(User)
+      expect(Sunspot.searchable).not_to be_empty
+      expect(Sunspot.searchable).to include(User)
     end
   end
 
@@ -16,14 +16,14 @@ describe Sunspot do
     it "should reset current session" do
       old_session = Sunspot.send(:session)
       Sunspot.reset!(true)
-      Sunspot.send(:session).should_not == old_session
+      expect(Sunspot.send(:session)).not_to eq(old_session)
     end
 
     it "should keep keep configuration if specified" do
       Sunspot.config.solr.url = "http://localhost:9999/path/solr"
       config_before_reset = Sunspot.config
       Sunspot.reset!(true)
-      Sunspot.config.should == config_before_reset
+      expect(Sunspot.config).to eq(config_before_reset)
     end
   end
 end

--- a/sunspot/spec/integration/atomic_updates_spec.rb
+++ b/sunspot/spec/integration/atomic_updates_spec.rb
@@ -6,13 +6,13 @@ describe 'atomic updates' do
   end
 
   def validate_hit(hit, title, featured)
-    hit.stored(:title).should == title
-    hit.stored(:featured).should == featured
+    expect(hit.stored(:title)).to eq(title)
+    expect(hit.stored(:featured)).to eq(featured)
   end
 
   def find_indexed_post(id)
     hit = Sunspot.search(Post).hits.find{ |h| h.primary_key.to_i == id }
-    hit.should_not be_nil
+    expect(hit).not_to be_nil
     hit
   end
 

--- a/sunspot/spec/integration/dynamic_fields_spec.rb
+++ b/sunspot/spec/integration/dynamic_fields_spec.rb
@@ -10,11 +10,11 @@ shared_examples 'dynamic fields' do
   end
 
   it 'should search for dynamic string field' do
-    Sunspot.search(Post) do
+    expect(Sunspot.search(Post) do
       dynamic(field_name) do
         with(:cuisine, 'Pizza')
       end
-    end.results.should == [@posts.first]
+    end.results).to eq([@posts.first])
   end
 
   describe 'faceting' do
@@ -28,31 +28,31 @@ shared_examples 'dynamic fields' do
 
     it 'should return value "value" with count 2' do
       row = @search.dynamic_facet(field_name, :cuisine).rows[0]
-      row.value.should == 'Greek'
-      row.count.should == 2
+      expect(row.value).to eq('Greek')
+      expect(row.count).to eq(2)
     end
 
     it 'should return value "other" with count 1' do
       row = @search.dynamic_facet(field_name, :cuisine).rows[1]
-      row.value.should == 'Pizza'
-      row.count.should == 1
+      expect(row.value).to eq('Pizza')
+      expect(row.count).to eq(1)
     end
   end
 
   it 'should order by dynamic string field ascending' do
-    Sunspot.search(Post) do
+    expect(Sunspot.search(Post) do
       dynamic field_name do
         order_by :cuisine, :asc
       end
-    end.results.last.should == @posts.first
+    end.results.last).to eq(@posts.first)
   end
 
   it 'should order by dynamic string field descending' do
-    Sunspot.search(Post) do
+    expect(Sunspot.search(Post) do
       dynamic field_name do
         order_by :cuisine, :desc
       end
-    end.results.first.should == @posts.first
+    end.results.first).to eq(@posts.first)
   end
 end
 

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -27,14 +27,14 @@ describe 'search faceting' do
 
       it "should return value #{value1.inspect} with count 2" do
         row = @search.facet(field).rows[0]
-        row.value.should == value1
-        row.count.should == 2
+        expect(row.value).to eq(value1)
+        expect(row.count).to eq(2)
       end
 
       it "should return value #{value2.inspect} with count 1" do
         row = @search.facet(field).rows[1]
-        row.value.should == value2
-        row.count.should == 1
+        expect(row.value).to eq(value2)
+        expect(row.count).to eq(1)
       end
     end
   end
@@ -66,7 +66,7 @@ describe 'search faceting' do
       search = Sunspot.search(Post) do
         facet :title, :limit => 3
       end
-      search.facet(:title).should have(3).rows
+      expect(search.facet(:title).rows.size).to eq(3)
     end
 
     it 'should not return zeros by default' do
@@ -74,7 +74,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title
       end
-      search.facet(:title).rows.map { |row| row.value }.should_not include('zero')
+      expect(search.facet(:title).rows.map { |row| row.value }).not_to include('zero')
     end
 
     it 'should return zeros when specified' do
@@ -82,14 +82,14 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :zeros => true
       end
-      search.facet(:title).rows.map { |row| row.value }.should include('zero')
+      expect(search.facet(:title).rows.map { |row| row.value }).to include('zero')
     end
     
     it 'should return facet rows from an offset' do
       search = Sunspot.search(Post) do
         facet :title, :offset => 3
       end
-      search.facet(:title).rows.map { |row| row.value }.should == %w(one zero)
+      expect(search.facet(:title).rows.map { |row| row.value }).to eq(%w(one zero))
     end
 
     it 'should return a specified minimum count' do
@@ -97,7 +97,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :minimum_count => 2
       end
-      search.facet(:title).rows.map { |row| row.value }.should == %w(four three two)
+      expect(search.facet(:title).rows.map { |row| row.value }).to eq(%w(four three two))
     end
 
     it 'should order facets lexically' do
@@ -105,7 +105,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :sort => :index
       end
-      search.facet(:title).rows.map { |row| row.value }.should == %w(four one three two)
+      expect(search.facet(:title).rows.map { |row| row.value }).to eq(%w(four one three two))
     end
 
     it 'should order facets by count' do
@@ -113,7 +113,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :sort => :count
       end
-      search.facet(:title).rows.map { |row| row.value }.should == %w(four three two one)
+      expect(search.facet(:title).rows.map { |row| row.value }).to eq(%w(four three two one))
     end
 
     it 'should limit facet values by prefix' do
@@ -121,7 +121,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :prefix => 't'
       end
-      search.facet(:title).rows.map { |row| row.value }.sort.should == %w(three two)
+      expect(search.facet(:title).rows.map { |row| row.value }.sort).to eq(%w(three two))
     end
 
     it 'should return :all facet' do
@@ -129,8 +129,8 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :extra => :any
       end
-      search.facet(:title).rows.first.value.should == :any
-      search.facet(:title).rows.first.count.should == 10
+      expect(search.facet(:title).rows.first.value).to eq(:any)
+      expect(search.facet(:title).rows.first.count).to eq(10)
     end
 
     it 'should return :none facet' do
@@ -138,8 +138,8 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :extra => :none
       end
-      search.facet(:title).rows.first.value.should == :none
-      search.facet(:title).rows.first.count.should == 1
+      expect(search.facet(:title).rows.first.value).to eq(:none)
+      expect(search.facet(:title).rows.first.count).to eq(1)
     end
 
     it 'gives correct facet count when group == true and truncate == true' do
@@ -152,7 +152,7 @@ describe 'search faceting' do
       end
 
       # Should be 5 instead of 11
-      search.facet(:title).rows.first.count.should == 5
+      expect(search.facet(:title).rows.first.count).to eq(5)
     end
   end
 
@@ -170,7 +170,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :prefix => 'title '
       end
-      search.facet(:title).rows.map { |row| row.value }.sort.should == ["title with spaces 1", "title with spaces 2"]
+      expect(search.facet(:title).rows.map { |row| row.value }.sort).to eq(["title with spaces 1", "title with spaces 2"])
     end
 
     it 'should limit facet values by a prefix with slashes' do
@@ -178,7 +178,7 @@ describe 'search faceting' do
         with :blog_id, 1
         facet :title, :prefix => 'title/'
       end
-      search.facet(:title).rows.map { |row| row.value }.sort.should == ["title/with/slashes/1", "title/with/slashes/2"]
+      expect(search.facet(:title).rows.map { |row| row.value }.sort).to eq(["title/with/slashes/1", "title/with/slashes/2"])
     end
   end
 
@@ -199,7 +199,7 @@ describe 'search faceting' do
           category_filter = with(:category_ids, 1)
           facet(:category_ids, :exclude => category_filter)
         end
-        search.facet(:category_ids).rows.map { |row| row.value }.to_set.should == Set[1, 2]
+        expect(search.facet(:category_ids).rows.map { |row| row.value }.to_set).to eq(Set[1, 2])
       end
 
       it 'should use facet keys to facet more than once with different exclusions' do
@@ -209,8 +209,8 @@ describe 'search faceting' do
           facet(:category_ids)
           facet(:category_ids, :exclude => category_filter, :name => :all_category_ids)
         end
-        search.facet(:category_ids).rows.map { |row| row.value }.should == [1]
-        search.facet(:all_category_ids).rows.map { |row| row.value }.to_set.should == Set[1, 2]
+        expect(search.facet(:category_ids).rows.map { |row| row.value }).to eq([1])
+        expect(search.facet(:all_category_ids).rows.map { |row| row.value }.to_set).to eq(Set[1, 2])
       end
     end
 
@@ -228,7 +228,7 @@ describe 'search faceting' do
             end
           end
         end
-        search.facet(:category_ids).rows.map { |row| [row.value, row.count] }.to_set.should == Set[[:category_1, 1], [:category_2, 1]]
+        expect(search.facet(:category_ids).rows.map { |row| [row.value, row.count] }.to_set).to eq(Set[[:category_1, 1], [:category_2, 1]])
       end
 
       it 'should use facet keys to facet more than once with different exclusions' do
@@ -253,8 +253,8 @@ describe 'search faceting' do
             end
           end
         end
-        search.facet(:category_ids).rows.map { |row| [row.value, row.count] }.to_set.should == Set[[:category_1, 1]]
-        search.facet(:all_category_ids).rows.map { |row| [row.value, row.count] }.to_set.should == Set[[:category_1, 1], [:category_2, 1]]
+        expect(search.facet(:category_ids).rows.map { |row| [row.value, row.count] }.to_set).to eq(Set[[:category_1, 1]])
+        expect(search.facet(:all_category_ids).rows.map { |row| [row.value, row.count] }.to_set).to eq(Set[[:category_1, 1], [:category_2, 1]])
       end
     end
   end
@@ -273,10 +273,10 @@ describe 'search faceting' do
       search = Sunspot.search(Post) do
         facet :published_at, :time_range => time..(time + 60*60*24*2), :sort => :count
       end
-      search.facet(:published_at).rows.first.value.should == (time..(time + 60*60*24))
-      search.facet(:published_at).rows.first.count.should == 2
-      search.facet(:published_at).rows.last.value.should == ((time + 60*60*24)..(time + 60*60*24*2))
-      search.facet(:published_at).rows.last.count.should == 1
+      expect(search.facet(:published_at).rows.first.value).to eq(time..(time + 60*60*24))
+      expect(search.facet(:published_at).rows.first.count).to eq(2)
+      expect(search.facet(:published_at).rows.last.value).to eq((time + 60*60*24)..(time + 60*60*24*2))
+      expect(search.facet(:published_at).rows.last.count).to eq(1)
     end
   end
 
@@ -290,10 +290,10 @@ describe 'search faceting' do
       search = Sunspot.search(Post, Namespaced::Comment) do
         facet(:class, :sort => :count)
       end
-      search.facet(:class).rows.first.value.should == Post
-      search.facet(:class).rows.first.count.should == 2
-      search.facet(:class).rows.last.value.should == Namespaced::Comment
-      search.facet(:class).rows.last.count.should == 1
+      expect(search.facet(:class).rows.first.value).to eq(Post)
+      expect(search.facet(:class).rows.first.count).to eq(2)
+      expect(search.facet(:class).rows.last.value).to eq(Namespaced::Comment)
+      expect(search.facet(:class).rows.last.count).to eq(1)
     end
   end
 
@@ -319,12 +319,12 @@ describe 'search faceting' do
         end
       end
       facet = search.facet(:rating_range)
-      facet.rows[0].value.should == (3.0..4.0)
-      facet.rows[0].count.should == 3
-      facet.rows[1].value.should == (1.0..2.0)
-      facet.rows[1].count.should == 2
-      facet.rows[2].value.should == (4.0..5.0)
-      facet.rows[2].count.should == 1
+      expect(facet.rows[0].value).to eq(3.0..4.0)
+      expect(facet.rows[0].count).to eq(3)
+      expect(facet.rows[1].value).to eq(1.0..2.0)
+      expect(facet.rows[1].count).to eq(2)
+      expect(facet.rows[2].value).to eq(4.0..5.0)
+      expect(facet.rows[2].count).to eq(1)
     end
   end
 end

--- a/sunspot/spec/integration/field_grouping_spec.rb
+++ b/sunspot/spec/integration/field_grouping_spec.rb
@@ -19,8 +19,8 @@ describe "field grouping" do
       group :title
     end
 
-    search.group(:title).groups.should include { |g| g.value == "Title1" }
-    search.group(:title).groups.should include { |g| g.value == "Title2" }
+    expect(search.group(:title).groups).to include { |g| g.value == "Title1" }
+    expect(search.group(:title).groups).to include { |g| g.value == "Title2" }
   end
 
   it "returns the number of matches unique groups" do
@@ -28,7 +28,7 @@ describe "field grouping" do
       group :title
     end
 
-    search.group(:title).total.should == 2
+    expect(search.group(:title).total).to eq(2)
   end
 
   it "provides access to the number of matches before grouping" do
@@ -36,7 +36,7 @@ describe "field grouping" do
       group :title
     end
 
-    search.group(:title).matches.should == @posts.length
+    expect(search.group(:title).matches).to eq(@posts.length)
   end
 
   it "allows grouping by multiple fields" do
@@ -44,8 +44,8 @@ describe "field grouping" do
       group :title, :sort_title
     end
 
-    search.group(:title).groups.should_not be_empty
-    search.group(:sort_title).groups.should_not be_empty
+    expect(search.group(:title).groups).not_to be_empty
+    expect(search.group(:sort_title).groups).not_to be_empty
   end
 
   it "allows specification of the number of documents per group" do
@@ -56,7 +56,7 @@ describe "field grouping" do
     end
 
     title1_group = search.group(:title).groups.detect { |g| g.value == "Title1" }
-    title1_group.hits.length.should == 2
+    expect(title1_group.hits.length).to eq(2)
   end
 
   it "allows specification of the sort within groups" do
@@ -69,7 +69,7 @@ describe "field grouping" do
     highest_ranked_post = @posts.sort_by { |p| -p.ratings_average }.first
 
     title1_group = search.group(:title).groups.detect { |g| g.value == "Title1" }
-    title1_group.hits.first.primary_key.to_i.should == highest_ranked_post.id
+    expect(title1_group.hits.first.primary_key.to_i).to eq(highest_ranked_post.id)
   end
 
   it "allows specification of an ordering function within groups" do
@@ -82,7 +82,7 @@ describe "field grouping" do
     highest_ranked_post = @posts.sort_by { |p| -p.ratings_average }.first
 
     title1_group = search.group(:title).groups.detect { |g| g.value == "Title1" }
-    title1_group.hits.first.primary_key.to_i.should == highest_ranked_post.id
+    expect(title1_group.hits.first.primary_key.to_i).to eq(highest_ranked_post.id)
   end
 
   it "allows pagination within groups" do
@@ -91,8 +91,8 @@ describe "field grouping" do
       paginate :per_page => 1, :page => 2
     end
 
-    search.group(:title).groups.length.should eql(1)
-    search.group(:title).groups.first.results.should == [ @posts.last ]
+    expect(search.group(:title).groups.length).to eql(1)
+    expect(search.group(:title).groups.first.results).to eq([ @posts.last ])
   end
 
   context "returns a paginated collection" do
@@ -104,10 +104,10 @@ describe "field grouping" do
       search.group(:title).groups
     end
 
-    it { subject.per_page.should      eql(1)   }
-    it { subject.total_pages.should   eql(2)   }
-    it { subject.current_page.should  eql(2)   }
-    it { subject.first_page?.should   be(false) }
-    it { subject.last_page?.should    be(true)  }
+    it { expect(subject.per_page).to      eql(1)   }
+    it { expect(subject.total_pages).to   eql(2)   }
+    it { expect(subject.current_page).to  eql(2)   }
+    it { expect(subject.first_page?).to   be(false) }
+    it { expect(subject.last_page?).to    be(true)  }
   end
 end

--- a/sunspot/spec/integration/field_grouping_spec.rb
+++ b/sunspot/spec/integration/field_grouping_spec.rb
@@ -107,7 +107,7 @@ describe "field grouping" do
     it { subject.per_page.should      eql(1)   }
     it { subject.total_pages.should   eql(2)   }
     it { subject.current_page.should  eql(2)   }
-    it { subject.first_page?.should   be_false }
-    it { subject.last_page?.should    be_true  }
+    it { subject.first_page?.should   be(false) }
+    it { subject.last_page?.should    be(true)  }
   end
 end

--- a/sunspot/spec/integration/field_lists_spec.rb
+++ b/sunspot/spec/integration/field_lists_spec.rb
@@ -17,7 +17,7 @@ describe 'fields lists' do
     hit = Sunspot.search(Post).hits.first
 
     stored_field_names.each do |field|
-      hit.stored(field).should_not be_nil
+      expect(hit.stored(field)).not_to be_nil
     end
   end
 
@@ -27,10 +27,10 @@ describe 'fields lists' do
         field_list :title
       end.hits.first
 
-    hit.stored(:title).should == @post.title
+    expect(hit.stored(:title)).to eq(@post.title)
 
     (stored_field_names - [:title]).each do |field|
-      hit.stored(field).should be_nil
+      expect(hit.stored(field)).to be_nil
     end
   end
 end

--- a/sunspot/spec/integration/geospatial_spec.rb
+++ b/sunspot/spec/integration/geospatial_spec.rb
@@ -15,7 +15,7 @@ describe "geospatial search" do
         with(:coordinates_new).in_radius(32, -68, 1)
       }.results
 
-      results.should include(@post)
+      expect(results).to include(@post)
     end
 
     it "filters out posts not in the radius" do
@@ -23,7 +23,7 @@ describe "geospatial search" do
         with(:coordinates_new).in_radius(33, -68, 1)
       }.results
 
-      results.should_not include(@post)
+      expect(results).not_to include(@post)
     end
 
     it "allows conjunction queries with radius" do
@@ -34,7 +34,7 @@ describe "geospatial search" do
         end
       }.results
 
-      results.should include(@post)
+      expect(results).to include(@post)
     end
 
     it "allows conjunction queries with bounding box" do
@@ -45,7 +45,7 @@ describe "geospatial search" do
         end
       }.results
 
-      results.should include(@post)
+      expect(results).to include(@post)
     end
   end
 
@@ -63,7 +63,7 @@ describe "geospatial search" do
         with(:coordinates_new).in_bounding_box [31, -69], [33, -67]
       }.results
 
-      results.should include(@post)
+      expect(results).to include(@post)
     end
 
     it "filters out posts not in the bounding box" do
@@ -71,7 +71,7 @@ describe "geospatial search" do
         with(:coordinates_new).in_bounding_box [20, -70], [21, -69]
       }.results
 
-      results.should_not include(@post)
+      expect(results).not_to include(@post)
     end
   end
 
@@ -93,7 +93,7 @@ describe "geospatial search" do
         order_by_geodist(:coordinates_new, 32, -68)
       }.results
 
-      results.should == @posts.reverse
+      expect(results).to eq(@posts.reverse)
     end
 
     it "orders posts by distance descending" do
@@ -101,7 +101,7 @@ describe "geospatial search" do
         order_by_geodist(:coordinates_new, 32, -68, :desc)
       }.results
 
-      results.should == @posts
+      expect(results).to eq(@posts)
     end
   end
 end

--- a/sunspot/spec/integration/highlighting_spec.rb
+++ b/sunspot/spec/integration/highlighting_spec.rb
@@ -11,16 +11,16 @@ describe 'keyword highlighting' do
   end
   
   it 'should include highlights in the results' do
-    @search_result.hits.first.highlights.length.should == 1
+    expect(@search_result.hits.first.highlights.length).to eq(1)
   end
   
   it 'should return formatted highlight fragments' do
-    @search_result.hits.first.highlights(:body).first.format.should == 'And the <em>fox</em> laughed'
+    expect(@search_result.hits.first.highlights(:body).first.format).to eq('And the <em>fox</em> laughed')
   end
   
   it 'should be empty for non-keyword searches' do
     search_result = Sunspot.search(Post){ with :blog_id, 1 }
-    search_result.hits.first.highlights.should be_empty
+    expect(search_result.hits.first.highlights).to be_empty
   end
   
   it "should process multiple keyword request on different fields with highlights correctly" do
@@ -35,8 +35,8 @@ describe 'keyword highlighting' do
         end
       end
     end.to_not raise_error
-    search_results.results.length.should eq(1)
-    search_results.results.first.should eq(@posts.last)
+    expect(search_results.results.length).to eq(1)
+    expect(search_results.results.first).to eq(@posts.last)
     # this one might be a Solr bug, therefore not related to Sunspot itself
     # search_results.hits.first.highlights.should_not be_empty
   end

--- a/sunspot/spec/integration/indexing_spec.rb
+++ b/sunspot/spec/integration/indexing_spec.rb
@@ -2,23 +2,23 @@ require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 describe 'indexing' do
   it 'should index non-multivalued field with newlines' do
-    lambda do
+    expect do
       Sunspot.index!(Post.new(:title => "A\nTitle"))
-    end.should_not raise_error
+    end.not_to raise_error
   end
 
   it 'should correctly remove by model instance' do
     post = Post.new(:title => 'test post')
     Sunspot.index!(post)
     Sunspot.remove!(post)
-    Sunspot.search(Post) { with(:title, 'test post') }.results.should be_empty
+    expect(Sunspot.search(Post) { with(:title, 'test post') }.results).to be_empty
   end
 
   it 'should correctly delete by ID' do
     post = Post.new(:title => 'test post')
     Sunspot.index!(post)
     Sunspot.remove_by_id!(Post, post.id)
-    Sunspot.search(Post) { with(:title, 'test post') }.results.should be_empty
+    expect(Sunspot.search(Post) { with(:title, 'test post') }.results).to be_empty
   end
 
   it 'removes documents by query' do
@@ -29,7 +29,7 @@ describe 'indexing' do
     Sunspot.remove!(Post) do
       with(:title, 'birds')
     end
-    Sunspot.search(Post).should have(1).results
+    expect(Sunspot.search(Post).results.size).to eq(1)
   end
 
 

--- a/sunspot/spec/integration/keyword_search_spec.rb
+++ b/sunspot/spec/integration/keyword_search_spec.rb
@@ -19,8 +19,8 @@ describe 'keyword search' do
     context 'edismax' do
       it 'matches with wildcards' do
         results = Sunspot.search(Post) { keywords '*oas*' }.results
-        [0,2].each { |i| results.should include(@posts[i])}
-        [1].each { |i| results.should_not include(@posts[i])}
+        [0,2].each { |i| expect(results).to include(@posts[i])}
+        [1].each { |i| expect(results).not_to include(@posts[i])}
       end
 
       it 'matches multiple keywords on different fields with wildcards using subqueries' do
@@ -28,52 +28,52 @@ describe 'keyword search' do
           keywords 'insuffic*',:fields=>[:title]
           keywords 'win*',:fields=>[:body]
         end.results
-        [0].each {|i| results.should include(@posts[i])}
-        [1,2].each {|i| results.should_not include(@posts[i])}
+        [0].each {|i| expect(results).to include(@posts[i])}
+        [1,2].each {|i| expect(results).not_to include(@posts[i])}
       end
 
       it 'matches with proximity' do
         results = Sunspot.search(Post) { keywords '"wind buffer"~4' }.results
-        [0,1].each {|i| results.should_not include(@posts[i])}
-        [2].each {|i| results.should include(@posts[i])}
+        [0,1].each {|i| expect(results).not_to include(@posts[i])}
+        [2].each {|i| expect(results).to include(@posts[i])}
       end
 
       it 'does not match if not within proximity' do
         results = Sunspot.search(Post) { keywords '"wind buffer"~1' }.results
-        results.should == []
+        expect(results).to eq([])
       end
     end
 
     it 'matches a single keyword out of a single field' do
       results = Sunspot.search(Post) { keywords 'toast' }.results
-      [0, 2].each { |i| results.should include(@posts[i]) }
-      [1].each { |i| results.should_not include(@posts[i]) }
+      [0, 2].each { |i| expect(results).to include(@posts[i]) }
+      [1].each { |i| expect(results).not_to include(@posts[i]) }
     end
 
     it 'matches multiple words out of a single field' do
       results = Sunspot.search(Post) { keywords 'elects toast' }.results
-      results.should == [@posts[0]]
+      expect(results).to eq([@posts[0]])
     end
 
     it 'matches multiple words in multiple fields' do
       results = Sunspot.search(Post) { keywords 'toast wind' }.results
-      [0, 2].each { |i| results.should include(@posts[i]) }
-      [1].each { |i| results.should_not include(@posts[i]) }
+      [0, 2].each { |i| expect(results).to include(@posts[i]) }
+      [1].each { |i| expect(results).not_to include(@posts[i]) }
     end
 
     it 'matches multiple types' do
       results = Sunspot.search(Post, Namespaced::Comment) do
         keywords 'toast'
       end.results
-      [@posts[0], @posts[2], @comment].each  { |obj| results.should include(obj) }
-      results.should_not include(@posts[1])
+      [@posts[0], @posts[2], @comment].each  { |obj| expect(results).to include(obj) }
+      expect(results).not_to include(@posts[1])
     end
 
     it 'matches keywords from only the fields specified' do
       results = Sunspot.search(Post) do
         keywords 'moron', :fields => [:title]
       end.results
-      results.should == [@posts[1]]
+      expect(results).to eq([@posts[1]])
     end
 
     it 'matches multiple keywords on different fields using subqueries' do
@@ -81,13 +81,13 @@ describe 'keyword search' do
         keywords 'moron', :fields => [:title]
         keywords 'wind',  :fields => [:body]
       end
-      search.results.should == []
+      expect(search.results).to eq([])
 
       search = Sunspot.search(Post) do
         keywords 'moron',   :fields => [:title]
         keywords 'buffer',  :fields => [:body]
       end
-      search.results.should == [@posts[1]]
+      expect(search.results).to eq([@posts[1]])
     end
 
     it 'matches multiple keywords with escaped characters' do
@@ -95,7 +95,7 @@ describe 'keyword search' do
         keywords 'spirit',   :fields => [:title]
         keywords 'host\'s',  :fields => [:body]
       end
-      search.results.should == [@posts[2]]
+      expect(search.results).to eq([@posts[2]])
     end
 
     it 'matches multiple keywords with phrase-based search' do
@@ -104,7 +104,7 @@ describe 'keyword search' do
         keywords '"interpret the buffer"', :fields => [:body]
         keywords '"does the"', :fields => [:body]
       end
-      search.results.should == [@posts[2]]
+      expect(search.results).to eq([@posts[2]])
     end
 
     it 'matches multiple keywords different options' do
@@ -112,7 +112,7 @@ describe 'keyword search' do
         keywords 'insufficient nonexistent', :fields => [:title], :minimum_match => 1
         keywords 'wind does', :fields => [:body], :minimum_match => 2
       end
-      search.results.should == [@posts[0]]
+      expect(search.results).to eq([@posts[0]])
     end
   end
 
@@ -125,9 +125,10 @@ describe 'keyword search' do
 
     it 'should assign a higher score to the result matching the higher-boosted field' do
       search = Sunspot.search(Post) { keywords 'rhinoceros' }
-      search.hits.map { |hit| hit.primary_key }.should ==
+      expect(search.hits.map { |hit| hit.primary_key }).to eq(
         @posts.map { |post| post.id.to_s }
-      search.hits.first.score.should > search.hits.last.score
+      )
+      expect(search.hits.first.score).to be > search.hits.last.score
     end
   end
 
@@ -142,9 +143,10 @@ describe 'keyword search' do
 
     it 'should assign a higher score to the higher-boosted document' do
       search = Sunspot.search(Post) { keywords 'test' }
-      search.hits.map { |hit| hit.primary_key }.should ==
+      expect(search.hits.map { |hit| hit.primary_key }).to eq(
         @posts.map { |post| post.id.to_s }
-      search.hits.first.score.should > search.hits.last.score
+      )
+      expect(search.hits.first.score).to be > search.hits.last.score
     end
   end
 
@@ -164,8 +166,8 @@ describe 'keyword search' do
           phrase_fields :body => 2.0
         end
       end.hits
-      hits.first.instance.should == @comments.first
-      hits.first.score.should > hits.last.score
+      expect(hits.first.instance).to eq(@comments.first)
+      expect(hits.first.score).to be > hits.last.score
     end
 
     it 'assigns a higher score to documents in which the search terms appear in a boosted field' do
@@ -174,8 +176,8 @@ describe 'keyword search' do
           fields :body => 2.0, :author_name => 0.75
         end
       end.hits
-      hits.first.instance.should == @comments.first
-      hits.first.score.should > hits.last.score
+      expect(hits.first.instance).to eq(@comments.first)
+      expect(hits.first.score).to be > hits.last.score
     end
 
     it 'assigns a higher score to documents in which the search terms appear in a higher boosted phrase field' do
@@ -184,8 +186,8 @@ describe 'keyword search' do
           phrase_fields :body => 2.0, :author_name => 0.75
         end
       end.hits
-      hits.first.instance.should == @comments.first
-      hits.first.score.should > hits.last.score
+      expect(hits.first.instance).to eq(@comments.first)
+      expect(hits.first.score).to be > hits.last.score
     end
   end
 
@@ -210,8 +212,8 @@ describe 'keyword search' do
         end
         query.without(@posts[1])
       end
-      search.results.should == [@posts[0], @posts[2]]
-      search.hits[0].score.should > search.hits[1].score
+      expect(search.results).to eq([@posts[0], @posts[2]])
+      expect(search.hits[0].score).to be > search.hits[1].score
     end
 
     it 'should assign scores in order of multiple boost query match' do
@@ -221,9 +223,9 @@ describe 'keyword search' do
           boost(1.5) { with(:average_rating).greater_than(3.0) }
         end
       end
-      search.results.should == @posts
-      search.hits[0].score.should > search.hits[1].score
-      search.hits[1].score.should > search.hits[2].score
+      expect(search.results).to eq(@posts)
+      expect(search.hits[0].score).to be > search.hits[1].score
+      expect(search.hits[1].score).to be > search.hits[2].score
     end
   end
 
@@ -241,11 +243,11 @@ describe 'keyword search' do
     end
 
     it 'should match documents that contain the minimum_match number of search terms' do
-      @search.results.should include(@posts[0])
+      expect(@search.results).to include(@posts[0])
     end
 
     it 'should not match documents that do not contain the minimum_match number of search terms' do
-      @search.results.should_not include(@posts[1])
+      expect(@search.results).not_to include(@posts[1])
     end
   end
 
@@ -264,15 +266,15 @@ describe 'keyword search' do
     end
 
     it 'should match exact phrase' do
-      @search.results.should include(@posts[0])
+      expect(@search.results).to include(@posts[0])
     end
 
     it 'should match phrase divided by query phrase slop terms' do
-      @search.results.should include(@posts[1])
+      expect(@search.results).to include(@posts[1])
     end
 
     it 'should not match phrase divided by more than query phrase slop terms' do
-      @search.results.should_not include(@posts[2])
+      expect(@search.results).not_to include(@posts[2])
     end
   end
 
@@ -298,15 +300,15 @@ describe 'keyword search' do
     end
 
     it 'should give phrase field boost to exact match' do
-      @sorted_hits[0].score.should > @sorted_hits[1].score
+      expect(@sorted_hits[0].score).to be > @sorted_hits[1].score
     end
 
     it 'should give phrase field boost to match within slop' do
-      @sorted_hits[2].score.should > @sorted_hits[3].score
+      expect(@sorted_hits[2].score).to be > @sorted_hits[3].score
     end
 
     it 'should not give phrase field boost to match beyond slop' do
-      @sorted_hits[4].score.should == @sorted_hits[5].score
+      expect(@sorted_hits[4].score).to eq(@sorted_hits[5].score)
     end
   end
 
@@ -316,8 +318,8 @@ describe 'keyword search' do
     end
 
     after :each do
-      @search.results.should == @posts
-      @search.hits.first.score.should > @search.hits.last.score
+      expect(@search.results).to eq(@posts)
+      expect(@search.hits.first.score).to be > @search.hits.last.score
     end
 
     it 'boosts via function query with float' do

--- a/sunspot/spec/integration/local_search_spec.rb
+++ b/sunspot/spec/integration/local_search_spec.rb
@@ -25,13 +25,13 @@ describe 'local search' do
     end
 
     it 'should return results in geo order' do
-      @search.results.should == @posts
+      expect(@search.results).to eq(@posts)
     end
 
     it 'should asssign higher score to closer locations' do
       hits = @search.hits
       hits[1..-1].each_with_index do |hit, i|
-        hit.score.should < hits[i].score
+        expect(hit.score).to be < hits[i].score
       end
     end
   end
@@ -51,13 +51,13 @@ describe 'local search' do
     end
 
     it 'should take both fulltext and distance into account in ordering' do
-      @search.results.should == @posts
+      expect(@search.results).to eq(@posts)
     end
 
     it 'should take both fulltext and distance into account in scoring' do
       hits = @search.hits
       hits[1..-1].each_with_index do |hit, i|
-        hit.score.should < hits[i].score
+        expect(hit.score).to be < hits[i].score
       end
     end
   end

--- a/sunspot/spec/integration/more_like_this_spec.rb
+++ b/sunspot/spec/integration/more_like_this_spec.rb
@@ -14,30 +14,30 @@ describe 'more_like_this' do
   end
 
   it 'should return results for all MLT fields' do
-    Sunspot.more_like_this(@posts.first).results.to_set.should == @posts[1..3].to_set
+    expect(Sunspot.more_like_this(@posts.first).results.to_set).to eq(@posts[1..3].to_set)
   end
 
   it 'should return results for specified text field' do
-    Sunspot.more_like_this(@posts.first) do 
+    expect(Sunspot.more_like_this(@posts.first) do 
       fields :body
-    end.results.to_set.should == @posts[2..3].to_set
+    end.results.to_set).to eq(@posts[2..3].to_set)
   end
 
   it 'should return empty result set if no results' do
-    Sunspot.more_like_this(@posts.last) do
+    expect(Sunspot.more_like_this(@posts.last) do
       with(:title, 'bogus')
-    end.results.should == []
+    end.results).to eq([])
   end
 
   describe 'when non-indexed object searched' do
     before(:each) { @mlt = Sunspot.more_like_this(Post.new) }
 
     it 'should return empty result set' do
-      @mlt.results.should == []
+      expect(@mlt.results).to eq([])
     end
 
     it 'shoult return a total of 0' do
-      @mlt.total.should == 0
+      expect(@mlt.total).to eq(0)
     end
   end
 end

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -126,10 +126,7 @@ describe 'scoped_search' do
   test_field_type 'Trie Float', :average_rating, :average_rating, Photo, -2.5, 0.0, 3.2, 3.5, 16.0
   test_field_type 'Trie Time', :created_at, :created_at, Photo, *(['1970-01-01 00:00:00 UTC', '1983-07-08 04:00:00 UTC', '1983-07-08 02:00:00 -0500',
                                                                    '2005-11-05 10:00:00 UTC', Time.now.to_s].map { |t| Time.parse(t) })
-
   describe 'Date range field type' do
-    let(:january) { Date.new(2015,1,1)..Date.new(2015,1,31) }
-    let(:february) { Date.new(2015,2,1)..Date.new(2015,2,28) }
     let(:date_ranges) do
       {
         'December and January' => Date.new(2014,12,25)..Date.new(2015,1,10),
@@ -143,6 +140,8 @@ describe 'scoped_search' do
     end
 
     before :all do
+      january = Date.new(2015,1,1)..Date.new(2015,1,31)
+      february = Date.new(2015,2,1)..Date.new(2015,2,28)
       Sunspot.remove_all
       @posts = [Post.new(featured_for: january), Post.new(featured_for: february), Post.new]
       Sunspot.index!(@posts)

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -22,95 +22,95 @@ describe 'scoped_search' do
       end
 
       it 'should filter by exact match' do
-        Sunspot.search(clazz) { with(field, values[2]) }.results.should == [@objects[2]]
+        expect(Sunspot.search(clazz) { with(field, values[2]) }.results).to eq([@objects[2]])
       end
 
       it 'should reject by inexact match' do
         results = Sunspot.search(clazz) { without(field, values[2]) }.results
-        [0, 1, 3, 4].each { |i| results.should include(@objects[i]) }
-        results.should_not include(@objects[2])
+        [0, 1, 3, 4].each { |i| expect(results).to include(@objects[i]) }
+        expect(results).not_to include(@objects[2])
       end
 
       it 'should filter by less than' do
         results = Sunspot.search(clazz) { with(field).less_than values[2] }.results
-        (0..1).each { |i| results.should include(@objects[i]) }
-        (2..4).each { |i| results.should_not include(@objects[i]) }
+        (0..1).each { |i| expect(results).to include(@objects[i]) }
+        (2..4).each { |i| expect(results).not_to include(@objects[i]) }
       end
 
       it 'should reject by less than' do
         results = Sunspot.search(clazz) { without(field).less_than values[2] }.results
-        (0..1).each { |i| results.should_not include(@objects[i]) }
-        (2..4).each { |i| results.should include(@objects[i]) }
+        (0..1).each { |i| expect(results).not_to include(@objects[i]) }
+        (2..4).each { |i| expect(results).to include(@objects[i]) }
       end
 
       it 'should filter by less than or equal to' do
         results = Sunspot.search(clazz) { with(field).less_than_or_equal_to values[2] }.results
-        (0..2).each { |i| results.should include(@objects[i]) }
-        (3..4).each { |i| results.should_not include(@objects[i]) }
+        (0..2).each { |i| expect(results).to include(@objects[i]) }
+        (3..4).each { |i| expect(results).not_to include(@objects[i]) }
       end
 
       it 'should reject by less than or equal to' do
         results = Sunspot.search(clazz) { without(field).less_than_or_equal_to values[2] }.results
-        (0..2).each { |i| results.should_not include(@objects[i]) }
-        (3..4).each { |i| results.should include(@objects[i]) }
+        (0..2).each { |i| expect(results).not_to include(@objects[i]) }
+        (3..4).each { |i| expect(results).to include(@objects[i]) }
       end
 
       it 'should filter by greater than' do
         results = Sunspot.search(clazz) { with(field).greater_than values[2] }.results
-        (3..4).each { |i| results.should include(@objects[i]) }
-        (0..2).each { |i| results.should_not include(@objects[i]) }
+        (3..4).each { |i| expect(results).to include(@objects[i]) }
+        (0..2).each { |i| expect(results).not_to include(@objects[i]) }
       end
 
       it 'should reject by greater than' do
         results = Sunspot.search(clazz) { without(field).greater_than values[2] }.results
-        (3..4).each { |i| results.should_not include(@objects[i]) }
-        (0..2).each { |i| results.should include(@objects[i]) }
+        (3..4).each { |i| expect(results).not_to include(@objects[i]) }
+        (0..2).each { |i| expect(results).to include(@objects[i]) }
       end
 
       it 'should filter by greater than or equal to' do
         results = Sunspot.search(clazz) { with(field).greater_than_or_equal_to values[2] }.results
-        (2..4).each { |i| results.should include(@objects[i]) }
-        (0..1).each { |i| results.should_not include(@objects[i]) }
+        (2..4).each { |i| expect(results).to include(@objects[i]) }
+        (0..1).each { |i| expect(results).not_to include(@objects[i]) }
       end
 
       it 'should reject by greater than' do
         results = Sunspot.search(clazz) { without(field).greater_than_or_equal_to values[2] }.results
-        (2..4).each { |i| results.should_not include(@objects[i]) }
-        (0..1).each { |i| results.should include(@objects[i]) }
+        (2..4).each { |i| expect(results).not_to include(@objects[i]) }
+        (0..1).each { |i| expect(results).to include(@objects[i]) }
       end
 
       it 'should filter by between' do
         results = Sunspot.search(clazz) { with(field).between(values[1]..values[3]) }.results
-        (1..3).each { |i| results.should include(@objects[i]) }
-        [0, 4].each { |i| results.should_not include(@objects[i]) }
+        (1..3).each { |i| expect(results).to include(@objects[i]) }
+        [0, 4].each { |i| expect(results).not_to include(@objects[i]) }
       end
 
       it 'should reject by between' do
         results = Sunspot.search(clazz) { without(field).between(values[1]..values[3]) }.results
-        (1..3).each { |i| results.should_not include(@objects[i]) }
-        [0, 4].each { |i| results.should include(@objects[i]) }
+        (1..3).each { |i| expect(results).not_to include(@objects[i]) }
+        [0, 4].each { |i| expect(results).to include(@objects[i]) }
       end
 
       it 'should filter by any of' do
         results = Sunspot.search(clazz) { with(field).any_of(values.values_at(1, 3)) }.results
-        [1, 3].each { |i| results.should include(@objects[i]) }
-        [0, 2, 4].each { |i| results.should_not include(@objects[i]) }
+        [1, 3].each { |i| expect(results).to include(@objects[i]) }
+        [0, 2, 4].each { |i| expect(results).not_to include(@objects[i]) }
       end
 
       it 'should reject by any of' do
         results = Sunspot.search(clazz) { without(field).any_of(values.values_at(1, 3)) }.results
-        [1, 3].each { |i| results.should_not include(@objects[i]) }
-        [0, 2, 4].each { |i| results.should include(@objects[i]) }
+        [1, 3].each { |i| expect(results).not_to include(@objects[i]) }
+        [0, 2, 4].each { |i| expect(results).to include(@objects[i]) }
       end
 
       it 'should order by field ascending' do
         results = Sunspot.search(clazz) { order_by field, :asc }.results
-        results.should == @objects
+        expect(results).to eq(@objects)
       end
 
       it 'should order by field descending' do
         results = Sunspot.search(clazz) { order_by field, :desc }.results
-        results.should == @objects.reverse
+        expect(results).to eq(@objects.reverse)
       end
     end
   end
@@ -148,32 +148,32 @@ describe 'scoped_search' do
     end
 
     it 'should filter by Contains' do
-      featured_for_posts(:containing, Date.new(2015,1,15) ).should == [@posts[0]]
-      featured_for_posts(:containing, 'December and January').should be_empty
-      featured_for_posts(:containing, 'January only').should == [@posts[0]]
-      featured_for_posts(:containing, 'January only', negated = true).should == @posts[1..-1]
+      expect(featured_for_posts(:containing, Date.new(2015,1,15) )).to eq([@posts[0]])
+      expect(featured_for_posts(:containing, 'December and January')).to be_empty
+      expect(featured_for_posts(:containing, 'January only')).to eq([@posts[0]])
+      expect(featured_for_posts(:containing, 'January only', negated = true)).to eq(@posts[1..-1])
     end
 
     it 'should filter by Intersects' do
-      featured_for_posts(:intersecting, Date.new(2015,1,15) ).should == [@posts[0]]
-      featured_for_posts(:intersecting, 'January only').should == [@posts[0]]
-      featured_for_posts(:intersecting, 'January and February').should == @posts[0..1]
-      featured_for_posts(:intersecting, 'January and February', negated = true).should == [@posts[2]]
-      featured_for_posts(:intersecting, 'February only').should == [@posts[1]]
-      featured_for_posts(:intersecting, 'February only', negated = true).should == [@posts[0], @posts[2]]
+      expect(featured_for_posts(:intersecting, Date.new(2015,1,15) )).to eq([@posts[0]])
+      expect(featured_for_posts(:intersecting, 'January only')).to eq([@posts[0]])
+      expect(featured_for_posts(:intersecting, 'January and February')).to eq(@posts[0..1])
+      expect(featured_for_posts(:intersecting, 'January and February', negated = true)).to eq([@posts[2]])
+      expect(featured_for_posts(:intersecting, 'February only')).to eq([@posts[1]])
+      expect(featured_for_posts(:intersecting, 'February only', negated = true)).to eq([@posts[0], @posts[2]])
     end
 
     it 'should filter by Within' do
-      featured_for_posts(:within, Date.new(2015,1,15) ).should be_empty
+      expect(featured_for_posts(:within, Date.new(2015,1,15) )).to be_empty
       (date_ranges.keys - date_ranges.keys.grep(/ to /)).each do |key|
-        featured_for_posts(:within, key).should be_empty
+        expect(featured_for_posts(:within, key)).to be_empty
       end
-      featured_for_posts(:within, 'December to February').should == [@posts[0]]
-      featured_for_posts(:within, 'December to February', negated = true).should == @posts[1..-1]
-      featured_for_posts(:within, 'January to March').should == [@posts[1]]
-      featured_for_posts(:within, 'January to March', negated = true).should == [@posts[0], @posts[2]]
-      featured_for_posts(:within, 'December to March').should == @posts[0..1]
-      featured_for_posts(:within, 'December to March', negated = true).should == [@posts[2]]
+      expect(featured_for_posts(:within, 'December to February')).to eq([@posts[0]])
+      expect(featured_for_posts(:within, 'December to February', negated = true)).to eq(@posts[1..-1])
+      expect(featured_for_posts(:within, 'January to March')).to eq([@posts[1]])
+      expect(featured_for_posts(:within, 'January to March', negated = true)).to eq([@posts[0], @posts[2]])
+      expect(featured_for_posts(:within, 'December to March')).to eq(@posts[0..1])
+      expect(featured_for_posts(:within, 'December to March', negated = true)).to eq([@posts[2]])
     end
   end
 
@@ -185,11 +185,11 @@ describe 'scoped_search' do
     end
 
     it 'should filter by exact match for true' do
-      Sunspot.search(Post) { with(:featured, true) }.results.should == [@posts[0]]
+      expect(Sunspot.search(Post) { with(:featured, true) }.results).to eq([@posts[0]])
     end
 
     it 'should filter for exact match for false' do
-      Sunspot.search(Post) { with(:featured, false) }.results.should == [@posts[1]]
+      expect(Sunspot.search(Post) { with(:featured, false) }.results).to eq([@posts[1]])
     end
   end
 
@@ -197,7 +197,7 @@ describe 'scoped_search' do
     it "allows for using symbols in defining static field names" do
       Sunspot.remove_all
       Sunspot.index!(legacy = Post.new(:title => "foo"))
-      Sunspot.search(Post) { with(:legacy, "legacy foo") }.results.should == [legacy]
+      expect(Sunspot.search(Post) { with(:legacy, "legacy foo") }.results).to eq([legacy])
     end
   end
 
@@ -205,7 +205,7 @@ describe 'scoped_search' do
     %w(AND OR NOT TO).each do |word|
       it "should successfully search for #{word.inspect}" do
         Sunspot.index!(post = Post.new(:title => word))
-        Sunspot.search(Post) { with(:title, word) }.results.should == [post]
+        expect(Sunspot.search(Post) { with(:title, word) }.results).to eq([post])
       end
     end
   end
@@ -218,11 +218,11 @@ describe 'scoped_search' do
     end
 
     it 'should filter results without value for field' do
-      Sunspot.search(Post) { with(:title, nil) }.results.should == [@posts[1]]
+      expect(Sunspot.search(Post) { with(:title, nil) }.results).to eq([@posts[1]])
     end
 
     it 'should exclude results without value for field' do
-      Sunspot.search(Post) { without(:title, nil) }.results.should == [@posts[0]]
+      expect(Sunspot.search(Post) { without(:title, nil) }.results).to eq([@posts[0]])
     end
   end
 
@@ -236,7 +236,7 @@ describe 'scoped_search' do
     end
 
     it 'should return results whose prefix matches' do
-      Sunspot.search(Post) { with(:title).starting_with('test') }.results.should == @posts[0..1]
+      expect(Sunspot.search(Post) { with(:title).starting_with('test') }.results).to eq(@posts[0..1])
     end
   end
 
@@ -252,20 +252,20 @@ describe 'scoped_search' do
 
     it 'should only return included object' do
       included_post = @posts.shift
-      Sunspot.search(Post) { with(included_post) }.results.should include(included_post)
+      expect(Sunspot.search(Post) { with(included_post) }.results).to include(included_post)
     end
 
     it 'should not return objects not included' do
       included_post = @posts.shift
       for excluded_post in @posts
-        Sunspot.search(Post) { with(included_post) }.results.should_not include(excluded_post)
+        expect(Sunspot.search(Post) { with(included_post) }.results).not_to include(excluded_post)
       end
     end
 
     it 'should return included objects' do
       included_posts = [@posts.shift, @posts.shift]
       for included_post in included_posts
-        Sunspot.search(Post) { with(included_posts) }.results.should include(included_post)
+        expect(Sunspot.search(Post) { with(included_posts) }.results).to include(included_post)
       end
     end
   end
@@ -282,20 +282,20 @@ describe 'scoped_search' do
 
     it 'should not return excluded object' do
       excluded_post = @posts.shift
-      Sunspot.search(Post) { without(excluded_post) }.results.should_not include(excluded_post)
+      expect(Sunspot.search(Post) { without(excluded_post) }.results).not_to include(excluded_post)
     end
 
     it 'should return objects not excluded' do
       excluded_post = @posts.shift
       for included_post in @posts
-        Sunspot.search(Post) { without(excluded_post) }.results.should include(included_post)
+        expect(Sunspot.search(Post) { without(excluded_post) }.results).to include(included_post)
       end
     end
 
     it 'should not return excluded objects' do
       excluded_posts = [@posts.shift, @posts.shift]
       for excluded_post in excluded_posts
-        Sunspot.search(Post) { without(excluded_posts) }.results.should_not include(excluded_post)
+        expect(Sunspot.search(Post) { without(excluded_posts) }.results).not_to include(excluded_post)
       end
     end
   end
@@ -308,50 +308,50 @@ describe 'scoped_search' do
     it 'should return results that match any restriction in a disjunction' do
       posts = (1..3).map { |i| Post.new(:blog_id => i)}
       Sunspot.index!(posts)
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         any_of do
           with(:blog_id, 1)
           with(:blog_id, 2)
         end
-      end.results.should == posts[0..1]
+      end.results).to eq(posts[0..1])
     end
 
     it 'should return results, ignoring any restriction in a disjunction that has been passed an empty array' do
       posts = (1..3).map { |i| Post.new(:blog_id => i)}
       Sunspot.index!(posts)
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         with(:blog_id, [])
-      end.results.should == posts
+      end.results).to eq(posts)
     end
 
     it 'should return results, ignoring any restriction in a negative disjunction that has been passed an empty array' do
       posts = (1..3).map { |i| Post.new(:blog_id => i)}
       Sunspot.index!(posts)
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         without(:blog_id, [])
-      end.results.should == posts
+      end.results).to eq(posts)
     end 
 
     it 'should return results, ignoring any restriction in a conjunction that has been passed an empty array' do
       posts = (1..3).map { |i| Post.new(:blog_id => i)}
       Sunspot.index!(posts)
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         all_of do
           with(:blog_id, 1)
           with(:blog_id, [])
         end
-      end.results.should == posts[0..0]
+      end.results).to eq(posts[0..0])
     end
 
     it 'should return results, ignoring any restriction in a negative conjunction that has been passed an empty array' do
       posts = (1..3).map { |i| Post.new(:blog_id => i)}
       Sunspot.index!(posts)
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         all_of do
           with(:blog_id, 1)
           without(:blog_id, [])
         end
-      end.results.should == posts[0..0]
+      end.results).to eq(posts[0..0])
     end
 
     it 'should return results that match a nested conjunction in a disjunction' do
@@ -362,7 +362,7 @@ describe 'scoped_search' do
         Post.new(:title => 'No', :blog_id => 2)
       ]
       Sunspot.index!(posts)
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         any_of do
           with(:blog_id, 1)
           all_of do
@@ -370,7 +370,7 @@ describe 'scoped_search' do
             with(:title, 'Yes')
           end
         end
-      end.results.should == posts[0..1]
+      end.results).to eq(posts[0..1])
     end
 
     it 'should return results that match a conjunction with a negated restriction' do
@@ -386,7 +386,7 @@ describe 'scoped_search' do
           without(:title, 'No')
         end
       end
-      search.results.should == posts[0..1]
+      expect(search.results).to eq(posts[0..1])
     end
 
     it 'should return results that match a conjunction with a disjunction with a conjunction with a negated restriction' do
@@ -410,7 +410,7 @@ describe 'scoped_search' do
           end
         end
       end
-      search.results.should == posts[0..2]
+      expect(search.results).to eq(posts[0..2])
     end
 
     it 'should return results that match a disjunction with a negated restriction and a nested disjunction in a conjunction with a negated restriction' do
@@ -435,7 +435,7 @@ describe 'scoped_search' do
           end
         end
       end
-      search.results.should == posts[0..2]
+      expect(search.results).to eq(posts[0..2])
     end
   end
 
@@ -455,7 +455,7 @@ describe 'scoped_search' do
         order_by :average_rating, :desc
         order_by :sort_title, :asc
       end
-      search.results.should == @posts
+      expect(search.results).to eq(@posts)
     end
   end
 
@@ -471,7 +471,7 @@ describe 'scoped_search' do
           result.id
         end
       end
-      result_sets[0].should_not == result_sets[1]
+      expect(result_sets[0]).not_to eq(result_sets[1])
     end
 
     # This could fail if the random set returned just happens to be the same as the last random set (the nature of randomness)
@@ -481,7 +481,7 @@ describe 'scoped_search' do
           result.id
         end
       end
-      result_sets[0].should_not == result_sets[1]
+      expect(result_sets[0]).not_to eq(result_sets[1])
     end
 
     context 'when providing a custom seed value' do
@@ -496,14 +496,14 @@ describe 'scoped_search' do
         next_results = Sunspot.search(Post) do
           order_by(:random, :seed => 54321)
         end.results.map { |result| result.id }
-        next_results.should_not == @first_results
+        expect(next_results).not_to eq(@first_results)
       end
 
       it 'should return the same results when passing the same seed value' do
         next_results = Sunspot.search(Post) do
           order_by(:random, :seed => 12345)
         end.results.map { |result| result.id }
-        next_results.should == @first_results
+        expect(next_results).to eq(@first_results)
       end
     end
   end
@@ -519,22 +519,22 @@ describe 'scoped_search' do
     it 'should order by sum' do
       # 1+3 > 2+1
       search = Sunspot.search(Post) {order_by_function :sum, :blog_id, :primary_category_id, :desc}
-      search.results.first.should == @p1
+      expect(search.results.first).to eq(@p1)
     end
     it 'should order by product and sum' do
       # 1 * (1+3) < 2 * (2+1)
       search = Sunspot.search(Post) { order_by_function :product, :blog_id, [:sum,:blog_id,:primary_category_id], :desc}
-      search.results.first.should == @p2
+      expect(search.results.first).to eq(@p2)
     end
     it 'should accept string literals' do
       # (1 * -2) > (2 * -2)
       search = Sunspot.search(Post) {order_by_function :product, :blog_id, '-2', :desc}
-      search.results.first.should == @p1
+      expect(search.results.first).to eq(@p1)
     end
     it 'should accept non-string literals' do
       # (1 * -2) > (2 * -2)
       search = Sunspot.search(Post) {order_by_function :product, :blog_id, -2, :desc}
-      search.results.first.should == @p1
+      expect(search.results.first).to eq(@p1)
     end
   end
 end

--- a/sunspot/spec/integration/spellcheck_spec.rb
+++ b/sunspot/spec/integration/spellcheck_spec.rb
@@ -21,7 +21,7 @@ describe 'spellcheck' do
     search = Sunspot.search(Post) do
       keywords 'Closure'
     end
-    search.spellcheck_suggestions.should == {}
+    expect(search.spellcheck_suggestions).to eq({})
   end
 
   it 'returns the list of suggestions' do
@@ -29,9 +29,9 @@ describe 'spellcheck' do
       keywords 'Closure'
       spellcheck :count => 3
     end
-    search.spellcheck_suggestions['closure']['suggestion'].should == [
+    expect(search.spellcheck_suggestions['closure']['suggestion']).to eq([
       {'word'=>'clojure', 'freq'=>2}, {'word'=>'conjure', 'freq'=>1}
-    ]
+    ])
   end
 
   it 'returns suggestion with highest frequency' do
@@ -39,7 +39,7 @@ describe 'spellcheck' do
       keywords 'Closure'
       spellcheck :count => 3
     end
-    search.spellcheck_suggestion_for('closure').should == 'clojure'
+    expect(search.spellcheck_suggestion_for('closure')).to eq('clojure')
   end
 
   it 'returns suggestion without collation when only more popular is true' do
@@ -48,7 +48,7 @@ describe 'spellcheck' do
       spellcheck :count => 3, :only_more_popular => true, :collate => false
     end
 
-    search.spellcheck_suggestion_for('closure').should == 'clojure'
+    expect(search.spellcheck_suggestion_for('closure')).to eq('clojure')
   end
 
   context 'spellcheck collation' do
@@ -58,7 +58,7 @@ describe 'spellcheck' do
         keywords 'lojure developing'
         spellcheck :count => 3, :only_more_popular => true
       end
-      search.spellcheck_collation('lojure', 'developing').should == 'clojure developing'
+      expect(search.spellcheck_collation('lojure', 'developing')).to eq('clojure developing')
     end
 
     it 'returns Solr collation if terms are not provided' do
@@ -67,7 +67,7 @@ describe 'spellcheck' do
         keywords 'lojure developing'
         spellcheck :count => 3, :only_more_popular => true
       end
-      search.spellcheck_collation.should == 'clojure developer'
+      expect(search.spellcheck_collation).to eq('clojure developer')
     end
 
     it 'returns Solr collation if terms are not provided even for single word' do
@@ -76,7 +76,7 @@ describe 'spellcheck' do
         keywords 'lojure'
         spellcheck :count => 3, :only_more_popular => true
       end
-      search.spellcheck_collation.should == 'clojure'
+      expect(search.spellcheck_collation).to eq('clojure')
     end
 
     it 'returns Solr collation if terms are provided even for single word' do
@@ -85,7 +85,7 @@ describe 'spellcheck' do
         keywords 'lojure'
         spellcheck :count => 3
       end
-      search.spellcheck_collation.should == 'clojure'
+      expect(search.spellcheck_collation).to eq('clojure')
     end
 
     it 'returns Solr collation if terms are provided even for single word' do
@@ -94,7 +94,7 @@ describe 'spellcheck' do
         keywords 'lojure'
         spellcheck :count => 3
       end
-      search.spellcheck_collation('lojure').should == 'clojure'
+      expect(search.spellcheck_collation('lojure')).to eq('clojure')
     end
 
     it 'returns Solr collation if terms are provided even if single keyword is word' do
@@ -103,7 +103,7 @@ describe 'spellcheck' do
         keywords 'C++, lojure Developer'
         spellcheck :count => 3
       end
-      search.spellcheck_collation.should == 'C++, clojure Developer'
+      expect(search.spellcheck_collation).to eq('C++, clojure Developer')
     end
 
     it 'returns nil if terms are provided which varies from actual keywords' do
@@ -112,7 +112,7 @@ describe 'spellcheck' do
         keywords 'clojure'
         spellcheck :count => 3
       end
-      search.spellcheck_collation('lojure').should == nil
+      expect(search.spellcheck_collation('lojure')).to eq(nil)
     end
   end
 

--- a/sunspot/spec/integration/stats_spec.rb
+++ b/sunspot/spec/integration/stats_spec.rb
@@ -10,38 +10,38 @@ describe 'search stats' do
   end
 
   it 'returns minimum stats' do
-    Sunspot.search(Post) do
+    expect(Sunspot.search(Post) do
       stats :average_rating
-    end.stats(:average_rating).min.should == 3.0
+    end.stats(:average_rating).min).to eq(3.0)
   end
 
   it 'returns maximum stats' do
-    Sunspot.search(Post) do
+    expect(Sunspot.search(Post) do
       stats :average_rating
-    end.stats(:average_rating).max.should == 4.0
+    end.stats(:average_rating).max).to eq(4.0)
   end
 
   it 'returns count stats' do
-    Sunspot.search(Post) do
+    expect(Sunspot.search(Post) do
       stats :average_rating
-    end.stats(:average_rating).count.should == 3
+    end.stats(:average_rating).count).to eq(3)
   end
 
   describe 'facets' do
     it 'returns minimum on facet row with two blog ids' do
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         stats :average_rating do
           facet :blog_id
         end
-      end.stats(:average_rating).facet(:blog_id).rows[1].min.should == 3.0
+      end.stats(:average_rating).facet(:blog_id).rows[1].min).to eq(3.0)
     end
 
     it 'returns maximum on facet row with two blog ids' do
-      Sunspot.search(Post) do
+      expect(Sunspot.search(Post) do
         stats :average_rating do
           facet :blog_id
         end
-      end.stats(:average_rating).facet(:blog_id).rows[1].max.should == 4.0
+      end.stats(:average_rating).facet(:blog_id).rows[1].max).to eq(4.0)
     end
   end
 end

--- a/sunspot/spec/integration/stored_fields_spec.rb
+++ b/sunspot/spec/integration/stored_fields_spec.rb
@@ -7,6 +7,6 @@ describe 'stored fields' do
   end
 
   it 'should return stored fields' do
-    Sunspot.search(Post).hits.first.stored(:title).should == 'A Title'
+    expect(Sunspot.search(Post).hits.first.stored(:title)).to eq('A Title')
   end
 end

--- a/sunspot/spec/integration/test_pagination.rb
+++ b/sunspot/spec/integration/test_pagination.rb
@@ -11,7 +11,7 @@ describe 'pagination' do
 
   it 'should return all by default' do
     results = Sunspot.search(Post) { order_by :blog_id }.results
-    results.should == @posts
+    expect(results).to eq(@posts)
   end
 
   it 'should return first page of 10' do
@@ -19,7 +19,7 @@ describe 'pagination' do
       order_by :blog_id
       paginate :page => 1, :per_page => 10
     end.results
-    results.should == @posts[0,10]
+    expect(results).to eq(@posts[0,10])
   end
 
   it 'should return second page of 10' do
@@ -27,7 +27,7 @@ describe 'pagination' do
       order_by :blog_id
       paginate :page => 2, :per_page => 10
     end.results
-    results.should == @posts[10,10]
+    expect(results).to eq(@posts[10,10])
   end
 
   it 'should return pages with offsets' do
@@ -38,6 +38,6 @@ describe 'pagination' do
 
     # page 1 is 3, 4, 5, 6, 7
     # page 2 is 8, 9, 10, 11, 12
-    results.should == @posts[8,5]
+    expect(results).to eq(@posts[8,5])
   end
 end

--- a/sunspot/spec/integration/unicode_spec.rb
+++ b/sunspot/spec/integration/unicode_spec.rb
@@ -10,6 +10,6 @@ describe "unicode characters" do
   end
 
   it "correctly retrieves the string as UTF-8" do
-    Sunspot.search(Post).hits.first.stored(:title).should == "Híghgrøøvé"
+    expect(Sunspot.search(Post).hits.first.stored(:title)).to eq("Híghgrøøvé")
   end
 end

--- a/sunspot/spec/spec_helper.rb
+++ b/sunspot/spec/spec_helper.rb
@@ -13,27 +13,32 @@ end
 require File.join(File.dirname(__FILE__), 'ext')
 
 RSpec.configure do |config|
-  # Run only examples with :focus => true
-  config.filter_run :focus => true
+  config.filter_run :focus
   config.run_all_when_everything_filtered = true
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = 'random'
 
   # Mock session available to all spec/api tests
   config.include MockSessionHelper,
                  :type => :api,
-                 :example_group => {:file_path => /spec[\\\/]api/}
+                 :file_path => /spec[\\\/]api/
 
   # Real Solr instance is available to integration tests
   config.include IntegrationHelper,
                  :type => :integration,
-                 :example_group => {:file_path => /spec[\\\/]integration/}
+                 :file_path => /spec[\\\/]integration/
 
   # Nested under spec/api
   [:indexer, :query, :search].each do |spec_type|
     helper_name = "#{spec_type}_helper"
 
     config.include Sunspot::Util.full_const_get(Sunspot::Util.camel_case(helper_name)),
-                   :type          => spec_type,
-                   :example_group => {:file_path => /spec[\\\/]api[\\\/]#{spec_type}/}
+                   :type => spec_type,
+                   :file_path => /spec[\\\/]api[\\\/]#{spec_type}/
   end
 end
 

--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rsolr', '>= 1.1.1', '< 3'
   s.add_dependency 'pr_geohash', '~>1.0'
 
-  s.add_development_dependency 'rspec', '~>2.6.0'
+  s.add_development_dependency 'rspec', '~> 2.99.0'
 
   s.rdoc_options << '--webcvs=http://github.com/outoftime/sunspot/tree/master/%s' <<
                   '--title' << 'Sunspot - Solr-powered search for Ruby objects - API Documentation' <<

--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rsolr', '>= 1.1.1', '< 3'
   s.add_dependency 'pr_geohash', '~>1.0'
 
-  s.add_development_dependency 'rspec', '~> 2.99.0'
+  s.add_development_dependency 'rspec', '~> 3.6.0'
 
   s.rdoc_options << '--webcvs=http://github.com/outoftime/sunspot/tree/master/%s' <<
                   '--title' << 'Sunspot - Solr-powered search for Ruby objects - API Documentation' <<

--- a/sunspot_rails/gemfiles/rails-3.0.0
+++ b/sunspot_rails/gemfiles/rails-3.0.0
@@ -11,7 +11,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-3.1.0
+++ b/sunspot_rails/gemfiles/rails-3.1.0
@@ -11,7 +11,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-3.2.0
+++ b/sunspot_rails/gemfiles/rails-3.2.0
@@ -11,7 +11,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -15,7 +15,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -15,7 +15,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end
 

--- a/sunspot_rails/gemfiles/rails-4.2.0
+++ b/sunspot_rails/gemfiles/rails-4.2.0
@@ -15,7 +15,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end
 

--- a/sunspot_rails/gemfiles/rails-5.0
+++ b/sunspot_rails/gemfiles/rails-5.0
@@ -11,7 +11,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes_continued'
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end
 

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -2,50 +2,50 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" do
   before(:each) do
-    File.stub(:exist?).and_return(false) # simulate sunspot.yml not existing
+    allow(File).to receive(:exist?).and_return(false) # simulate sunspot.yml not existing
     @config = Sunspot::Rails::Configuration.new
   end
 
   it "should handle the 'hostname' property when not set" do
-    @config.hostname.should == 'localhost'
+    expect(@config.hostname).to eq('localhost')
   end
 
   it "should handle the 'path' property when not set" do
-    @config.path.should == '/solr/default'
+    expect(@config.path).to eq('/solr/default')
   end
 
   it "should set the scheme to http" do
-    @config.scheme.should == "http"
+    expect(@config.scheme).to eq("http")
   end
 
   it "should not have userinfo" do
-    @config.userinfo.should be_nil
+    expect(@config.userinfo).to be_nil
   end
 
   it "should not set a proxy" do
-    @config.proxy.should be_nil
+    expect(@config.proxy).to be_nil
   end
 
   describe "port" do
     it "should default to port 8981 in test" do
-      ::Rails.stub(:env => 'test')
+      allow(::Rails).to receive_messages(:env => 'test')
       @config = Sunspot::Rails::Configuration.new
-      @config.port.should == 8981
+      expect(@config.port).to eq(8981)
     end
     it "should default to port 8982 in development" do
-      ::Rails.stub(:env => 'development')
+      allow(::Rails).to receive_messages(:env => 'development')
       @config = Sunspot::Rails::Configuration.new
-      @config.port.should == 8982
+      expect(@config.port).to eq(8982)
     end
     it "should default to 8983 in production" do
-      ::Rails.stub(:env => 'production')
+      allow(::Rails).to receive_messages(:env => 'production')
       @config = Sunspot::Rails::Configuration.new
-      @config.port.should == 8983
+      expect(@config.port).to eq(8983)
     end
     it "should generally default to 8983" do
-      ::Rails.stub(:env => 'staging')
+      allow(::Rails).to receive_messages(:env => 'staging')
       @config = Sunspot::Rails::Configuration.new
-      @config.port.should == 8983
+      expect(@config.port).to eq(8983)
     end
   end
 
@@ -58,139 +58,139 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   end
 
   it "should set 'log_level' property using Rails log level when not set" do
-    ::Rails.logger.stub(:level){ 3 }
-    @config.log_level.should == 'SEVERE'
+    allow(::Rails.logger).to receive(:level){ 3 }
+    expect(@config.log_level).to eq('SEVERE')
   end
 
   it "should handle the 'log_file' property" do
-    @config.log_file.should =~ /log\/solr_test.log/
+    expect(@config.log_file).to match(/log\/solr_test.log/)
   end
 
   it "should handle the 'solr_home' property when not set" do
-    Rails.should_receive(:root).at_least(1).and_return('/some/path')
-    @config.solr_home.should == '/some/path/solr'
+    expect(Rails).to receive(:root).at_least(1).and_return('/some/path')
+    expect(@config.solr_home).to eq('/some/path/solr')
   end
 
   it "should handle the 'pid_dir' property when not set" do
-    Rails.should_receive(:root).at_least(1).and_return('/some/path')
-    @config.pid_dir.should == '/some/path/solr/pids/test'
+    expect(Rails).to receive(:root).at_least(1).and_return('/some/path')
+    expect(@config.pid_dir).to eq('/some/path/solr/pids/test')
   end
 
   it "should handle the 'auto_commit_after_request' propery when not set" do
-    @config.auto_commit_after_request?.should == true
+    expect(@config.auto_commit_after_request?).to eq(true)
   end
 
   it "should handle the 'auto_commit_after_delete_request' propery when not set" do
-    @config.auto_commit_after_delete_request?.should == false
+    expect(@config.auto_commit_after_delete_request?).to eq(false)
   end
 
   it "should handle the 'bind_address' property when not set" do
-    @config.bind_address.should be_nil
+    expect(@config.bind_address).to be_nil
   end
 
   it "should handle the 'disabled' property when not set" do
-    @config.disabled?.should be_false
+    expect(@config.disabled?).to be_falsey
   end
 
   it "should handle the 'auto_index_callback' property when not set" do
-    @config.auto_index_callback.should == "after_save"
+    expect(@config.auto_index_callback).to eq("after_save")
   end
 
   it "should handle the 'auto_remove_callback' property when not set" do
-    @config.auto_remove_callback.should == "after_destroy"
+    expect(@config.auto_remove_callback).to eq("after_destroy")
   end
 end
 
 describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
   before(:each) do
-    ::Rails.stub(:env => 'config_test')
+    allow(::Rails).to receive_messages(:env => 'config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
   it "should handle the 'scheme' property when set" do
-    @config.scheme.should == "http"
+    expect(@config.scheme).to eq("http")
   end
 
   it "should handle the 'user' and 'pass' properties when set" do
-    @config.userinfo.should == "user:pass"
+    expect(@config.userinfo).to eq("user:pass")
   end
 
   it "should handle the 'hostname' property when set" do
-    @config.hostname.should == 'some.host'
+    expect(@config.hostname).to eq('some.host')
   end
 
   it "should handle the 'port' property when set" do
-    @config.port.should == 1234
+    expect(@config.port).to eq(1234)
   end
 
   it "should handle the 'path' property when set" do
-    @config.path.should == '/solr/idx'
+    expect(@config.path).to eq('/solr/idx')
   end
 
   it "should handle the 'log_level' propery when set" do
-    @config.log_level.should == 'WARNING'
+    expect(@config.log_level).to eq('WARNING')
   end
 
   it "should handle the 'solr_home' propery when set" do
-    @config.solr_home.should == '/my_superior_path'
+    expect(@config.solr_home).to eq('/my_superior_path')
   end
 
   it "should handle the 'pid_dir' property when set" do
-    @config.pid_dir.should == '/my_superior_path/pids'
+    expect(@config.pid_dir).to eq('/my_superior_path/pids')
   end
 
   it "should handle the 'solr_home' property when set" do
-    @config.solr_home.should == '/my_superior_path'
+    expect(@config.solr_home).to eq('/my_superior_path')
   end
 
   it "should handle the 'auto_commit_after_request' propery when set" do
-    @config.auto_commit_after_request?.should == false
+    expect(@config.auto_commit_after_request?).to eq(false)
   end
 
   it "should handle the 'auto_commit_after_delete_request' propery when set" do
-    @config.auto_commit_after_delete_request?.should == true
+    expect(@config.auto_commit_after_delete_request?).to eq(true)
   end
 
   it "should handle the 'bind_address' property when set" do
-    @config.bind_address.should == "127.0.0.1"
+    expect(@config.bind_address).to eq("127.0.0.1")
   end
 
   it "should handle the 'read_timeout' property when set" do
-    @config.read_timeout.should == 2
+    expect(@config.read_timeout).to eq(2)
   end
 
   it "should handle the 'open_timeout' property when set" do
-    @config.open_timeout.should == 0.5
+    expect(@config.open_timeout).to eq(0.5)
   end
 
   it "should handle the 'proxy' property when set" do
-    @config.proxy.should == 'http://proxy.com:12345'
+    expect(@config.proxy).to eq('http://proxy.com:12345')
   end
 end
 
 describe Sunspot::Rails::Configuration, "with auto_index_callback and auto_remove_callback set" do
   before do
-    ::Rails.stub(:env => 'config_commit_test')
+    allow(::Rails).to receive_messages(:env => 'config_commit_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
   it "should handle the 'auto_index_callback' property when set" do
-    @config.auto_index_callback.should == "after_commit"
+    expect(@config.auto_index_callback).to eq("after_commit")
   end
 
   it "should handle the 'auto_remove_callback' property when set" do
-    @config.auto_remove_callback.should == "after_commit"
+    expect(@config.auto_remove_callback).to eq("after_commit")
   end
 end
 
 describe Sunspot::Rails::Configuration, "with disabled: true in sunspot.yml" do
   before(:each) do
-    ::Rails.stub(:env => 'config_disabled_test')
+    allow(::Rails).to receive_messages(:env => 'config_disabled_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
   it "should handle the 'disabled' property when set" do
-    @config.disabled?.should be_true
+    expect(@config.disabled?).to be_truthy
   end
 end
 
@@ -200,7 +200,7 @@ describe Sunspot::Rails::Configuration, "with ENV['SOLR_URL'] overriding sunspot
   end
 
   before(:each) do
-    ::Rails.stub(:env => 'config_test')
+    allow(::Rails).to receive_messages(:env => 'config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -209,15 +209,15 @@ describe Sunspot::Rails::Configuration, "with ENV['SOLR_URL'] overriding sunspot
   end
 
   it "should handle the 'hostname' property when set" do
-    @config.hostname.should == 'environment.host'
+    expect(@config.hostname).to eq('environment.host')
   end
 
   it "should handle the 'port' property when set" do
-    @config.port.should == 5432
+    expect(@config.port).to eq(5432)
   end
 
   it "should handle the 'path' property when set" do
-    @config.path.should == '/solr/env'
+    expect(@config.path).to eq('/solr/env')
   end
 end
 
@@ -227,7 +227,7 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] overriding suns
   end
 
   before(:each) do
-    ::Rails.stub(:env => 'config_test')
+    allow(::Rails).to receive_messages(:env => 'config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -236,15 +236,15 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] overriding suns
   end
 
   it "should handle the 'hostname' property when set" do
-    @config.hostname.should == 'index.websolr.test'
+    expect(@config.hostname).to eq('index.websolr.test')
   end
 
   it "should handle the 'port' property when set" do
-    @config.port.should == 80
+    expect(@config.port).to eq(80)
   end
 
   it "should handle the 'path' property when set" do
-    @config.path.should == '/solr/a1b2c3d4e5f'
+    expect(@config.path).to eq('/solr/a1b2c3d4e5f')
   end
 end
 
@@ -254,7 +254,7 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] using https" do
   end
 
   before(:each) do
-    ::Rails.stub(:env => 'config_test')
+    allow(::Rails).to receive_messages(:env => 'config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -263,19 +263,19 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] using https" do
   end
 
   it "should set the scheme to https" do
-    @config.scheme.should == "https"
+    expect(@config.scheme).to eq("https")
   end
 
   it "should handle the 'hostname' property when set" do
-    @config.hostname.should == 'index.websolr.test'
+    expect(@config.hostname).to eq('index.websolr.test')
   end
 
   it "should handle the 'port' property when set" do
-    @config.port.should == 443
+    expect(@config.port).to eq(443)
   end
 
   it "should handle the 'path' property when set" do
-    @config.path.should == '/solr/a1b2c3d4e5f'
+    expect(@config.path).to eq('/solr/a1b2c3d4e5f')
   end
 end
 
@@ -285,7 +285,7 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] including useri
   end
 
   before(:each) do
-    ::Rails.stub(:env => 'config_test')
+    allow(::Rails).to receive_messages(:env => 'config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -294,22 +294,22 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] including useri
   end
 
   it "should include username and passowrd" do
-    @config.userinfo.should == "user:pass"
+    expect(@config.userinfo).to eq("user:pass")
   end
 
   it "should set the scheme to https" do
-    @config.scheme.should == "https"
+    expect(@config.scheme).to eq("https")
   end
 
   it "should handle the 'hostname' property when set" do
-    @config.hostname.should == 'index.websolr.test'
+    expect(@config.hostname).to eq('index.websolr.test')
   end
 
   it "should handle the 'port' property when set" do
-    @config.port.should == 443
+    expect(@config.port).to eq(443)
   end
 
   it "should handle the 'path' property when set" do
-    @config.path.should == '/solr/a1b2c3d4e5f'
+    expect(@config.path).to eq('/solr/a1b2c3d4e5f')
   end
 end

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -28,22 +28,22 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
 
   describe "port" do
     it "should default to port 8981 in test" do
-      allow(::Rails).to receive_messages(:env => 'test')
+      allow(::Rails).to receive(:env).and_return('test')
       @config = Sunspot::Rails::Configuration.new
       expect(@config.port).to eq(8981)
     end
     it "should default to port 8982 in development" do
-      allow(::Rails).to receive_messages(:env => 'development')
+      allow(::Rails).to receive(:env).and_return('development')
       @config = Sunspot::Rails::Configuration.new
       expect(@config.port).to eq(8982)
     end
     it "should default to 8983 in production" do
-      allow(::Rails).to receive_messages(:env => 'production')
+      allow(::Rails).to receive(:env).and_return('production')
       @config = Sunspot::Rails::Configuration.new
       expect(@config.port).to eq(8983)
     end
     it "should generally default to 8983" do
-      allow(::Rails).to receive_messages(:env => 'staging')
+      allow(::Rails).to receive(:env).and_return('staging')
       @config = Sunspot::Rails::Configuration.new
       expect(@config.port).to eq(8983)
     end
@@ -103,7 +103,7 @@ end
 
 describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
   before(:each) do
-    allow(::Rails).to receive_messages(:env => 'config_test')
+    allow(::Rails).to receive(:env).and_return('config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -170,7 +170,7 @@ end
 
 describe Sunspot::Rails::Configuration, "with auto_index_callback and auto_remove_callback set" do
   before do
-    allow(::Rails).to receive_messages(:env => 'config_commit_test')
+    allow(::Rails).to receive(:env).and_return('config_commit_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -185,7 +185,7 @@ end
 
 describe Sunspot::Rails::Configuration, "with disabled: true in sunspot.yml" do
   before(:each) do
-    allow(::Rails).to receive_messages(:env => 'config_disabled_test')
+    allow(::Rails).to receive(:env).and_return('config_disabled_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -200,7 +200,7 @@ describe Sunspot::Rails::Configuration, "with ENV['SOLR_URL'] overriding sunspot
   end
 
   before(:each) do
-    allow(::Rails).to receive_messages(:env => 'config_test')
+    allow(::Rails).to receive(:env).and_return('config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -227,7 +227,7 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] overriding suns
   end
 
   before(:each) do
-    allow(::Rails).to receive_messages(:env => 'config_test')
+    allow(::Rails).to receive(:env).and_return('config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -254,7 +254,7 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] using https" do
   end
 
   before(:each) do
-    allow(::Rails).to receive_messages(:env => 'config_test')
+    allow(::Rails).to receive(:env).and_return('config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 
@@ -285,7 +285,7 @@ describe Sunspot::Rails::Configuration, "with ENV['WEBSOLR_URL'] including useri
   end
 
   before(:each) do
-    allow(::Rails).to receive_messages(:env => 'config_test')
+    allow(::Rails).to receive(:env).and_return('config_test')
     @config = Sunspot::Rails::Configuration.new
   end
 

--- a/sunspot_rails/spec/model_lifecycle_spec.rb
+++ b/sunspot_rails/spec/model_lifecycle_spec.rb
@@ -8,7 +8,7 @@ describe 'searchable with lifecycle' do
     end
 
     it 'should automatically index' do
-      PostWithAuto.search.results.should == [@post]
+      expect(PostWithAuto.search.results).to eq([@post])
     end
   end
 
@@ -20,20 +20,20 @@ describe 'searchable with lifecycle' do
     end
 
     it 'should automatically update index' do
-      PostWithAuto.search { with :title, 'Test 1' }.results.should == [@post]
+      expect(PostWithAuto.search { with :title, 'Test 1' }.results).to eq([@post])
     end
 
     it "should index model if relevant attribute changed" do
       @post = PostWithAuto.create!
       @post.title = 'new title'
-      @post.should_receive :solr_index
+      expect(@post).to receive :solr_index
       @post.save!
     end
 
     it "should not index model if relevant attribute not changed" do
       @post = PostWithAuto.create!
       @post.updated_at = Date.tomorrow
-      @post.should_not_receive :solr_index
+      expect(@post).not_to receive :solr_index
       @post.save!
     end
   end
@@ -46,7 +46,7 @@ describe 'searchable with lifecycle' do
     end
 
     it 'should automatically remove it from the index' do
-      PostWithAuto.search_ids.should be_empty
+      expect(PostWithAuto.search_ids).to be_empty
     end
   end
 
@@ -56,7 +56,7 @@ describe 'searchable with lifecycle' do
     end
 
     it "should not reindex the object on an update_at change, because it is marked as to-ignore" do
-      Sunspot.should_not_receive(:index).with(@post)
+      expect(Sunspot).not_to receive(:index).with(@post)
       @post.update_attribute :updated_at, 123.seconds.from_now
     end
   end
@@ -67,12 +67,12 @@ describe 'searchable with lifecycle' do
     end
 
     it "should not reindex the object on an update_at change, because it is not in the whitelist" do
-      Sunspot.should_not_receive(:index).with(@post)
+      expect(Sunspot).not_to receive(:index).with(@post)
       @post.update_attribute :updated_at, 123.seconds.from_now
     end
 
     it "should reindex the object on a title change, because it is in the whitelist" do
-      Sunspot.should_receive(:index).with(@post)
+      expect(Sunspot).to receive(:index).with(@post)
       @post.update_attribute :title, "brand new title"
     end
 

--- a/sunspot_rails/spec/model_spec.rb
+++ b/sunspot_rails/spec/model_spec.rb
@@ -8,17 +8,17 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should not commit the model' do
-      Post.search.results.should be_empty
+      expect(Post.search.results).to be_empty
     end
 
     it 'should index the model' do
       Sunspot.commit
-      Post.search.results.should == [@post]
+      expect(Post.search.results).to eq([@post])
     end
 
     it "should not blow up if there's a default scope specifying order" do
       posts = Array.new(2) { |j| PostWithDefaultScope.create! :title => (10-j).to_s }
-      lambda { PostWithDefaultScope.index(:batch_size => 1) }.should_not raise_error
+      expect { PostWithDefaultScope.index(:batch_size => 1) }.not_to raise_error
     end
   end
 
@@ -29,7 +29,7 @@ describe 'ActiveRecord mixin' do
 
     it 'should not break auto-indexing' do
       @post.title = 'Title'
-      lambda { @post.save! }.should_not raise_error
+      expect { @post.save! }.not_to raise_error
     end
   end
 
@@ -40,7 +40,7 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should immediately index and commit' do
-      Post.search.results.should == [@post]
+      expect(Post.search.results).to eq([@post])
     end
   end
 
@@ -52,12 +52,12 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should not commit immediately' do
-      Post.search.results.should == [@post]
+      expect(Post.search.results).to eq([@post])
     end
 
     it 'should remove the model from the index' do
       Sunspot.commit
-      Post.search.results.should be_empty
+      expect(Post.search.results).to be_empty
     end
   end
 
@@ -69,7 +69,7 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should immediately remove the model and commit' do
-      Post.search.results.should be_empty
+      expect(Post.search.results).to be_empty
     end
   end
 
@@ -81,12 +81,12 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should not commit immediately' do
-      Post.search.results.to_set.should == @posts.to_set
+      expect(Post.search.results.to_set).to eq(@posts.to_set)
     end
 
     it 'should remove all instances from the index' do
       Sunspot.commit
-      Post.search.results.should be_empty
+      expect(Post.search.results).to be_empty
     end
   end
 
@@ -98,7 +98,7 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should remove all instances from the index and commit immediately' do
-      Post.search.results.should be_empty
+      expect(Post.search.results).to be_empty
     end
   end
 
@@ -109,25 +109,25 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should return results specified by search' do
-      Post.search do
+      expect(Post.search do
         with :title, 'Test Post'
-      end.results.should == [@post]
+      end.results).to eq([@post])
     end
 
     it 'should not return results excluded by search' do
-      Post.search do
+      expect(Post.search do
         with :title, 'Bogus Post'
-      end.results.should be_empty
+      end.results).to be_empty
     end
 
     it 'should not allow bogus options to search' do
-      lambda { Post.search(:bogus => :option) }.should raise_error(ArgumentError)
+      expect { Post.search(:bogus => :option) }.to raise_error(ArgumentError)
     end
 
     it 'should pass :include option from search call to data accessor' do
-      Post.search(:include => [:location]) do
+      expect(Post.search(:include => [:location]) do
         with :title, 'Test Post'
-      end.data_accessor_for(Post).include.should == [:location]
+      end.data_accessor_for(Post).include).to eq([:location])
     end
     
     it 'should use the include option on the data accessor when specified' do
@@ -137,38 +137,38 @@ describe 'ActiveRecord mixin' do
         data_accessor_for(Post).include = [:location]
       end.results.first
 
-      (Rails.version >= '3.1' ? post.association(:location).loaded? : post.loaded_location?).should be_true # Rails 3.1 removed "loaded_#{association}" method
+      expect(Rails.version >= '3.1' ? post.association(:location).loaded? : post.loaded_location?).to be_truthy # Rails 3.1 removed "loaded_#{association}" method
     end
     
     it 'should use the select option from search call to data accessor' do
-      Post.search(:select => 'id, title, body') do
+      expect(Post.search(:select => 'id, title, body') do
         with :title, 'Test Post'
-      end.data_accessor_for(Post).select.should == 'id, title, body'
+      end.data_accessor_for(Post).select).to eq('id, title, body')
     end
     
     it 'should use the select option on the data accessor when specified' do
-      Post.search do
+      expect(Post.search do
         with :title, 'Test Post'
         data_accessor_for(Post).select = 'id, title, body'
-      end.results.first.attribute_names.sort.should == ['body', 'id', 'title']
+      end.results.first.attribute_names.sort).to eq(['body', 'id', 'title'])
     end
     
     it 'should not use the select option on the data accessor when not specified' do
-      Post.search do
+      expect(Post.search do
         with :title, 'Test Post'
-      end.results.first.attribute_names.should == Post.first.attribute_names
+      end.results.first.attribute_names).to eq(Post.first.attribute_names)
     end
 
     it 'should accept an array as a select option' do
-      Post.search(:select => ['id', 'title', 'body']) do
+      expect(Post.search(:select => ['id', 'title', 'body']) do
         with :title, 'Test Post'
-      end.results.first.attribute_names.sort.should == ['body', 'id', 'title']
+      end.results.first.attribute_names.sort).to eq(['body', 'id', 'title'])
     end
 
     it 'should use the scoped option from search call to data accessor' do
-      Post.search(:scopes => [:includes_location]) do
+      expect(Post.search(:scopes => [:includes_location]) do
         with :title, 'Test Post'
-      end.data_accessor_for(Post).scopes.should == [:includes_location]
+      end.data_accessor_for(Post).scopes).to eq([:includes_location])
     end
 
     it 'should use the scopes option on the data accessor when specified' do
@@ -178,16 +178,16 @@ describe 'ActiveRecord mixin' do
         data_accessor_for(Post).scopes = [:includes_location]
       end.results.first
 
-      (Rails.version >= '3.1' ? post.association(:location).loaded? : post.loaded_location?).should be_true # Rails 3.1 removed "loaded_#{association}" method
+      expect(Rails.version >= '3.1' ? post.association(:location).loaded? : post.loaded_location?).to be_truthy # Rails 3.1 removed "loaded_#{association}" method
     end
 
     it 'should gracefully handle nonexistent records' do
       post2 = Post.create!(:title => 'Test Post')
       post2.index!
       post2.destroy
-      Post.search do
+      expect(Post.search do
         with :title, 'Test Post'
-      end.results.should == [@post]
+      end.results).to eq([@post])
     end
 
     it 'should use an ActiveRecord object for coordinates' do
@@ -195,7 +195,7 @@ describe 'ActiveRecord mixin' do
       post.location = Location.create!(:lat => 40.0, :lng => -70.0)
       post.save
       post.index!
-      Post.search { with(:location).near(40.0, -70.0) }.results.should == [post]
+      expect(Post.search { with(:location).near(40.0, -70.0) }.results).to eq([post])
     end
 
   end
@@ -207,17 +207,17 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should return IDs' do
-      Post.search_ids.to_set.should == @posts.map { |post| post.id }.to_set
+      expect(Post.search_ids.to_set).to eq(@posts.map { |post| post.id }.to_set)
     end
   end
   
   describe 'searchable?()' do
     it 'should not be true for models that have not been configured for search' do
-      Location.should_not be_searchable
+      expect(Location).not_to be_searchable
     end
 
     it 'should be true for models that have been configured for search' do
-      Post.should be_searchable
+      expect(Post).to be_searchable
     end
   end
 
@@ -229,7 +229,7 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should return IDs of objects that are in the index but not the database' do
-      Post.index_orphans.should == [@posts.first.id]
+      expect(Post.index_orphans).to eq([@posts.first.id])
     end
   end
 
@@ -243,7 +243,7 @@ describe 'ActiveRecord mixin' do
     it 'should remove orphans from the index' do
       Post.clean_index_orphans
       Sunspot.commit
-      Post.search.results.should == [@posts.last]
+      expect(Post.search.results).to eq([@posts.last])
     end
   end
 
@@ -255,7 +255,7 @@ describe 'ActiveRecord mixin' do
     it 'should index all instances' do
       Post.reindex(:batch_size => nil)
       Sunspot.commit
-      Post.search.results.to_set.should == @posts.to_set
+      expect(Post.search.results.to_set).to eq(@posts.to_set)
     end
 
     it 'should remove all currently indexed instances' do
@@ -264,7 +264,7 @@ describe 'ActiveRecord mixin' do
       old_post.destroy
       Post.reindex
       Sunspot.commit
-      Post.search.results.to_set.should == @posts.to_set
+      expect(Post.search.results.to_set).to eq(@posts.to_set)
     end
     
   end
@@ -277,7 +277,7 @@ describe 'ActiveRecord mixin' do
     it 'should index all instances' do
       Post.reindex(:batch_size => nil)
       Sunspot.commit
-      Post.search.results.to_set.should == @posts.to_set
+      expect(Post.search.results.to_set).to eq(@posts.to_set)
     end
 
     it 'should remove all currently indexed instances' do
@@ -286,14 +286,14 @@ describe 'ActiveRecord mixin' do
       old_post.destroy
       Post.reindex
       Sunspot.commit
-      Post.search.results.to_set.should == @posts.to_set
+      expect(Post.search.results.to_set).to eq(@posts.to_set)
     end
     
     describe "using batch sizes" do
       it 'should index with a specified batch size' do
         Post.reindex(:batch_size => 1)
         Sunspot.commit
-        Post.search.results.to_set.should == @posts.to_set
+        expect(Post.search.results.to_set).to eq(@posts.to_set)
       end
     end
   end
@@ -307,19 +307,19 @@ describe 'ActiveRecord mixin' do
     end
 
     it "should use batches if the batch_size is specified" do
-      relation(Post).class.any_instance.should_receive(:find_in_batches)
+      expect_any_instance_of(relation(Post).class).to receive(:find_in_batches)
       Post.reindex(:batch_size => 50)
     end
 
     it "should select all if the batch_size isn't greater than 0" do
-      relation(Post).class.any_instance.should_not_receive(:find_in_batches)
+      expect_any_instance_of(relation(Post).class).not_to receive(:find_in_batches)
       Post.reindex(:batch_size => nil)
       Post.reindex(:batch_size => 0)
     end
 
     describe "when not using batches" do
       it "should search for models with includes" do
-        Post.should_receive(:includes).with(:author).and_return(relation(Post))
+        expect(Post).to receive(:includes).with(:author).and_return(relation(Post))
         Post.reindex(:batch_size => nil, :include => :author)
       end
 
@@ -335,7 +335,7 @@ describe 'ActiveRecord mixin' do
         it 'should only index those models where :if constraints pass' do
           Post.reindex(:batch_size => nil)
 
-          Post.search.results.should_not include(@posts.first)
+          expect(Post.search.results).not_to include(@posts.first)
         end
       end
     
@@ -343,12 +343,12 @@ describe 'ActiveRecord mixin' do
 
     describe "when using batches" do
       it "should commit after indexing each batch" do
-        Sunspot.should_receive(:commit).twice
+        expect(Sunspot).to receive(:commit).twice
         Post.reindex(:batch_size => 1)
       end
 
       it "should commit after indexing everything" do
-        Sunspot.should_receive(:commit).once
+        expect(Sunspot).to receive(:commit).once
         Post.reindex(:batch_commit => false)
       end
 
@@ -364,7 +364,7 @@ describe 'ActiveRecord mixin' do
         it 'should only index those models where :if constraints pass' do
           Post.reindex(:batch_size => 50)
 
-          Post.search.results.should_not include(@posts.first)
+          expect(Post.search.results).not_to include(@posts.first)
         end
       end
     end
@@ -386,12 +386,13 @@ describe 'ActiveRecord mixin' do
     end
 
     it "should return results" do
-      @posts.first.more_like_this.results.should == [@posts[3], @posts[1]]
+      expect(@posts.first.more_like_this.results).to eq([@posts[3], @posts[1]])
     end
 
     it "should return results for specified classes" do
-      @posts.first.more_like_this(Post, PostWithAuto).results.to_set.should ==
+      expect(@posts.first.more_like_this(Post, PostWithAuto).results.to_set).to eq(
         Set[@posts_with_auto[0], @posts[1], @posts[3]]
+      )
     end
   end
 
@@ -407,7 +408,7 @@ describe 'ActiveRecord mixin' do
     end
 
     it 'should return IDs' do
-      @posts.first.more_like_this_ids.to_set.should == [@posts[3], @posts[1]].map { |post| post.id }.to_set
+      expect(@posts.first.more_like_this_ids.to_set).to eq([@posts[3], @posts[1]].map { |post| post.id }.to_set)
     end
   end
 
@@ -424,7 +425,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns true' do
         # searchable :if => :returns_true
         before do
-          subject.should_receive(:returns_true).and_return(true)
+          expect(subject).to receive(:returns_true).and_return(true)
           subject.class.sunspot_options[:if] = :returns_true
         end
 
@@ -434,7 +435,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns false' do
         # searchable :if => :returns_false
         before do
-          subject.should_receive(:returns_false).and_return(false)
+          expect(subject).to receive(:returns_false).and_return(false)
           subject.class.sunspot_options[:if] = :returns_false
         end
 
@@ -446,7 +447,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns true' do
         # searchable :if => 'returns_true'
         before do
-          subject.should_receive(:returns_true).and_return(true)
+          expect(subject).to receive(:returns_true).and_return(true)
           subject.class.sunspot_options[:if] = 'returns_true'
         end
 
@@ -456,7 +457,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns false' do
         # searchable :if => 'returns_false'
         before do
-          subject.should_receive(:returns_false).and_return(false)
+          expect(subject).to receive(:returns_false).and_return(false)
           subject.class.sunspot_options[:if] = 'returns_false'
         end
 
@@ -488,8 +489,8 @@ describe 'ActiveRecord mixin' do
       context 'all constraints returns true' do
         # searchable :if => [:returns_true_1, :returns_true_2]
         before do
-          subject.should_receive(:returns_true_1).and_return(true)
-          subject.should_receive(:returns_true_2).and_return(true)
+          expect(subject).to receive(:returns_true_1).and_return(true)
+          expect(subject).to receive(:returns_true_2).and_return(true)
           subject.class.sunspot_options[:if] = [:returns_true_1, 'returns_true_2']
         end
 
@@ -499,8 +500,8 @@ describe 'ActiveRecord mixin' do
       context 'one constraint returns false' do
         # searchable :if => [:returns_true, :returns_false]
         before do
-          subject.should_receive(:returns_true).and_return(true)
-          subject.should_receive(:returns_false).and_return(false)
+          expect(subject).to receive(:returns_true).and_return(true)
+          expect(subject).to receive(:returns_false).and_return(false)
           subject.class.sunspot_options[:if] = [:returns_true, 'returns_false']
         end
 
@@ -511,12 +512,12 @@ describe 'ActiveRecord mixin' do
     it 'removes the model from the index if the constraint does not match' do
       subject.save!
       Sunspot.commit
-      subject.class.search.results.should include(subject)
+      expect(subject.class.search.results).to include(subject)
 
       subject.class.sunspot_options[:if] = proc { false }
       subject.save!
       Sunspot.commit
-      subject.class.search.results.should_not include(subject)
+      expect(subject.class.search.results).not_to include(subject)
     end
   end
 
@@ -533,7 +534,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns true' do
         # searchable :unless => :returns_true
         before do
-          subject.should_receive(:returns_true).and_return(true)
+          expect(subject).to receive(:returns_true).and_return(true)
           subject.class.sunspot_options[:unless] = :returns_true
         end
 
@@ -543,7 +544,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns false' do
         # searchable :unless => :returns_false
         before do
-          subject.should_receive(:returns_false).and_return(false)
+          expect(subject).to receive(:returns_false).and_return(false)
           subject.class.sunspot_options[:unless] = :returns_false
         end
 
@@ -555,7 +556,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns true' do
         # searchable :unless => 'returns_true'
         before do
-          subject.should_receive(:returns_true).and_return(true)
+          expect(subject).to receive(:returns_true).and_return(true)
           subject.class.sunspot_options[:unless] = 'returns_true'
         end
 
@@ -565,7 +566,7 @@ describe 'ActiveRecord mixin' do
       context 'constraint returns false' do
         # searchable :unless => 'returns_false'
         before do
-          subject.should_receive(:returns_false).and_return(false)
+          expect(subject).to receive(:returns_false).and_return(false)
           subject.class.sunspot_options[:unless] = 'returns_false'
         end
 
@@ -597,8 +598,8 @@ describe 'ActiveRecord mixin' do
       context 'all constraints returns true' do
         # searchable :unless => [:returns_true_1, :returns_true_2]
         before do
-          subject.should_receive(:returns_true_1).and_return(true)
-          subject.should_receive(:returns_true_2).and_return(true)
+          expect(subject).to receive(:returns_true_1).and_return(true)
+          expect(subject).to receive(:returns_true_2).and_return(true)
           subject.class.sunspot_options[:unless] = [:returns_true_1, 'returns_true_2']
         end
 
@@ -608,8 +609,8 @@ describe 'ActiveRecord mixin' do
       context 'one constraint returns false' do
         # searchable :unless => [:returns_true, :returns_false]
         before do
-          subject.should_receive(:returns_true).and_return(true)
-          subject.should_receive(:returns_false).and_return(false)
+          expect(subject).to receive(:returns_true).and_return(true)
+          expect(subject).to receive(:returns_false).and_return(false)
           subject.class.sunspot_options[:unless] = [:returns_true, 'returns_false']
         end
 

--- a/sunspot_rails/spec/rake_task_spec.rb
+++ b/sunspot_rails/spec/rake_task_spec.rb
@@ -12,27 +12,27 @@ describe 'sunspot namespace rake task' do
       run_rake_task("sunspot:reindex", '', '', true)
 
       # This model should not be used by any other test and therefore should only be loaded by this test
-      Sunspot.searchable.collect(&:name).should include('RakeTaskAutoLoadTestModel')
+      expect(Sunspot.searchable.collect(&:name)).to include('RakeTaskAutoLoadTestModel')
     end
 
     it "should accept a space delimited list of models to reindex" do
-      Post.should_receive(:solr_reindex)
-      Author.should_receive(:solr_reindex)
-      Blog.should_not_receive(:solr_reindex)
+      expect(Post).to receive(:solr_reindex)
+      expect(Author).to receive(:solr_reindex)
+      expect(Blog).not_to receive(:solr_reindex)
 
       run_rake_task("sunspot:reindex", '', "Post Author", true)
     end
 
     it "should accept a plus delimited list of models to reindex" do
-      Post.should_receive(:solr_reindex)
-      Author.should_receive(:solr_reindex)
-      Blog.should_not_receive(:solr_reindex)
+      expect(Post).to receive(:solr_reindex)
+      expect(Author).to receive(:solr_reindex)
+      expect(Blog).not_to receive(:solr_reindex)
 
       run_rake_task("sunspot:reindex", '', "Post+Author", true)
     end
 
     it "should raise exception when all tables of sunspot models are empty" do
-      STDOUT.should_receive(:puts).with("You have no data in the database. Reindexing does nothing here.")
+      expect(STDOUT).to receive(:puts).with("You have no data in the database. Reindexing does nothing here.")
       empty_tables
       run_rake_task("sunspot:reindex")
     end

--- a/sunspot_rails/spec/request_lifecycle_spec.rb
+++ b/sunspot_rails/spec/request_lifecycle_spec.rb
@@ -21,19 +21,19 @@ describe PostsController, :type => :controller do
 
   it 'should automatically commit after each action if specified' do
     @configuration.user_configuration = { 'auto_commit_after_request' => true }
-    Sunspot.should_receive(:commit_if_dirty)
+    expect(Sunspot).to receive(:commit_if_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
   
   it 'should not commit, if configuration is set to false' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false }
-    Sunspot.should_not_receive(:commit_if_dirty)
+    expect(Sunspot).not_to receive(:commit_if_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
 
   it 'should commit if configuration is not specified' do
     @configuration.user_configuration = {}
-    Sunspot.should_receive(:commit_if_dirty)
+    expect(Sunspot).to receive(:commit_if_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
   
@@ -42,20 +42,20 @@ describe PostsController, :type => :controller do
   it 'should automatically commit after each delete if specified' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false,
                                           'auto_commit_after_delete_request' => true }
-    Sunspot.should_receive(:commit_if_delete_dirty)
+    expect(Sunspot).to receive(:commit_if_delete_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
   
   it 'should not automatically commit on delete if configuration is set to false' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false,
                                           'auto_commit_after_delete_request' => false }
-    Sunspot.should_not_receive(:commit_if_delete_dirty)
+    expect(Sunspot).not_to receive(:commit_if_delete_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
 
   it 'should not automatically commit on delete if configuration is not specified' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false }
-    Sunspot.should_not_receive(:commit_if_delete_dirty)
+    expect(Sunspot).not_to receive(:commit_if_delete_dirty)
     post :create, :post => { :title => 'Test 1' }
   end
 end

--- a/sunspot_rails/spec/searchable_spec.rb
+++ b/sunspot_rails/spec/searchable_spec.rb
@@ -6,10 +6,10 @@ describe Sunspot::Rails::Searchable do
     	# Rspec runs tests in random order, causing this test to fail on occasion unless we ensure the models have loaded.
     	Author; Blog; Post;
 
-      Sunspot.searchable.should_not be_empty
-      Sunspot.searchable.should include(Author)
-      Sunspot.searchable.should include(Blog)
-      Sunspot.searchable.should include(Post)
+      expect(Sunspot.searchable).not_to be_empty
+      expect(Sunspot.searchable).to include(Author)
+      expect(Sunspot.searchable).to include(Blog)
+      expect(Sunspot.searchable).to include(Post)
     end
   end
 end

--- a/sunspot_rails/spec/server_spec.rb
+++ b/sunspot_rails/spec/server_spec.rb
@@ -4,28 +4,28 @@ describe Sunspot::Rails::Server do
   before :each do
     @server = Sunspot::Rails::Server.new
     @config = Sunspot::Rails::Configuration.new
-    @server.stub(:configuration){ @config }
+    allow(@server).to receive(:configuration){ @config }
     @solr_home = File.join(@config.solr_home)
   end
 
   it "sets the correct Solr home" do
-    @server.solr_home.should == @solr_home
+    expect(@server.solr_home).to eq(@solr_home)
   end
 
   it "sets the correct Solr PID path" do
-    @server.pid_path.should == File.join(@server.pid_dir, 'sunspot-solr-test.pid')
+    expect(@server.pid_path).to eq(File.join(@server.pid_dir, 'sunspot-solr-test.pid'))
   end
 
   it "sets the correct port" do
-    @server.port.should == 8983
+    expect(@server.port).to eq(8983)
   end
 
   it "sets the log level using configuration" do
-    @config.stub(:log_level){ 'WARNING' }
-    @server.log_level.should == "WARNING"
+    allow(@config).to receive(:log_level){ 'WARNING' }
+    expect(@server.log_level).to eq("WARNING")
   end
 
   it "sets the correct log file" do
-    @server.log_file.should == File.join(Rails.root, 'log', 'sunspot-solr-test.log')
+    expect(@server.log_file).to eq(File.join(Rails.root, 'log', 'sunspot-solr-test.log'))
   end
 end

--- a/sunspot_rails/spec/session_spec.rb
+++ b/sunspot_rails/spec/session_spec.rb
@@ -19,7 +19,7 @@ describe 'Sunspot::Rails session' do
 
     # There should be no items in the queue with the same object_id
     object_ids = sessions.map(&:object_id)
-    object_ids.uniq.should == object_ids
+    expect(object_ids.uniq).to eq(object_ids)
   end
 
   it 'should create a separate master/slave session if configured' do
@@ -31,7 +31,7 @@ describe 'Sunspot::Rails session' do
   context 'disabled' do
     before do
       Sunspot::Rails.reset
-      ::Rails.stub(:env).and_return("config_disabled_test")
+      allow(::Rails).to receive(:env).and_return("config_disabled_test")
     end
 
     after do
@@ -39,7 +39,7 @@ describe 'Sunspot::Rails session' do
     end
 
     it 'sets the session proxy as a stub' do
-      Sunspot::Rails.build_session.should be_a_kind_of(Sunspot::Rails::StubSessionProxy)
+      expect(Sunspot::Rails.build_session).to be_a_kind_of(Sunspot::Rails::StubSessionProxy)
     end
   end
 

--- a/sunspot_rails/spec/shared_examples/indexed_after_save.rb
+++ b/sunspot_rails/spec/shared_examples/indexed_after_save.rb
@@ -3,6 +3,6 @@ shared_examples_for 'indexed after save' do
     subject.save!
     Sunspot.commit
 
-    subject.class.search.results.should include(subject)
+    expect(subject.class.search.results).to include(subject)
   end
 end

--- a/sunspot_rails/spec/shared_examples/not_indexed_after_save.rb
+++ b/sunspot_rails/spec/shared_examples/not_indexed_after_save.rb
@@ -3,6 +3,6 @@ shared_examples_for 'not indexed after save' do
     subject.save!
     Sunspot.commit
 
-    subject.class.search.results.should_not include(subject)
+    expect(subject.class.search.results).not_to include(subject)
   end
 end

--- a/sunspot_rails/spec/spec_helper.rb
+++ b/sunspot_rails/spec/spec_helper.rb
@@ -64,6 +64,17 @@ RSpec.configure do |config|
     empty_tables
     Sunspot.remove_all!
   end  
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end
 
 def empty_tables

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -13,108 +13,108 @@ describe 'specs with Sunspot stubbed' do
     foo = double('Foo')
     block = lambda { foo.bar }
 
-    foo.should_receive(:bar)
+    expect(foo).to receive(:bar)
 
     Sunspot.batch(&block)
   end
 
   it 'should not send index to session' do
-    @session.should_not_receive(:index)
+    expect(@session).not_to receive(:index)
     @post.index
   end
 
   it 'should not send index! to session' do
-    @session.should_not_receive(:index!)
+    expect(@session).not_to receive(:index!)
     @post.index!
   end
 
   it 'should not send atomic_update to session' do
-    @session.should_not_receive(:atomic_update)
+    expect(@session).not_to receive(:atomic_update)
     @post.index
   end
 
   it 'should not send atomic_update! to session' do
-    @session.should_not_receive(:atomic_update!)
+    expect(@session).not_to receive(:atomic_update!)
     @post.index!
   end
 
   it 'should not send commit to session' do
-    @session.should_not_receive(:commit)
+    expect(@session).not_to receive(:commit)
     Sunspot.commit
   end
 
   it 'should not send remove to session' do
-    @session.should_not_receive(:remove)
+    expect(@session).not_to receive(:remove)
     @post.remove_from_index
   end
 
   it 'should not send remove! to session' do
-    @session.should_not_receive(:remove)
+    expect(@session).not_to receive(:remove)
     @post.remove_from_index!
   end
 
   it 'should not send remove_by_id to session' do
-    @session.should_not_receive(:remove_by_id)
+    expect(@session).not_to receive(:remove_by_id)
     Sunspot.remove_by_id(Post, 1)
   end
 
   it 'should not send remove_by_id! to session' do
-    @session.should_not_receive(:remove_by_id!)
+    expect(@session).not_to receive(:remove_by_id!)
     Sunspot.remove_by_id!(Post, 1)
   end
 
   it 'should not send remove_all to session' do
-    @session.should_not_receive(:remove_all)
+    expect(@session).not_to receive(:remove_all)
     Post.remove_all_from_index
   end
 
   it 'should not send remove_all! to session' do
-    @session.should_not_receive(:remove_all!)
+    expect(@session).not_to receive(:remove_all!)
     Post.remove_all_from_index!
   end
 
   it 'should not send optimize to session' do
-    @session.should_not_receive(:optimize)
+    expect(@session).not_to receive(:optimize)
     Sunspot.optimize
   end
 
   it 'should return false for dirty?' do
-    @session.should_not_receive(:dirty?)
-    Sunspot.dirty?.should == false
+    expect(@session).not_to receive(:dirty?)
+    expect(Sunspot.dirty?).to eq(false)
   end
 
   it 'should not send commit_if_dirty to session' do
-    @session.should_not_receive(:commit_if_dirty)
+    expect(@session).not_to receive(:commit_if_dirty)
     Sunspot.commit_if_dirty
   end
 
   it 'should return false for delete_dirty?' do
-    @session.should_not_receive(:delete_dirty?)
-    Sunspot.delete_dirty?.should == false
+    expect(@session).not_to receive(:delete_dirty?)
+    expect(Sunspot.delete_dirty?).to eq(false)
   end
 
   it 'should not send commit_if_delete_dirty to session' do
-    @session.should_not_receive(:commit_if_delete_dirty)
+    expect(@session).not_to receive(:commit_if_delete_dirty)
     Sunspot.commit_if_delete_dirty
   end
 
   it 'should not execute a search when #search called' do
-    @session.should_not_receive(:search)
+    expect(@session).not_to receive(:search)
     Post.search
   end
 
   it 'should not execute a search when #search called with parameters' do
-    @session.should_not_receive(:search)
+    expect(@session).not_to receive(:search)
     Post.search(:include => :blog, :select => 'id, title')
   end
 
   it 'should return a new search' do
-    @session.should_not_receive(:new_search)
-    Sunspot.new_search(Post).should respond_to(:execute)
+    expect(@session).not_to receive(:new_search)
+    expect(Sunspot.new_search(Post)).to respond_to(:execute)
   end
 
   it 'should not send more_like_this to session' do
-    @session.should_not_receive(:more_like_this)
+    expect(@session).not_to receive(:more_like_this)
     Sunspot.more_like_this(@post)
   end
 
@@ -124,31 +124,31 @@ describe 'specs with Sunspot stubbed' do
     end
 
     it 'should return empty results' do
-      @search.results.should == []
+      expect(@search.results).to eq([])
     end
 
     it 'should return empty hits' do
-      @search.hits.should == []
+      expect(@search.hits).to eq([])
     end
 
     it 'should return the same for raw_results as hits' do
-      @search.raw_results.should == @search.hits
+      expect(@search.raw_results).to eq(@search.hits)
     end
 
     it 'should return zero total' do
-      @search.total.should == 0
+      expect(@search.total).to eq(0)
     end
 
     it 'should return empty results for a given facet' do
-      @search.facet(:category_id).rows.should == []
+      expect(@search.facet(:category_id).rows).to eq([])
     end
 
     it 'should return empty results for a given dynamic facet' do
-      @search.dynamic_facet(:custom).rows.should == []
+      expect(@search.dynamic_facet(:custom).rows).to eq([])
     end
 
     it 'should return empty array if listing facets' do
-      @search.facets.should == []
+      expect(@search.facets).to eq([])
     end
 
     describe '#data_accessor_for' do
@@ -157,11 +157,11 @@ describe 'specs with Sunspot stubbed' do
       end
 
       it 'should provide accessor for select' do
-        @accessor.should respond_to(:select, :select=)
+        expect(@accessor).to respond_to(:select, :select=)
       end
 
       it 'should provide accessor for include' do
-        @accessor.should respond_to(:include, :include=)
+        expect(@accessor).to respond_to(:include, :include=)
       end
     end
 
@@ -171,7 +171,7 @@ describe 'specs with Sunspot stubbed' do
       end
 
       it 'should response to all the available data methods' do
-        @stats.should respond_to(
+        expect(@stats).to respond_to(
           :min,
           :max,
           :count,
@@ -183,11 +183,11 @@ describe 'specs with Sunspot stubbed' do
       end
 
       it 'should return empty results for a given facet' do
-        @stats.facet(:category_id).rows.should == []
+        expect(@stats.facet(:category_id).rows).to eq([])
       end
 
       it 'should return empty array if listing facets' do
-        @stats.facets.should == []
+        expect(@stats.facets).to eq([])
       end
 
     end

--- a/sunspot_rails/sunspot_rails.gemspec
+++ b/sunspot_rails/sunspot_rails.gemspec
@@ -36,9 +36,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'sunspot', Sunspot::VERSION
   s.add_dependency 'nokogiri'
 
-  s.add_development_dependency 'rspec', '~> 1.2'
-  s.add_development_dependency 'rspec-rails', '~> 1.2'
-
   s.rdoc_options << '--webcvs=http://github.com/outoftime/sunspot/tree/master/%s' <<
                   '--title' << 'Sunspot-Rails - Rails integration for the Sunspot Solr search library - API Documentation' <<
                   '--main' << 'README.rdoc'

--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -158,7 +158,7 @@ module Sunspot
       end
 
       def exec_in_solr_executable_directory(command)
-        FileUtils.cd(solr_executable_directory) {  system(*command) }
+        FileUtils.cd(solr_executable_directory) { system(*command) }
       end
 
       #

--- a/sunspot_solr/spec/server_spec.rb
+++ b/sunspot_solr/spec/server_spec.rb
@@ -23,32 +23,32 @@ describe Sunspot::Solr::Server do
     before { expect(subject).to receive(:bootstrap) }
 
     it 'runs the Solr server in the foreground' do
-      expect(subject).to receive(:exec).with("./solr", "start", "-f", any_args)
+      expect(subject).to receive(:system).with("./solr", "start", "-f", any_args)
       subject.run
     end
 
     it 'runs the Solr server with the memory specified' do
       subject.memory = 2048
-      expect(subject).to receive(:exec).with("./solr", "start", "-f", "-m", "2048", any_args)
+      expect(subject).to receive(:system).with("./solr", "start", "-f", "-m", "2048", any_args)
       subject.run
     end
 
     it 'runs the Solr server with the port specified' do
       subject.port = 8981
-      expect(subject).to receive(:exec).with("./solr", "start", "-f", "-p", "8981", any_args)
+      expect(subject).to receive(:system).with("./solr", "start", "-f", "-p", "8981", any_args)
       subject.run
     end
 
     it 'runs the Solr server with the hostname specified' do
       subject.bind_address = "0.0.0.0"
-      expect(subject).to receive(:exec).with("./solr", "start", "-f", "-h", "0.0.0.0", any_args)
+      expect(subject).to receive(:system).with("./solr", "start", "-f", "-h", "0.0.0.0", any_args)
       subject.run
     end
 
     it 'runs the Solr server with the solr home directory specified' do
       specified_dir = Dir.mktmpdir + "/test_directory"
       subject.solr_home = specified_dir
-      expect(subject).to receive(:exec).with(any_args, "-s", specified_dir)
+      expect(subject).to receive(:system).with(any_args, "-s", specified_dir)
       subject.run
     end
   end


### PR DESCRIPTION
@bragboy This would make Travis green again :)

And I started on updating rspec to version 3.6.
For sunspot it's allready done
For sunspot_rails the Version of rspec-rails is now 2.99
-> I will continue to update rspec-rails to version 3.6 but there was an error which needs more investigation. This Version will show deprecation Warnings if someone commits some test with the old syntax.

I used Transpec to fixed all the deprecation Warnings