### PR TITLE
Java 9 compatibility, disable GC logging for now. Fixes #872

### DIFF
--- a/sunspot_solr/solr/bin/solr.in.cmd
+++ b/sunspot_solr/solr/bin/solr.in.cmd
@@ -24,8 +24,11 @@ REM set SOLR_JAVA_HOME=
 REM Increase Java Min/Max Heap as needed to support your indexing / query needs
 set SOLR_JAVA_MEM=-Xms512m -Xmx512m
 
-REM Enable verbose GC logging
-set GC_LOG_OPTS=-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime
+REM Enable verbose GC logging (Java 9+)
+REM set GC_LOG_OPTS=-Xlog:gc*
+
+REM Enable verbose GC logging (Java <9)
+REM set GC_LOG_OPTS=-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime
 
 REM These GC settings have shown to work well for a number of common Solr workloads
 set GC_TUNE=-XX:NewRatio=3 ^

--- a/sunspot_solr/solr/bin/solr.in.sh
+++ b/sunspot_solr/solr/bin/solr.in.sh
@@ -25,9 +25,12 @@ SOLR_HEAP="512m"
 # Comment out SOLR_HEAP if you are using this though, that takes precedence
 #SOLR_JAVA_MEM="-Xms512m -Xmx512m"
 
-# Enable verbose GC logging
-GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
--XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
+# Enable verbose GC logging (Java 9+)
+#GC_LOG_OPTS="-Xlog:gc*"
+
+# Enable verbose GC logging (Java <9)
+#GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
+#-XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
 
 # These GC settings have shown to work well for a number of common Solr workloads
 GC_TUNE="-XX:NewRatio=3 \


### PR DESCRIPTION
GC Logging in Java 9 requires the use of other command line options.

Source: https://github.com/apache/lucene-solr/blob/master/solr/bin/solr.in.sh#L44

Related issues and docs: https://issues.apache.org/jira/browse/SOLR-10184 / http://openjdk.java.net/jeps/158

For sunspot_solr, we could detect the java version and use the appropriate options. Or just disable GC logging? This PR does the latter.

Fixes #872 