### PR TITLE
Fix Rails 5 spec failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: ruby
-cache: bundler
 sudo: false
+cache:
+  bundler: true
+  directories:
+    - sunspot/vendor/bundle
+    - sunspot_solr/vendor/bundle
+    - sunspot_rails/tmp/rails_3_0_0_app/vendor/bundle
+    - sunspot_rails/tmp/rails_3_1_0_app/vendor/bundle
+    - sunspot_rails/tmp/rails_3_2_0_app/vendor/bundle
+    - sunspot_rails/tmp/rails_4_0_0_app/vendor/bundle
+    - sunspot_rails/tmp/rails_4_1_0_app/vendor/bundle
+    - sunspot_rails/tmp/rails_4_2_0_app/vendor/bundle
+    - sunspot_rails/tmp/rails_5_0_app/vendor/bundle
 
 rvm:
   - 1.9.3
@@ -25,10 +36,10 @@ env:
 # Limit the size of the matrix by only performing the most common builds
 matrix:
   exclude:
-    # Not supporting Ruby 2.0 and Rails < 3
-    - rvm: 2.0.0
+    # Ruby 2.2+ is not supported on Rails 3.0 / 3.1
+    - rvm: 2.3.1
       env: GEM=sunspot_rails RAILS=3.0.0
-    - rvm: 2.0.0
+    - rvm: 2.3.1
       env: GEM=sunspot_rails RAILS=3.1.0
     # Rails 5 only supports ruby > 2.2.2
     - rvm: 1.9.3
@@ -36,19 +47,6 @@ matrix:
     - rvm: 2.0.0
       env: GEM=sunspot_rails RAILS=5.0
     - rvm: 2.1.0
-      env: GEM=sunspot_rails RAILS=5.0
-  allow_failures:
-    # SQLITE fails to load correctly on Travis in Ruby 2.0
-    - rvm: 2.0.0
-      env: GEM=sunspot_rails RAILS=3.2.0
-    - rvm: 2.0.0
-      env: GEM=sunspot_rails RAILS=4.0.0
-    - rvm: 2.0.0
-      env: GEM=sunspot_rails RAILS=4.1.0
-    - rvm: 2.0.0
-      env: GEM=sunspot_rails RAILS=4.2.0
-    # rails 5.0 doesn't work with rspec-rails-2.14.2 undefined method 'alias_method_chain'
-    - rvm: 2.3.1
       env: GEM=sunspot_rails RAILS=5.0
 
 script:

--- a/sunspot_rails/dev_tasks/spec.rake
+++ b/sunspot_rails/dev_tasks/spec.rake
@@ -27,10 +27,8 @@ namespace :spec do
     ENV['BUNDLE_PATH']    = vendor_path(version)
     ENV['BUNDLE_GEMFILE'] = gemfile_path(version)
 
-    unless File.exist?(ENV['BUNDLE_PATH'])
-      puts "Installing gems for Rails #{version} (this will only be done once)..."
-      sh("bundle install #{ENV['BUNDLE_ARGS']}") || exit(1)
-    end
+    puts "Installing gems for Rails #{version} (this will only be done once)..."
+    sh("bundle install #{ENV['BUNDLE_ARGS']}") || exit(1)
   end
 
   task :generate_rails_app do

--- a/sunspot_rails/gemfiles/rails-3.0.0
+++ b/sunspot_rails/gemfiles/rails-3.0.0
@@ -13,7 +13,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-3.1.0
+++ b/sunspot_rails/gemfiles/rails-3.1.0
@@ -13,7 +13,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-3.2.0
+++ b/sunspot_rails/gemfiles/rails-3.2.0
@@ -13,7 +13,7 @@ gem 'sunspot_solr', :path => File.expand_path('../../../sunspot_solr', __FILE__)
 gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-4.0.0
+++ b/sunspot_rails/gemfiles/rails-4.0.0
@@ -17,7 +17,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
   gem 'test-unit', '~> 3.2.0' if RUBY_VERSION >= '2.2.0'
 end

--- a/sunspot_rails/gemfiles/rails-4.1.0
+++ b/sunspot_rails/gemfiles/rails-4.1.0
@@ -17,7 +17,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end
 

