### PR TITLE
Extract ID prefix into a separate method.

### DIFF
--- a/sunspot/lib/sunspot/adapters.rb
+++ b/sunspot/lib/sunspot/adapters.rb
@@ -56,6 +56,20 @@ module Sunspot
       end
 
       #
+      # An ID prefix to be added to the index_id
+      #
+      # ==== Returns
+      #
+      # String:: ID prefix for use in index ID to control shards
+      # a document ise stored on
+      #
+      def id_prefix
+        setup = Sunspot::Setup.for(@instance.class)
+
+        setup && setup.id_prefix_for(@instance)
+      end
+
+      #
       # The universally-unique ID for this instance that will be stored in solr
       #
       # ==== Returns
@@ -63,9 +77,6 @@ module Sunspot
       # String:: ID for use in Solr
       #
       def index_id #:nodoc:
-        setup     = Sunspot::Setup.for(@instance.class)
-        id_prefix = setup ? setup.id_prefix_for(@instance) : nil
-
         InstanceAdapter.index_id_for("#{id_prefix}#{@instance.class.name}", id)
       end
 

--- a/sunspot/lib/sunspot/adapters.rb
+++ b/sunspot/lib/sunspot/adapters.rb
@@ -60,8 +60,8 @@ module Sunspot
       #
       # ==== Returns
       #
-      # String:: ID prefix for use in index ID to control shards
-      # a document ise stored on
+      # String:: ID prefix for use in index ID to determine
+      # the shard a document is sent to for indexing
       #
       def id_prefix
         setup = Sunspot::Setup.for(@instance.class)


### PR DESCRIPTION
Useful sometimes to get record's ID prefix from third-party libraries.

For example, we use an index queue for background indexing and it uses `Sunspot.remove_by_id`, which stops working once we add an ID prefix, because in the index we get `USA!Profile 123` while `remove_by_id` tries to remove `Profile 123`.