### PR TITLE
Composite ID support

### DIFF
--- a/sunspot/lib/sunspot/adapters.rb
+++ b/sunspot/lib/sunspot/adapters.rb
@@ -63,7 +63,10 @@ module Sunspot
       # String:: ID for use in Solr
       #
       def index_id #:nodoc:
-        InstanceAdapter.index_id_for(@instance.class.name, id)
+        setup     = Sunspot::Setup.for(@instance.class)
+        id_prefix = setup ? setup.id_prefix_for(@instance) : nil
+
+        InstanceAdapter.index_id_for("#{id_prefix}#{@instance.class.name}", id)
       end
 
       class <<self

--- a/sunspot/lib/sunspot/dsl/fields.rb
+++ b/sunspot/lib/sunspot/dsl/fields.rb
@@ -55,6 +55,22 @@ module Sunspot
         @setup.add_document_boost(attr_name, &block)
       end
 
+      #
+      # If you use the compositeId router for shards, you can send documents
+      # with a prefix in the document ID which will be used to calculate the
+      # hash Solr uses to determine the shard a document is sent to for indexing.
+      # The prefix can be anything you’d like it to be (it doesn’t have to be
+      # the shard name, for example), but it must be consistent so Solr
+      # behaves consistently.
+      #
+      # ==== Parameters
+      #
+      # attr_name<Symbol,String>:: Attribute name to call or a string constant
+      #
+      def id_prefix(attr_name = nil, &block)
+        @setup.add_id_prefix(attr_name, &block)
+      end
+
       # method_missing is used to provide access to typed fields, because
       # developers should be able to add new Sunspot::Type implementations
       # dynamically and have them recognized inside the Fields DSL. Like #text,

--- a/sunspot/lib/sunspot/search/hit.rb
+++ b/sunspot/lib/sunspot/search/hit.rb
@@ -17,6 +17,10 @@ module Sunspot
       # Class name of object associated with this hit, as string.
       #
       attr_reader :class_name
+      #
+      # ID prefix used for compositeId shard router
+      #
+      attr_reader :id_prefix
       # 
       # Keyword relevance score associated with this result. Nil if this hit
       # is not from a keyword search.
@@ -27,7 +31,8 @@ module Sunspot
       attr_writer :result #:nodoc:
 
       def initialize(raw_hit, highlights, search) #:nodoc:
-        @class_name, @primary_key = *raw_hit['id'].match(/([^ ]+) (.+)/)[1..2]
+        @id_prefix, @class_name, @primary_key =
+          *raw_hit['id'].match(/((?:[^!]+!)+)*([^\s]+)\s(.+)/)[1..3]
         @score = raw_hit['score']
         @search = search
         @stored_values = raw_hit

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -294,7 +294,9 @@ module Sunspot
       if @id_prefix_extractor
         value = @id_prefix_extractor.value_for(model)
 
-        "#{value}!" if value.is_a?(String) and value.size > 0 and value[-1] != "!"
+        if value.is_a?(String) and value.size > 0
+          value[-1] == "!" ? value : "#{value}!"
+        end
       end
     end
 

--- a/sunspot/spec/api/adapters_spec.rb
+++ b/sunspot/spec/api/adapters_spec.rb
@@ -20,6 +20,14 @@ describe Sunspot::Adapters::InstanceAdapter do
     Sunspot::Adapters::InstanceAdapter::for(UnseenModel)
     expect(Sunspot::Adapters::InstanceAdapter::registered_adapter_for(UnseenModel)).to be(AbstractModelInstanceAdapter)
   end
+
+  it "appends ID prefix when configured" do
+    expect(AbstractModelInstanceAdapter.new(ModelWithPrefixId.new).index_id).to eq "USERDATA!ModelWithPrefixId 1"
+  end
+
+  it "doesn't appends ID prefix when not configured" do
+    expect(AbstractModelInstanceAdapter.new(ModelWithoutPrefixId.new).index_id).to eq "ModelWithoutPrefixId 1"
+  end
 end
 
 describe Sunspot::Adapters::DataAccessor do

--- a/sunspot/spec/api/adapters_spec.rb
+++ b/sunspot/spec/api/adapters_spec.rb
@@ -25,6 +25,11 @@ describe Sunspot::Adapters::InstanceAdapter do
     expect(AbstractModelInstanceAdapter.new(ModelWithPrefixId.new).index_id).to eq "USERDATA!ModelWithPrefixId 1"
   end
 
