### PR TITLE
Add DSL for skipping stored fields retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,16 @@ Post.search.hits.each do |hit|
 end
 ```
 
+Please note that when you have stored fields declared, they all going to be retrieved from Solr every time,
+even if you dont really need them. You can reduce returned stored dataset by using field lists,
+or you can skip all of them entirely:
+
+```ruby
+Post.search do
+  without_stored_fields
+end
+```
+
 ## Hits vs. Results
 
 Sunspot simply stores the type and primary key of objects in Solr.

--- a/sunspot/lib/sunspot/dsl/scope.rb
+++ b/sunspot/lib/sunspot/dsl/scope.rb
@@ -18,6 +18,10 @@ module Sunspot
         @query.add_field_list(Sunspot::Query::FieldList.new([:id] + list)) unless list.empty?
       end
 
+      def without_stored_fields
+        @query.add_field_list(Sunspot::Query::FieldList.new([:id]))
+      end
+
       #
       # Build a positive restriction. This method can take three forms: equality
       # restriction, restriction by another restriction, or identity

--- a/sunspot/spec/api/query/dsl_spec.rb
+++ b/sunspot/spec/api/query/dsl_spec.rb
@@ -1,27 +1,35 @@
 require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'query DSL', :type => :query do
+  let(:blog_id) { 1 }
+
   it 'should allow building search using block argument rather than instance_eval' do
-    @blog_id = 1
     session.search Post do |query|
       query.field_list [:blog_id, :title]
-      query.with(:blog_id, @blog_id)
+      query.with(:blog_id, blog_id)
     end
     expect(connection).to have_last_search_including(:fq, 'blog_id_i:1')
     expect(connection).to have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
   end
 
   it 'should allow field_list specified as arguments' do
-    @blog_id = 1
     session.search Post do |query|
       query.field_list :blog_id, :title
-      query.with(:blog_id, @blog_id)
+      query.with(:blog_id, blog_id)
     end
     expect(connection).to have_last_search_with(fl: [:id, :blog_id_i, :title_ss])
   end
 
+  it 'should allow to skip stored fields retrieval' do
+    session.search Post do |query|
+      query.with(:blog_id, blog_id)
+      query.without_stored_fields
+    end
+    expect(connection).to have_last_search_with(fl: [:id])
+  end
+
   it 'should accept a block in the #new_search method' do
-    search = session.new_search(Post) { with(:blog_id, 1) }
+    search = session.new_search(Post) { with(:blog_id, blog_id) }
     search.execute
     expect(connection).to have_last_search_including(:fq, 'blog_id_i:1')
   end

--- a/sunspot/spec/integration/field_lists_spec.rb
+++ b/sunspot/spec/integration/field_lists_spec.rb
@@ -22,14 +22,19 @@ describe 'fields lists' do
   end
 
   it 'loads only filtered fields' do
-    hit =
-      Sunspot.search(Post) do
-        field_list :title
-      end.hits.first
+    hit = Sunspot.search(Post) { field_list(:title) }.hits.first
 
     expect(hit.stored(:title)).to eq(@post.title)
 
     (stored_field_names - [:title]).each do |field|
+      expect(hit.stored(field)).to be_nil
+    end
+  end
+
+  it 'does not load any stored fields' do
+    hit = Sunspot.search(Post) { without_stored_fields }.hits.first
+
+    stored_field_names.each do |field|
       expect(hit.stored(field)).to be_nil
     end
   end


### PR DESCRIPTION
When you have some stored fields declared for your model, Solr will retrieve them all when you search for something, even if you dont really need it.
There is a `field_lists` feature that could reduce a set of retrieved stored fields, but 
- it does not accepts an empty array as an argument currently, and
- using it without any arguments at all is not quite semantically clear

So I thought that using a new `without_stored_fields` DSL would be actually better

P.S. This patch saved us a lot of IO on our AWS server