--- a/sunspot_rails/gemfiles/rails-4.2.0
+++ b/sunspot_rails/gemfiles/rails-4.2.0
@@ -17,7 +17,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes' # Rails 4 support for attr_accessor so specs still work
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end
 

--- a/sunspot_rails/gemfiles/rails-5.0
+++ b/sunspot_rails/gemfiles/rails-5.0
@@ -13,7 +13,7 @@ gem 'sunspot_rails', :path => File.expand_path('../..', __FILE__)
 
 group :test do
   gem 'protected_attributes_continued'
-  gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'progress_bar', '~> 1.0.5', require: false
 end
 

--- a/sunspot_rails/spec/rails_template/app/controllers/posts_controller.rb
+++ b/sunspot_rails/spec/rails_template/app/controllers/posts_controller.rb
@@ -1,6 +1,16 @@
 class PostsController < ApplicationController
   def create
-    PostWithAuto.create(params[:post])
-    render :nothing => true
+    PostWithAuto.create(permitted_params[:post])
+    head(:ok)
+  end
+
+  private
+
+  def permitted_params
+    if ::Rails::VERSION::MAJOR >= 4
+      params.permit! # ActionController::Parameters
+    else
+      params
+    end
   end
 end

--- a/sunspot_rails/spec/request_lifecycle_spec.rb
+++ b/sunspot_rails/spec/request_lifecycle_spec.rb
@@ -15,26 +15,22 @@ describe PostsController, :type => :controller do
     Sunspot::Rails.configuration = nil
   end
 
-  unless respond_to?(:describes)
-    controller_name :posts  # RSpec 1
-  end
-
   it 'should automatically commit after each action if specified' do
     @configuration.user_configuration = { 'auto_commit_after_request' => true }
     expect(Sunspot).to receive(:commit_if_dirty)
-    post :create, :post => { :title => 'Test 1' }
+    post :create, :params => { :post => { :title => 'Test 1' } }
   end
   
   it 'should not commit, if configuration is set to false' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false }
     expect(Sunspot).not_to receive(:commit_if_dirty)
-    post :create, :post => { :title => 'Test 1' }
+    post :create, :params => { :post => { :title => 'Test 1' } }
   end
 
   it 'should commit if configuration is not specified' do
     @configuration.user_configuration = {}
     expect(Sunspot).to receive(:commit_if_dirty)
-    post :create, :post => { :title => 'Test 1' }
+    post :create, :params => { :post => { :title => 'Test 1' } }
   end
   
   ### auto_commit_if_delete_dirty
@@ -43,19 +39,19 @@ describe PostsController, :type => :controller do
     @configuration.user_configuration = { 'auto_commit_after_request' => false,
                                           'auto_commit_after_delete_request' => true }
     expect(Sunspot).to receive(:commit_if_delete_dirty)
-    post :create, :post => { :title => 'Test 1' }
+    post :create, :params => { :post => { :title => 'Test 1' } }
   end
   
   it 'should not automatically commit on delete if configuration is set to false' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false,
                                           'auto_commit_after_delete_request' => false }
     expect(Sunspot).not_to receive(:commit_if_delete_dirty)
-    post :create, :post => { :title => 'Test 1' }
+    post :create, :params => { :post => { :title => 'Test 1' } }
   end
 
   it 'should not automatically commit on delete if configuration is not specified' do
     @configuration.user_configuration = { 'auto_commit_after_request' => false }
     expect(Sunspot).not_to receive(:commit_if_delete_dirty)
-    post :create, :post => { :title => 'Test 1' }
+    post :create, :params => { :post => { :title => 'Test 1' } }
   end
 end

--- a/sunspot_rails/spec/spec_helper.rb
+++ b/sunspot_rails/spec/spec_helper.rb
@@ -11,7 +11,6 @@ Bundler.require(ENV['DB'])
 
 require File.expand_path('config/environment', ENV['RAILS_ROOT'])
 require 'rspec/rails'
-require 'rspec/autorun'
 
 if RSolr::VERSION >= '2'
   require File.join('sunspot', 'rails', 'solr_logging')


### PR DESCRIPTION
This does the following:
- updates `rspec-rails` dependency so it is compatible with rails 5
- refines `travis.yml` testing matrix as well as enabling caches for faster builds