### PR TITLE
Add filter to DataExtractor that removes some of control chars

### DIFF
--- a/sunspot/lib/sunspot/data_extractor.rb
+++ b/sunspot/lib/sunspot/data_extractor.rb
@@ -25,7 +25,7 @@ module Sunspot
           when Array
             object.map { |o| extract_value_from(o) }
           when Hash
-            object.map { |(k, v)| [extract_value_from(k), extract_value_from(v)] }.to_h
+            object.inject({}) { |h, (k, v)| h.merge(extract_value_from(k) => extract_value_from(v)) }
           else
             object
         end

--- a/sunspot/lib/sunspot/data_extractor.rb
+++ b/sunspot/lib/sunspot/data_extractor.rb
@@ -9,8 +9,7 @@ module Sunspot
     # Abstract extractor to perform common actions on extracted values
     #
     class AbstractExtractor
-      CHAR_BLACKLIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16,
-        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127]
+      BLACKLIST_REGEXP = /[\x0-\x8\xB\xC\xE-\x1F\x7f]/
 
       def value_for(object)
         extract_value_from(object)
@@ -32,8 +31,7 @@ module Sunspot
       end
 
       def remove_blacklisted_chars(object)
-        object.chars.
-          reject { |c| CHAR_BLACKLIST.include?(c.ord) }.join
+        object.gsub(BLACKLIST_REGEXP, '')
       end
     end
 

--- a/sunspot/lib/sunspot/data_extractor.rb
+++ b/sunspot/lib/sunspot/data_extractor.rb
@@ -5,16 +5,48 @@ module Sunspot
   # method, which takes an object and returns the value extracted from it.
   #
   module DataExtractor #:nodoc: all
+    #
+    # Abstract extractor to perform common actions on extracted values
+    #
+    class AbstractExtractor
+      CHAR_BLACKLIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127]
+
+      def value_for(object)
+        extract_value_from(object)
+      end
+
+      private
+
+      def extract_value_from(object)
+        case object
+          when String
+            remove_blacklisted_chars(object)
+          when Array
+            object.map { |o| extract_value_from(o) }
+          when Hash
+            object.map { |(k, v)| [extract_value_from(k), extract_value_from(v)] }.to_h
+          else
+            object
+        end
+      end
+
+      def remove_blacklisted_chars(object)
+        object.chars.
+          reject { |c| CHAR_BLACKLIST.include?(c.ord) }.join
+      end
+    end
+
     # 
     # AttributeExtractors extract data by simply calling a method on the block.
     #
-    class AttributeExtractor
+    class AttributeExtractor < AbstractExtractor
       def initialize(attribute_name)
         @attribute_name = attribute_name
       end
 
       def value_for(object)
-        object.send(@attribute_name)
+        super object.send(@attribute_name)
       end
     end
 
@@ -24,26 +56,26 @@ module Sunspot
     # as the argument to the block. Either way, the return value of the block is
     # the value returned by the extractor.
     #
-    class BlockExtractor
+    class BlockExtractor < AbstractExtractor
       def initialize(&block)
         @block = block
       end
 
       def value_for(object)
-        Util.instance_eval_or_call(object, &@block)
+        super Util.instance_eval_or_call(object, &@block)
       end
     end
 
     # 
     # Constant data extractors simply return the same value for every object.
     #
-    class Constant
+    class Constant < AbstractExtractor
       def initialize(value)
         @value = value
       end
 
       def value_for(object)
-        @value
+        super @value
       end
     end
   end

--- a/sunspot/spec/api/data_extractor_spec.rb
+++ b/sunspot/spec/api/data_extractor_spec.rb
@@ -1,0 +1,39 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+
+describe Sunspot::DataExtractor do
+  it "removes special characters from strings" do
+    extractor = Sunspot::DataExtractor::AttributeExtractor.new(:name)
+    blog      = Blog.new(:name => "Te\x0\x1\x7\x6\x8st\xB\xC\xE Bl\x1Fo\x7fg")
+
+    expect(extractor.value_for(blog)).to eq "Test Blog"
+  end
+
+  it "removes special characters from arrays" do
+    extractor = Sunspot::DataExtractor::BlockExtractor.new { tags }
+    post      = Post.new(:tags => ["Te\x0\x1\x7\x6\x8st Ta\x1Fg\x7f 1", "Test\xB\xC\xE Tag 2"])
+
+    expect(extractor.value_for(post)).to eq ["Test Tag 1", "Test Tag 2"]
+  end
+
+  it "removes special characters from hashes" do
+    extractor = Sunspot::DataExtractor::Constant.new({ "Te\x0\x1\x7\x6\x8st" => "Ta\x1Fg\x7f" })
+
+    expect(extractor.value_for(Post.new)).to eq({ "Test" => "Tag" })
+  end
+
+  it "skips other data types" do
+    [
+      :"Te\x0\x1\x7\x6\x8st",
+      123,
+      123.0,
+      nil,
+      false,
+      true,
+      Sunspot::Util::Coordinates.new(40.7, -73.5)
+    ].each do |value|
+      extractor = Sunspot::DataExtractor::Constant.new(value)
+
+      expect(extractor.value_for(Post.new)).to eq value
+    end
+  end
+end


### PR DESCRIPTION
XML transport doesn't support some of the control chars.

Fixes XML parser error in Solr:
```
org.apache.solr.common.SolrException: Illegal character ((CTRL-CHAR, code
11))
```