### PR TITLE
Replace includes with eager_load

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/adapters.rb
+++ b/sunspot_rails/lib/sunspot/rails/adapters.rb
@@ -76,8 +76,8 @@ module Sunspot #:nodoc:
         
         def scope_for_load
           scope = relation
-          scope = scope.includes(@include) if @include.present?
-          scope = scope.select(@select)    if @select.present?
+          scope = scope.eager_load(@include) if @include.present?
+          scope = scope.select(@select)      if @select.present?
           Array.wrap(@scopes).each do |s|
             scope = scope.send(s)
           end


### PR DESCRIPTION
The `includes` method doesn't work well with some complicated associations that contains conditions. For example:

```ruby
class Public::Profile
  has_many :profile_diagnosed_conditions, -> { where(:kind => 0) }, :class_name => "Public::ProfileCondition"
  has_many :diagnosed_conditions,
    :through => :profile_diagnosed_conditions, :source => :condition
  has_many :verified_diagnosed_conditions, -> { verified },
    :through => :profile_diagnosed_conditions, :source => :condition

class Profile
  has_many :public_diagnosed_conditions, :through => :public_profiles, :source => :verified_diagnosed_conditions

  searchable :include => [:public_diagnosed_conditions] do
```

When indexing `Profile` this `include` option yields:

```
Unknown column 'conditions.status' in 'where clause'
```

While `eager_load` works fine.