### PR TITLE
JoinQParser doesn't support filter queries (fq) and seems is not going to

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,9 +933,9 @@ end
 # ...produces:
 # sort: "score desc", fl: "* score", start: 0, rows: 20,
 # fq: ["type:Profile"],
-# q: "(_query_:"{!join from=profile_ids_i to=id_i v=$qTweet91755700 fq=$fqTweet91755700}" OR _query_:"{!join from=profile_ids_i to=id_i v=$qRss91753840 fq=$fqRss91753840}")",
-# qTweet91755700: "_query_:"{!edismax qf='keywords_text' mm='1'}keyword1 keyword2"", fqTweet91755700: "type:Tweet",
-# qRss91753840: "_query_:"{!edismax qf='keywords_text'}keyword3"", fqRss91753840: "type:Rss"
+# q: (_query_:"{!join from=profile_ids_i to=id_i v=$qTweet91755700}" OR _query_:"{!join from=profile_ids_i to=id_i v=$qRss91753840}"),
+# qTweet91755700: _query_:"{!field f=type}Tweet"+_query_:"{!edismax qf='keywords_text' mm='1'}keyword1 keyword2",
+# qRss91753840: _query_:"{!field f=type}Rss"+_query_:"{!edismax qf='keywords_text'}keyword3"
 ```
 
 ### Highlighting

--- a/sunspot/lib/sunspot/query/join.rb
+++ b/sunspot/lib/sunspot/query/join.rb
@@ -42,12 +42,10 @@ module Sunspot
         keywords = escape_quotes(params.delete(:q))
         options = params.map { |key, value| escape_param(key, value) }.join(' ')
         q_name = "q#{@target.name}#{self.object_id}"
-        fq_name = "f#{q_name}"
 
         {
-          :q => "_query_:\"{!join from=#{@from} to=#{@to} v=$#{q_name} fq=$#{fq_name}}\"",
-          q_name => "_query_:\"{!edismax #{options}}#{keywords}\"",
-          fq_name => "type:#{@target.name}"
+          :q     => "_query_:\"{!join from=#{@from} to=#{@to} v=$#{q_name}}\"",
+          q_name => "_query_:\"{!field f=type}#{@target.name}\"+_query_:\"{!edismax #{options}}#{keywords}\""
         }
       end
 

--- a/sunspot/spec/api/query/fulltext_examples.rb
+++ b/sunspot/spec/api/query/fulltext_examples.rb
@@ -418,11 +418,9 @@ shared_examples_for 'fulltext query' do
 
       obj_id = find_ob_id(srch)
       q_name = "qPhoto#{obj_id}"
-      fq_name = "f#{q_name}"
 
-      expect(connection.searches.last[:q]).to eq "(_query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\" OR _query_:\"{!edismax qf='description_text^1.2'}keyword2\")"
-      expect(connection.searches.last[q_name]).to eq "_query_:\"{!edismax qf='caption_text'}keyword1\""
-      expect(connection.searches.last[fq_name]).to eq "type:Photo"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name}}\" OR _query_:\"{!edismax qf='description_text^1.2'}keyword2\")"
+      expect(connection.searches.last[q_name]).to eq "_query_:\"{!field f=type}Photo\"+_query_:\"{!edismax qf='caption_text'}keyword1\""
     end
 
     it "should be able to resolve name conflicts with the :prefix option" do
@@ -435,11 +433,9 @@ shared_examples_for 'fulltext query' do
 
       obj_id = find_ob_id(srch)
       q_name = "qPhoto#{obj_id}"
-      fq_name = "f#{q_name}"
 
-      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='description_text^1.2'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\")"
-      expect(connection.searches.last[q_name]).to eq "_query_:\"{!edismax qf='description_text'}keyword2\""
-      expect(connection.searches.last[fq_name]).to eq "type:Photo"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='description_text^1.2'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name}}\")"
+      expect(connection.searches.last[q_name]).to eq "_query_:\"{!field f=type}Photo\"+_query_:\"{!edismax qf='description_text'}keyword2\""
     end
 
     it "should recognize fields when adding from DSL, e.g. when calling boost_fields" do
@@ -453,11 +449,9 @@ shared_examples_for 'fulltext query' do
 
       obj_id = find_ob_id(srch)
       q_name = "qPhoto#{obj_id}"
-      fq_name = "f#{q_name}"
 
-      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='description_text^1.5'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name} fq=$#{fq_name}}\")"
-      expect(connection.searches.last[q_name]).to eq "_query_:\"{!edismax qf='description_text^1.3'}keyword1\""
-      expect(connection.searches.last[fq_name]).to eq "type:Photo"
+      expect(connection.searches.last[:q]).to eq "(_query_:\"{!edismax qf='description_text^1.5'}keyword1\" OR _query_:\"{!join from=photo_container_id_i to=id_i v=$#{q_name}}\")"
+      expect(connection.searches.last[q_name]).to eq "_query_:\"{!field f=type}Photo\"+_query_:\"{!edismax qf='description_text^1.3'}keyword1\""
     end
 
     private

--- a/sunspot/spec/integration/join_spec.rb
+++ b/sunspot/spec/integration/join_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+describe "searching by joined fields" do
+  before :each do
+    Sunspot.remove_all!
+
+    @container1 = PhotoContainer.new(:id => 1)
+    @container2 = PhotoContainer.new(:id => 2).tap { |c| allow(c).to receive(:id).and_return(2) }
+    @container3 = PhotoContainer.new(:id => 3).tap { |c| allow(c).to receive(:id).and_return(3) }
+
+    @picture = Picture.new(:photo_container_id => @container1.id, :description => "one")
+    @photo1  = Photo.new(:photo_container_id => @container1.id, :description => "two")
+    @photo2  = Photo.new(:photo_container_id => @container2.id, :description => "three")
+
+    Sunspot.index!(@container1, @container2, @photo1, @photo2, @picture)
+  end
+
+  it "matches by joined fields" do
+    {
+      "one"   => [],
+      "two"   => [@container1],
+      "three" => [@container2]
+    }.each do |key, res|
+      results = Sunspot.search(PhotoContainer) {
+        fulltext(key, :fields => [:photo_description])
+      }.results
+
+      expect(results).to eq res
+    end
+  end
+
+  it "doesn't match by joined fields with the same name from other collections" do
+    {
+      "one"   => [@container1],
+      "two"   => [],
+      "three" => []
+    }.each do |key, res|
+      results = Sunspot.search(PhotoContainer) {
+        fulltext(key, :fields => [:picture_description])
+      }.results
+
+      expect(results).to eq res
+    end
+  end
+end

--- a/sunspot/spec/mocks/photo.rb
+++ b/sunspot/spec/mocks/photo.rb
@@ -13,6 +13,15 @@ Sunspot.setup(Photo) do
   time :created_at, :trie => true
 end
 
+class Picture < MockRecord
+  attr_accessor :description, :photo_container_id
+end
+
+Sunspot.setup(Picture) do
+  text :description
+  integer :photo_container_id
+end
+
 class PhotoContainer < MockRecord
   attr_accessor :description
 
@@ -25,8 +34,9 @@ Sunspot.setup(PhotoContainer) do
   integer :id
   text :description, :default_boost => 1.2
 
-  join(:caption, :target => Photo, :type => :string, :join => { :from => :photo_container_id, :to => :id })
-  join(:photo_rating, :target => Photo, :type => :trie_float, :join => { :from => :photo_container_id, :to => :id }, :as => 'average_rating_ft')
-  join(:caption, :target => Photo, :type => :text, :join => { :from => :photo_container_id, :to => :id })
-  join(:description, :prefix => "photo", :target => Photo, :type => :text, :join => { :from => :photo_container_id, :to => :id })
+  join(:caption,      :target => Photo,   :type => :string,     :join => { :from => :photo_container_id, :to => :id })
+  join(:photo_rating, :target => Photo,   :type => :trie_float, :join => { :from => :photo_container_id, :to => :id }, :as => 'average_rating_ft')
+  join(:caption,      :target => Photo,   :type => :text,       :join => { :from => :photo_container_id, :to => :id })
+  join(:description,  :target => Photo,   :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "photo")
+  join(:description,  :target => Picture, :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "picture")
 end


### PR DESCRIPTION
There's an issue with the current joins implementation, reproduces when you have a few associations with the same field names, e.g. `url:text` in the example below:

```ruby
class Profile < ActiveRecord::Base
  has_many :sites
  has_many :posts

  searchable do
    integer :id

    join(:url, :target => Site, :type => :text, :join => { :from => :profile_id, :to => :id }, :prefix => "site")
    join(:url, :target => Post, :type => :text, :join => { :from => :profile_id, :to => :id }, :prefix => "post")
  end
end

class Site < ActiveRecord::Base
  searchable do
    integer :profile_id
    text :url
  end
end

class Post < ActiveRecord::Base
  searchable do
    integer :profile_id
    text :url
  end
end
```

Since sunspot keeps everything in a single collection and the `{!join}` query parser doesn't support the `fq` param, when we search `Sunspot.search(Profile) { fulltext("twitter.com", :fields => [:site_url]) }` it would also search in `Post` urls.

This pull request fixes this by appending a separate query that explicitly selects only docs of the correct type for join.