### PR TITLE
 Configure update_format (json/xml) via yaml config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,14 @@ rvm:
   # - jruby
 
 env:
-  - GEM=sunspot
+  - GEM=sunspot UPDATE_FORMAT=xml
+  - GEM=sunspot UPDATE_FORMAT=json
   - GEM=sunspot_rails
   - GEM=sunspot_solr
+
+matrix:
+  allow_failures:
+    - env: GEM=sunspot UPDATE_FORMAT=json
 
 script:
   - ci/travis.sh

--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -26,6 +26,7 @@ module Sunspot
             read_timeout nil
             open_timeout nil
             proxy nil
+            update_format :xml
           end
           master_solr do
             url nil

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -254,12 +254,13 @@ module Sunspot
     # RSolr::Connection::Base:: The connection for this session
     #
     def connection
-      @connection ||=
-        self.class.connection_class.connect(:url          => config.solr.url,
-                                            :read_timeout => config.solr.read_timeout,
-                                            :open_timeout => config.solr.open_timeout,
-                                            :proxy        => config.solr.proxy,
-                                            :update_format => :xml)
+      @connection ||= self.class.connection_class.connect(
+        url: config.solr.url,
+        read_timeout: config.solr.read_timeout,
+        open_timeout: config.solr.open_timeout,
+        proxy: config.solr.proxy,
+        update_format: config.solr.update_format || :xml
+      )
     end
 
     def indexer

--- a/sunspot/spec/api/query/fulltext_examples.rb
+++ b/sunspot/spec/api/query/fulltext_examples.rb
@@ -66,7 +66,9 @@ shared_examples_for 'fulltext query' do
     end
 
     it 'puts default dismax parameters in subquery' do
-      expect(subqueries(:q).last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text))
+      expect(subqueries(:q).last[:qf].split(' ').sort).to(
+        eq(%w(backwards_title_text body_textsv tags_textv text_array_text title_text))
+      )
     end
 
     it 'puts field list in main query' do
@@ -78,14 +80,18 @@ shared_examples_for 'fulltext query' do
     search = search do
       keywords 'keyword search'
     end
-    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text))
+    expect(connection.searches.last[:qf].split(' ').sort).to(
+      eq(%w(backwards_title_text body_textsv tags_textv text_array_text title_text))
+    )
   end
 
   it 'searches both stored and unstored text fields' do
     search Post, Namespaced::Comment do
       keywords 'keyword search'
     end
-    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(author_name_text backwards_title_text body_text body_textsv tags_textv title_text))
+    expect(connection.searches.last[:qf].split(' ').sort).to(
+      eq(%w(author_name_text backwards_title_text body_text body_textsv tags_textv text_array_text title_text))
+    )
   end
 
   it 'searches only specified text fields when specified' do
@@ -101,7 +107,7 @@ shared_examples_for 'fulltext query' do
         exclude_fields :backwards_title, :body_mlt
       end
     end
-    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(body_textsv tags_textv title_text))
+    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(body_textsv tags_textv text_array_text title_text))
   end
 
   it 'assigns boost to fields when specified' do
@@ -173,7 +179,9 @@ shared_examples_for 'fulltext query' do
         boost_fields :title => 1.5
       end
     end
-    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text^1.5))
+    expect(connection.searches.last[:qf].split(' ').sort).to(
+      eq(%w(backwards_title_text body_textsv tags_textv text_array_text title_text^1.5))
+    )
   end
 
   it 'ignores boost fields that do not apply' do
@@ -182,7 +190,9 @@ shared_examples_for 'fulltext query' do
         boost_fields :bogus => 1.2, :title => 1.5
       end
     end
-    expect(connection.searches.last[:qf].split(' ').sort).to eq(%w(backwards_title_text body_textsv tags_textv title_text^1.5))
+    expect(connection.searches.last[:qf].split(' ').sort).to(
+      eq(%w(backwards_title_text body_textsv tags_textv text_array_text title_text^1.5))
+    )
   end
 
   it 'sets default boost with default fields' do

--- a/sunspot/spec/helpers/integration_helper.rb
+++ b/sunspot/spec/helpers/integration_helper.rb
@@ -2,6 +2,7 @@ module IntegrationHelper
   def self.included(base)
     base.before(:all) do
       Sunspot.config.solr.url = ENV['SOLR_URL'] || 'http://localhost:8983/solr/default'
