### PR TITLE
(Sorting) Check validity of const name before performing a const_get

### DIFF
--- a/sunspot/lib/sunspot/query/sort.rb
+++ b/sunspot/lib/sunspot/query/sort.rb
@@ -1,11 +1,11 @@
 module Sunspot
   module Query
-    # 
+    #
     # The classes in this module implement query components that build sort
     # parameters for Solr. As well as regular sort on fields, there are several
     # "special" sorts that allow ordering for metrics calculated during the
     # search.
-    # 
+    #
     module Sort #:nodoc: all
       DIRECTIONS = {
         :asc => 'asc',
@@ -15,7 +15,7 @@ module Sunspot
       }
 
       class <<self
-        # 
+        #
         # Certain field names are "special", referring to specific non-field
         # sorts, which are generally by other metrics associated with hits.
         #
@@ -24,13 +24,14 @@ module Sunspot
         #
         def special(name)
           special_class_name = "#{Util.camel_case(name.to_s)}Sort"
-          if const_defined?(special_class_name) && special_class_name != 'FieldSort'
+          valid_const_name = special_class_name =~ /^[a-z_][a-z_0-9]*$/i
+          if valid_const_name && const_defined?(special_class_name) && special_class_name != 'FieldSort'
             const_get(special_class_name)
           end
         end
       end
 
-      # 
+      #
       # Base class for sorts. All subclasses should implement the #to_param
       # method, which is a string that is then concatenated with other sort
       # strings by the SortComposite to form the sort parameter.
@@ -42,11 +43,11 @@ module Sunspot
 
         private
 
-        # 
+        #
         # Translate fairly forgiving direction argument into solr direction
         #
         def direction_for_solr
-          DIRECTIONS[@direction] || 
+          DIRECTIONS[@direction] ||
             raise(
               ArgumentError,
               "Unknown sort direction #{@direction}. Acceptable input is: #{DIRECTIONS.keys.map { |input| input.inspect } * ', '}"
@@ -54,7 +55,7 @@ module Sunspot
         end
       end
 
-      # 
+      #
       # A FieldSort is the usual kind of sort, by the value of a particular
       # field, ascending or descending
       #
@@ -71,7 +72,7 @@ module Sunspot
         end
       end
 
-      # 
+      #
       # A RandomSort uses Solr's random field functionality to sort results
       # (usually) randomly.
       #
@@ -91,7 +92,7 @@ module Sunspot
         end
       end
 
-      # 
+      #
       # A ScoreSort sorts by keyword relevance score. This is only useful when
       # performing fulltext search.
       #


### PR DESCRIPTION
In our application, we use uuids for our dynamic field names. We are unable to order on dynamic fields because Sunspot attempts to perform a `const_get` on `our-uuid-valueSort`, which is an invalid name for a Ruby constant.

Adding a regex match before performing this `const_get` fixes this issue.