### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - 2.3.1
   - 2.4.3
   - 2.5.0
+  - ruby-head
   # - rbx-2.0
   # - jruby
 
@@ -26,6 +27,7 @@ env:
 matrix:
   allow_failures:
     - env: GEM=sunspot UPDATE_FORMAT=json
+    - rvm: ruby-head
 
 script:
   - ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
     - env: GEM=sunspot UPDATE_FORMAT=json
     - rvm: ruby-head
 
+before_install: gem install bundler
+
 script:
   - ci/travis.sh
 

--- a/sunspot/lib/sunspot/schema.rb
+++ b/sunspot/lib/sunspot/schema.rb
@@ -88,8 +88,16 @@ module Sunspot
     # Return an XML representation of this schema using the ERB template
     #
     def to_xml
-      template = File.join(File.dirname(__FILE__), '..', '..', 'templates', 'schema.xml.erb')
-      ERB.new(File.read(template), nil, '-').result(binding)
+      template_path = File.join(File.dirname(__FILE__), '..', '..', 'templates', 'schema.xml.erb')
+      template_text = File.read(template_path)
+
+      erb = if RUBY_VERSION >= '2.6'
+        ERB.new(template_text, trim_mode: '-')
+      else
+        ERB.new(template_text, nil, '-')
+      end
+
+      erb.result(binding)
     end
 
     private


### PR DESCRIPTION
The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087b685e8dc0f21f4a89875f25c22f5c39a9/NEWS#stdlib-updates-outstanding-ones-only

The following address is related Ruby's commit.
https://github.com/ruby/ruby/commit/cc777d0

This PR uses `ERB.version` to switch `ERB.new` interface. Because Sunspot supports multiple Ruby versions, it need to use the appropriate interface.

Using `ERB.version` instead of `RUBY_VERSON` is based on the following patch.
https://github.com/ruby/ruby/pull/1826

This patch is built into Ruby.
https://github.com/ruby/ruby/commit/40db89c0934c23d7464d47946bb682b9035411f9