+      Sunspot.config.solr.update_format = ENV['UPDATE_FORMAT'].to_sym if ENV['UPDATE_FORMAT']
       Sunspot.reset!(true)
     end
   end

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -37,6 +37,9 @@ end
 
 Sunspot.setup(Post) do
   text :title, :boost => 2
+  text :text_array, :boost => 3 do
+    [title, title]
+  end
   text :body, :stored => true, :more_like_this => true
   text :backwards_title do
     title.reverse if title

--- a/sunspot/spec/spec_helper.rb
+++ b/sunspot/spec/spec_helper.rb
@@ -23,14 +23,10 @@ RSpec.configure do |config|
   config.order = 'random'
 
   # Mock session available to all spec/api tests
-  config.include MockSessionHelper,
-                 :type => :api,
-                 :file_path => /spec[\\\/]api/
+  config.include MockSessionHelper, type: :api, file_path: /spec[\\\/]api/
 
   # Real Solr instance is available to integration tests
-  config.include IntegrationHelper,
-                 :type => :integration,
-                 :file_path => /spec[\\\/]integration/
+  config.include IntegrationHelper, type: :integration, file_path: /spec[\\\/]integration/
 
   # Nested under spec/api
   [:indexer, :query, :search].each do |spec_type|

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -53,6 +53,7 @@ module Sunspot #:nodoc:
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy
+        config.solr.update_format = sunspot_rails_configuration.update_format
         config
       end
 
@@ -68,6 +69,7 @@ module Sunspot #:nodoc:
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy
+        config.solr.update_format = sunspot_rails_configuration.update_format
         config
       end
     end

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -301,6 +301,10 @@ module Sunspot #:nodoc:
         @open_timeout ||= user_configuration_from_key('solr', 'open_timeout')
       end
 
+      def update_format
+        @update_format ||= user_configuration_from_key('solr', 'update_format')
+      end
+
       def proxy
         @proxy ||= user_configuration_from_key('solr', 'proxy')
       end

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -50,11 +50,15 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   end
 
   it "should set the read timeout to nil when not set" do
-    @config.read_timeout == nil
+    expect(@config.read_timeout).to be_nil
   end
 
   it "should set the open timeout to nil when not set" do
-    @config.open_timeout == nil
+    expect(@config.open_timeout).to be_nil
+  end
+
+  it "should set the update_format to nil when not set" do
+    expect(@config.update_format).to be_nil
   end
 
   it "should set 'log_level' property using Rails log level when not set" do
@@ -161,6 +165,10 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
 
   it "should handle the 'open_timeout' property when set" do
     expect(@config.open_timeout).to eq(0.5)
+  end
+
+  it "should handle the 'update_format' property when set" do
+    expect(@config.update_format).to eq('json')
   end
 
   it "should handle the 'proxy' property when set" do

--- a/sunspot_rails/spec/rails_app/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_app/config/sunspot.yml
@@ -22,6 +22,7 @@ config_test:
     bind_address: 127.0.0.1
     read_timeout: 2
     open_timeout: 0.5
+    update_format: json
     proxy: http://proxy.com:12345
   auto_commit_after_request: false
   auto_commit_after_delete_request: true

--- a/sunspot_rails/sunspot_rails.gemspec
+++ b/sunspot_rails/sunspot_rails.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rails', '>= 3'
+  s.add_dependency 'rails', '~> 3'
   s.add_dependency 'sunspot', Sunspot::VERSION
 
   s.add_development_dependency 'appraisal', '2.2.0'

--- a/sunspot_rails/sunspot_rails.gemspec
+++ b/sunspot_rails/sunspot_rails.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rails', '~> 3'
+  s.add_dependency 'rails', '>= 3'
   s.add_dependency 'sunspot', Sunspot::VERSION
 
   s.add_development_dependency 'appraisal', '2.2.0'


### PR DESCRIPTION
This is a follow up to #860, #856.
`update_format` is now configurable via `sunspot.yml` file for those who might prefer `json` format despite the fact that it fails for some specific cases (which I hope will be fixed in `rsolr` soon)