+  it "supports nested ID prefixes" do
+    expect(AbstractModelInstanceAdapter.
+      new(ModelWithNestedPrefixId.new).index_id).to eq "USER!USERDATA!ModelWithNestedPrefixId 1"
+  end
+
   it "doesn't appends ID prefix when not configured" do
     expect(AbstractModelInstanceAdapter.new(ModelWithoutPrefixId.new).index_id).to eq "ModelWithoutPrefixId 1"
   end

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -12,6 +12,20 @@ describe 'hits', :type => :search do
     end).to eq([['Post', post_1.id.to_s], ['Post', post_2.id.to_s]])
   end
 
+  it "should return ID prefix when used with compositeId shard router" do
+    Sunspot.index!(ModelWithPrefixId.new)
+
+    expect(Sunspot.search(ModelWithPrefixId).
+      hits.map { |h| h.id_prefix }.uniq).to eq ["USERDATA!"]
+  end
+
+  it "should parse nested ID prefixes" do
+    Sunspot.index!(ModelWithNestedPrefixId.new)
+
+    expect(Sunspot.search(ModelWithNestedPrefixId).
+      hits.map { |h| h.id_prefix }.uniq).to eq ["USER!USERDATA!"]
+  end
+
   it 'returns search total as attribute of hits' do
     stub_results(Post.new, 4)
     expect(session.search(Post) do

--- a/sunspot/spec/api/sunspot_spec.rb
+++ b/sunspot/spec/api/sunspot_spec.rb
@@ -24,6 +24,9 @@ describe Sunspot do
       config_before_reset = Sunspot.config
       Sunspot.reset!(true)
       expect(Sunspot.config).to eq(config_before_reset)
+
+      # Restore sunspot config after test
+      Sunspot.reset!(false)
     end
   end
 end

--- a/sunspot/spec/mocks/adapters.rb
+++ b/sunspot/spec/mocks/adapters.rb
@@ -7,7 +7,30 @@ end
 class UnseenModel < AbstractModel
 end
 
+class ModelWithPrefixId < AbstractModel
+  def id
+    1
+  end
+end
+
+Sunspot.setup(ModelWithPrefixId) do
+  id_prefix { "USERDATA" }
+end
+
+class ModelWithoutPrefixId < AbstractModel
+  def id
+    1
+  end
+end
+
+Sunspot.setup(ModelWithoutPrefixId) do
+end
+
+
 class AbstractModelInstanceAdapter < Sunspot::Adapters::InstanceAdapter
+  def id
+    @instance.id
+  end
 end
 
 class AbstractModelDataAccessor < Sunspot::Adapters::DataAccessor

--- a/sunspot/spec/mocks/adapters.rb
+++ b/sunspot/spec/mocks/adapters.rb
@@ -14,7 +14,17 @@ class ModelWithPrefixId < AbstractModel
 end
 
 Sunspot.setup(ModelWithPrefixId) do
-  id_prefix { "USERDATA" }
+  id_prefix { "USERDATA!" }
+end
+
+class ModelWithNestedPrefixId < AbstractModel
+  def id
+    1
+  end
+end
+
+Sunspot.setup(ModelWithNestedPrefixId) do
+  id_prefix { "USER!USERDATA!" }
 end
 
 class ModelWithoutPrefixId < AbstractModel


### PR DESCRIPTION
This allows using compositeId shard router to choose the shards where to place documents. Useful in combination with joins on sharded collections since the collections that need to be joined have to be single-sharded.

In our use case, we have models `User` and `Profile` and when searching users we perform a join, which returns not all records because both the user and the associated profile have to be on a single shard for Solr to be able to join them.

With this patch we can do:
```ruby
searchable do
  id_prefix do
    "USERDATA!"
  end
end
```
In both models, which makes them to be added to a single shard. The `id_prefix` method can accept a `String` (constant), a `Symbol` (attr name), and a block.

With blocks this could be implemented smarter, for example it's possible to create dynamic prefixes, lile:
```ruby
searchable do
  id_prefix do
    "USER#{self.id}" # self.user.id in the Profile model
  end
end
```

This way Solr we make sure the pairs `User` and `Profile` are always on a single shards but not all of the users and profile stored on a single shard together, so the shards still utilized (good for large collections). And Solr supports distributed joins, the only limitation is that the records to join have to be on a single shard, not the whole set/collection.