### PR TITLE
Update sunspot_rails homepage

### DIFF
--- a/sunspot_rails/sunspot_rails.gemspec
+++ b/sunspot_rails/sunspot_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                   'Brian Atkinson', 'Tom Coleman', 'Matt Mitchell', 'Nathan Beyer', 'Kieran Topping', 'Nicolas Braem', 'Jeremy Ashkenas',
                   'Dylan Vaughn', 'Brian Durand', 'Sam Granieri', 'Nick Zadrozny', 'Jason Ronallo']
   s.email       = ["mat@patch.com"]
-  s.homepage = 'http://github.com/outoftime/sunspot/tree/master/sunspot_rails'
+  s.homepage = 'http://github.com/sunspot/sunspot/tree/master/sunspot_rails'
   s.summary     = 'Rails integration for the Sunspot Solr search library'
   s.license     = 'MIT'
   s.description = <<-TEXT


### PR DESCRIPTION
Makes the same change as https://github.com/sunspot/sunspot/pull/686 for `sunspot_rails`.