### PR TITLE
Ability to set group.ngroups option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ rvm:
   - 2.3.1
   - 2.4.3
   - 2.5.0
-  - ruby-head
+  - 2.5.3
+  # - ruby-head
   # - rbx-2.0
   # - jruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 
 before_install: 
   - gem install bundler
-  - gem install psych
+  - gem install psych -v 2.2.4
 
 script:
   - ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ rvm:
   - 2.3.1
   - 2.4.3
   - 2.5.0
-  - 2.5.3
-  # - ruby-head
+  - ruby-head
   # - rbx-2.0
   # - jruby
 
@@ -29,7 +28,9 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 
-before_install: gem install bundler
+before_install: 
+  - gem install bundler
+  - gem psych
 
 script:
   - ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
 
 before_install: 
   - gem install bundler
-  - gem install psych -v 2.2.4
 
 script:
   - ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 
 before_install: 
   - gem install bundler
-  - gem psych
+  - gem install psych
 
 script:
   - ci/travis.sh

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ Additional options are supported by the DSL:
 Post.search do
   group :blog_id_str do
     limit 3
-    total false # If you don't need to have the total group counter
+    ngroups false # If you don't need the total groups counter
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ Additional options are supported by the DSL:
 Post.search do
   group :blog_id_str do
     limit 3
+    total false # If you don't need to have the total group counter
   end
 end
 

--- a/sunspot/lib/sunspot/dsl/group.rb
+++ b/sunspot/lib/sunspot/dsl/group.rb
@@ -59,6 +59,16 @@ module Sunspot
         @group.truncate = true
       end
 
+      #
+      # The group.ngroups option true return the total number of groups
+      # this is expensive and sometimes you don't need it!
+      # If total is false paginated_collection last_page? and total_pages wont't work.
+      # Defaults to true.
+      #
+      def total(enabled)
+        @group.total = enabled
+      end
+
       # Specify the order that results should be returned in. This method can
       # be called multiple times; precedence will be in the order given.
       #

--- a/sunspot/lib/sunspot/dsl/group.rb
+++ b/sunspot/lib/sunspot/dsl/group.rb
@@ -62,11 +62,11 @@ module Sunspot
       #
       # The group.ngroups option true return the total number of groups
       # this is expensive and sometimes you don't need it!
-      # If total is false paginated_collection last_page? and total_pages wont't work.
+      # If ngroups is false paginated_collection last_page? and total_pages wont't work.
       # Defaults to true.
       #
-      def total(enabled)
-        @group.total = enabled
+      def ngroups(enabled)
+        @group.ngroups = enabled
       end
 
       # Specify the order that results should be returned in. This method can

--- a/sunspot/lib/sunspot/query/group.rb
+++ b/sunspot/lib/sunspot/query/group.rb
@@ -4,7 +4,7 @@ module Sunspot
     # A Group groups by the unique values of a given field, or by given queries.
     #
     class Group
-      attr_accessor :limit, :truncate, :total
+      attr_accessor :limit, :truncate, :ngroups
       attr_reader :fields, :queries
 
       def initialize
@@ -31,7 +31,7 @@ module Sunspot
       def to_params
         params = {
           :group            => 'true',
-          :"group.ngroups"  => @total.nil? ? 'true' : @total.to_s
+          :"group.ngroups"  => @ngroups.nil? ? 'true' : @ngroups.to_s
         }
 
         params.merge!(@sort.to_params('group.'))

--- a/sunspot/lib/sunspot/query/group.rb
+++ b/sunspot/lib/sunspot/query/group.rb
@@ -4,7 +4,7 @@ module Sunspot
     # A Group groups by the unique values of a given field, or by given queries.
     #
     class Group
-      attr_accessor :limit, :truncate
+      attr_accessor :limit, :truncate, :total
       attr_reader :fields, :queries
 
       def initialize
@@ -30,16 +30,15 @@ module Sunspot
 
       def to_params
         params = {
-          :group            => "true",
-          :"group.ngroups"  => "true",
+          :group            => 'true',
+          :"group.ngroups"  => @total.nil? ? 'true' : @total.to_s
         }
 
-        params.merge!(@sort.to_params("group."))
+        params.merge!(@sort.to_params('group.'))
         params[:"group.field"] = @fields.map(&:indexed_name) if @fields.any?
         params[:"group.query"] = @queries.map(&:to_boolean_phrase) if @queries.any?
         params[:"group.limit"] = @limit if @limit
         params[:"group.truncate"] = @truncate if @truncate
-
         params
       end
     end

--- a/sunspot/spec/integration/field_grouping_spec.rb
+++ b/sunspot/spec/integration/field_grouping_spec.rb
@@ -94,6 +94,25 @@ describe "field grouping" do
     expect(search.group(:title).groups.length).to eql(1)
     expect(search.group(:title).groups.first.results).to eq([ @posts.last ])
   end
+  
+  context "returns a not paginated collection" do
+    subject do
+      search = Sunspot.search(Post) do
+        group :title do
+          total false
+        end
+        paginate :per_page => 1, :page => 2
+
+      end
+      search.group(:title).groups
+    end
+
+    it { expect(subject.per_page).to      eql(1)   }
+    it { expect(subject.total_pages).to   eql(0)   }
+    it { expect(subject.current_page).to  eql(2)   }
+    it { expect(subject.first_page?).to   be(false) }
+    it { expect(subject.last_page?).to    be(true)  }
+  end
 
   context "returns a paginated collection" do
     subject do

--- a/sunspot/spec/integration/field_grouping_spec.rb
+++ b/sunspot/spec/integration/field_grouping_spec.rb
@@ -99,7 +99,7 @@ describe "field grouping" do
     subject do
       search = Sunspot.search(Post) do
         group :title do
-          total false
+          ngroups false
         end
         paginate :per_page => 1, :page => 2
 


### PR DESCRIPTION
Hi,
by default the _Sunspot::Query::Group.to_params_ method has the **group.ngroups** option set to "true". If you don't need the total groups counter, ngroups=false increases performances, here's why we've added this option. Paginated collections return wrong values for total_pages, total_count and last_page? if ngroups is false.

Thank you,
Duccio

