### PR TITLE
Add Rails 6.0.0.rc1 support

### DIFF
--- a/sunspot_rails/Appraisals
+++ b/sunspot_rails/Appraisals
@@ -61,3 +61,13 @@ if ruby_version >= Gem::Version.new('2.2.0')
     end
   end
 end
+
+if ruby_version >= Gem::Version.new('2.2.0')
+  appraise "rails-6.0.0.rc1" do
+    gem 'sunspot', path: File.expand_path('sunspot', ENV['SUNSPOT_LIB_HOME'])
+    gem 'sunspot_solr', path: File.expand_path('sunspot_solr', ENV['SUNSPOT_LIB_HOME'])
+    gem 'rails', "~> 6.0.0.rc1"
+    gem 'sqlite3', "~> 1.4.0"
+    gem 'progress_bar', '~> 1.0.5', require: false
+  end
+end

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -99,9 +99,15 @@ module Sunspot #:nodoc:
 
             unless options[:auto_remove] == false
               # after_commit { |searchable| searchable.remove_from_index }, :on => :destroy
-              __send__ Sunspot::Rails.configuration.auto_remove_callback,
-                       proc { |searchable| searchable.remove_from_index },
-                       :on => :destroy
+              if ::Rails::VERSION::MAJOR >= 6
+                __send__ Sunspot::Rails.configuration.auto_remove_callback,
+                         proc { |searchable| searchable.remove_from_index },
+                         :if => :destroy
+              else
+                __send__ Sunspot::Rails.configuration.auto_remove_callback,
+                         proc { |searchable| searchable.remove_from_index },
+                         :on => :destroy
+              end
             end
             options[:include] = Util::Array(options[:include])
 

--- a/sunspot_rails/spec/model_lifecycle_spec.rb
+++ b/sunspot_rails/spec/model_lifecycle_spec.rb
@@ -15,7 +15,7 @@ describe 'searchable with lifecycle' do
   describe 'on update' do
     before :each do
       @post = PostWithAuto.create
-      @post.update_attributes(:title => 'Test 1')
+      @post.update(:title => 'Test 1')
       Sunspot.commit
     end
 


### PR DESCRIPTION
When using sunspot_rails with rails6.0.0.rc1, the application raises exception.
```
ArgumentError (Unknown key: :on. Valid keys are: :if, :unless, :prepend)
```

It seems that [Pull Request for AR](https://github.com/rails/rails/pull/30919) raises error in [setting callback](https://github.com/sunspot/sunspot/blob/master/sunspot_rails/lib/sunspot/rails/searchable.rb#L102-L104).
Then I use `if => :destroy` callback and add test support for Rails6.

- - -

And now I seem to encountered another bug, `after_commit on: :destroy` not run.
This behavior is reported [here](https://github.com/rails/rails/issues/36082).
So I creates PullRequest as draft, and update when new version AR is released.