### PR TITLE
Allow geofilt searches to be negated. Fixes #363.

### DIFF
--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -135,7 +135,7 @@ module Sunspot
 
         protected
 
-        # 
+        #
         # Return escaped Solr API representation of given value
         #
         # ==== Parameters
@@ -158,9 +158,13 @@ module Sunspot
       end
 
       class InRadius < Base
-        def initialize(negated, field, lat, lon, radius)
-          @lat, @lon, @radius = lat, lon, radius
-          super negated, field, [lat, lon, radius]
+        def initialize(negated, field, *value)
+          @lat, @lon, @radius = value
+          super negated, field, value
+        end
+
+        def negate
+          self.class.new(!@negated, @field, *@value)
         end
 
         private

--- a/sunspot/spec/integration/geospatial_spec.rb
+++ b/sunspot/spec/integration/geospatial_spec.rb
@@ -26,15 +26,30 @@ describe "geospatial search" do
       expect(results).not_to include(@post)
     end
 
+    it "filters out posts in the radius" do
+      results = Sunspot.search(Post) {
+        without(:coordinates_new).in_radius(32, -68, 1)
+      }.results
+
+      expect(results).not_to include(@post)
+    end
+
     it "allows conjunction queries with radius" do
+      post = Post.new(:title => "Howdy",
+                      :coordinates => Sunspot::Util::Coordinates.new(35, -68))
+
+      Sunspot.index!(post)
+
       results = Sunspot.search(Post) {
         any_of do
           with(:coordinates_new).in_radius(32, -68, 1)
           with(:coordinates_new).in_radius(35, 68, 1)
+          without(:coordinates_new).in_radius(35, -68, 1)
         end
       }.results
 
       expect(results).to include(@post)
+      expect(results).not_to include(post)
     end
 
     it "allows conjunction queries with bounding box" do


### PR DESCRIPTION
`InRadius` has a few additional parameters which prevented `#negate` from working properly with it.