### PR TITLE
Proper update_format configuration via sunspot.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ jdk:
 env:
   - GEM=sunspot UPDATE_FORMAT=xml
   - GEM=sunspot UPDATE_FORMAT=json
-  - GEM=sunspot_rails
+  - GEM=sunspot_rails UPDATE_FORMAT=xml
+  - GEM=sunspot_rails UPDATE_FORMAT=json
   - GEM=sunspot_solr
 
 matrix:

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -259,7 +259,7 @@ module Sunspot
         read_timeout: config.solr.read_timeout,
         open_timeout: config.solr.open_timeout,
         proxy: config.solr.proxy,
-        update_format: config.solr.update_format || :xml
+        update_format: update_format_generator
       )
     end
 
@@ -275,6 +275,12 @@ module Sunspot
         Setup.for(types.first)
       else
         CompositeSetup.for(types)
+      end
+    end
+
+    def update_format_generator
+      if config.solr.update_format && RSolr.version.to_i > 1
+        config.solr.update_format.downcase.to_sym == :json ? RSolr::JSON::Generator : RSolr::Xml::Generator
       end
     end
   end

--- a/sunspot_rails/spec/rails_app/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_app/config/sunspot.yml
@@ -2,6 +2,7 @@ test:
   solr:
     hostname: localhost
     port: 8983
+    update_format: <%= ENV.fetch('UPDATE_FORMAT', 'xml') %>
   auto_index_callback: after_save
   auto_remove_callback: after_destroy
 development:


### PR DESCRIPTION
## Problem

found this in logs while trying to set JSON transport for solr via `sunspot.xml`:

> undefined method `add' for "json"

```yml 
# sunspot.yml 

development:
  solr:
    hostname: localhost
    port: <%=ENV['SOLR_PORT'] %>
    path: /solr/collection1
    update_format: json
```

## Solution

fix it.
Seem like it is related to recent changes to `rsolr` gem, not sure why wasnt this catched earlier