### PR TITLE
Add recommended gitignore to quick start steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ with:
 bundle exec rake sunspot:solr:start # or sunspot:solr:run to start in foreground
 ```
 
+This will generate a `/solr` folder with default configuration files and indexes.
+
+If you're using source control, it's recommended that the files generated for indexing and running (PIDs) are not checked in. You can do this by adding the following lines to `.gitignore`:
+
+```
+solr/data
+solr/test/data
+solr/development/data
+solr/default/data
+solr/pids
+```
+
+
 ## Setting Up Objects
 
 Add a `searchable` block to the objects you wish to index.


### PR DESCRIPTION
For a related issue filed here: https://github.com/sunspot/sunspot/issues/926

Index and PID files generated by the `sunspot_solr` gem should not be checked into source control. This step might be missed by developers less familiar to sunspot and/or the development solr gem and do a `git add .`. This adds a section to the README calling out this step.