### PR TITLE
Remove deprecated GC_TUNE option UseParNewGC from startup in sunspot_solr

### DIFF
--- a/sunspot_solr/solr/bin/solr.in.cmd
+++ b/sunspot_solr/solr/bin/solr.in.cmd
@@ -36,7 +36,6 @@ set GC_TUNE=-XX:NewRatio=3 ^
  -XX:TargetSurvivorRatio=90 ^
  -XX:MaxTenuringThreshold=8 ^
  -XX:+UseConcMarkSweepGC ^
- -XX:+UseParNewGC ^
  -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 ^
  -XX:+CMSScavengeBeforeRemark ^
  -XX:PretenureSizeThreshold=64m ^

--- a/sunspot_solr/solr/bin/solr.in.sh
+++ b/sunspot_solr/solr/bin/solr.in.sh
@@ -38,7 +38,6 @@ GC_TUNE="-XX:NewRatio=3 \
 -XX:TargetSurvivorRatio=90 \
 -XX:MaxTenuringThreshold=8 \
 -XX:+UseConcMarkSweepGC \
--XX:+UseParNewGC \
 -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 \
 -XX:+CMSScavengeBeforeRemark \
 -XX:PretenureSizeThreshold=64m \


### PR DESCRIPTION
This option was deprecated in Java 9 and removed in Java 10. I'm able to point a Gemfile at my fork and solr works as expected. This should fix #907.