### PR TITLE
Fix #939

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -98,10 +98,17 @@ module Sunspot #:nodoc:
             end
 
             unless options[:auto_remove] == false
+              on_filter_invalid = /(before|after|around)_(save|destroy|create)/
               # after_commit { |searchable| searchable.remove_from_index }, :on => :destroy
-              __send__ Sunspot::Rails.configuration.auto_remove_callback,
-                       proc { |searchable| searchable.remove_from_index },
-                       :on => :destroy
+              # Only add the on filter if the callback supports it
+              if on_filter_invalid.match?(Sunspot::Rails.configuration.auto_remove_callback)
+                __send__ Sunspot::Rails.configuration.auto_remove_callback,
+                        proc { |searchable| searchable.remove_from_index }
+              else
+                __send__ Sunspot::Rails.configuration.auto_remove_callback,
+                        proc { |searchable| searchable.remove_from_index },
+                        :on => :destroy
+              end
             end
             options[:include] = Util::Array(options[:include])
 

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -98,10 +98,9 @@ module Sunspot #:nodoc:
             end
 
             unless options[:auto_remove] == false
-              on_filter_invalid = /(before|after|around)_(save|destroy|create)/
               # after_commit { |searchable| searchable.remove_from_index }, :on => :destroy
               # Only add the on filter if the callback supports it
-              if on_filter_invalid.match?(Sunspot::Rails.configuration.auto_remove_callback)
+              if Sunspot::Rails.configuration.auto_remove_callback =~ /save|destroy|create/
                 __send__ Sunspot::Rails.configuration.auto_remove_callback,
                         proc { |searchable| searchable.remove_from_index }
               else


### PR DESCRIPTION
rails/30919 added strict callback checking
for Rails 6. The on callback used to be ignored on our default callback.
It now raises an error.

This change checks the configured callback
and conditionally adds the on filter.