### PR TITLE
Fix #281 NoMethodError (undefined method `result=' for nil:NilClass)

### DIFF
--- a/sunspot/lib/sunspot/search/hit_enumerable.rb
+++ b/sunspot/lib/sunspot/search/hit_enumerable.rb
@@ -34,7 +34,7 @@ module Sunspot
           hits_for_class = id_hit_hash[class_name]
           data_accessor.load_all(ids).each do |result|
             hit = hits_for_class.delete(Adapters::InstanceAdapter.adapt(result).id.to_s)
-            hit.result = result
+            hit.result = result if hit
           end
           hits_for_class.values.each { |hit| hit.result = nil }
         end

--- a/sunspot/spec/api/hit_enumerable_spec.rb
+++ b/sunspot/spec/api/hit_enumerable_spec.rb
@@ -44,4 +44,27 @@ describe Sunspot::Search::HitEnumerable do
       subject.populate_hits
     end
   end
+
+  describe "#populate_hits" do
+    let(:post_1) { Post.new(id: "1", title: "Title 1") }
+
+    before do
+      allow(subject).to receive(:solr_docs).and_return([{ "id" => "Post 1", "score" => 3.14 }])
+      allow(subject).to receive(:highlights_for)
+    end
+
+    it "populates the hit object with the result from the data accessor" do
+      allow_any_instance_of(MockAdapter::DataAccessor).to receive(:load_all).and_return([post_1])
+      expect_any_instance_of(Sunspot::Search::Hit).to receive(:result=).with(post_1)
+
+      subject.populate_hits
+    end
+
+    it "populates the hit object only once if there are duplicate entries in the database (ex: db missing unique constraints)" do
+      allow_any_instance_of(MockAdapter::DataAccessor).to receive(:load_all).and_return([post_1, post_1])
+      expect_any_instance_of(Sunspot::Search::Hit).to receive(:result=).with(post_1)
+
+      subject.populate_hits
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/sunspot/sunspot/issues/281

This is a rare case. The issue only shows up if the data source being used does not have a unique `primary key`. If it happens that there's a duplicated entry in the database table, then the gem will crash unexpectedly when the application attempts a search.

Example:
```
> SELECT id, title FROM posts;

     id     |  title
------------+---------------
1           | Title 1
1           | Title 1
```

If the `id` column is not unique and it's declared as the `primary_key` in the code, then the following code will raise an exception:

```
search = Sunspot.search(Post) { with :title, "Title 1" }
search.results # => NoMethodError (undefined method `result=' for nil:NilClass)
```
As rare as this is, it can happen.

It's arguable what the expected output for a case like this would be. SOLR won't keep track of the duplicate, so the fix I'm proposing just returns one of the two. I'm open to ideas or suggestions though.