### PR TITLE
Default to XML update format since json still has issues

### DIFF
--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -259,7 +259,7 @@ module Sunspot
         read_timeout: config.solr.read_timeout,
         open_timeout: config.solr.open_timeout,
         proxy: config.solr.proxy,
-        update_format: update_format_generator
+        update_format: update_format
       )
     end
 
@@ -278,9 +278,11 @@ module Sunspot
       end
     end
 
-    def update_format_generator
-      if config.solr.update_format && RSolr.version.to_i > 1
-        config.solr.update_format.downcase.to_sym == :json ? RSolr::JSON::Generator : RSolr::Xml::Generator
+    def update_format
+      if config.solr.update_format && config.solr.update_format.to_s.match(/xml|json/i)
+        config.solr.update_format.downcase.to_sym
+      else
+        :xml
       end
     end
   end


### PR DESCRIPTION
## Problem

while testing recent updates on live system found some issues:
1. update format was set to `json` by default (original implementation was defaulting to `xml`
2. https://github.com/sunspot/sunspot/issues/948

## Solution

get back to `xml` as a default transport for now