### PR TITLE
Extend the DataExtractor's filter to also remove xFFFE and xFFFF

### DIFF
--- a/sunspot/lib/sunspot/data_extractor.rb
+++ b/sunspot/lib/sunspot/data_extractor.rb
@@ -9,7 +9,7 @@ module Sunspot
     # Abstract extractor to perform common actions on extracted values
     #
     class AbstractExtractor
-      BLACKLIST_REGEXP = /[\x0-\x8\xB\xC\xE-\x1F\x7f]/
+      BLACKLIST_REGEXP = /[\x0-\x8\xB\xC\xE-\x1F\x7f\uFFFE-\uFFFF]/
 
       def value_for(object)
         extract_value_from(object)


### PR DESCRIPTION
Extend the regex to also remove `xFFFE` and `xFFFF` characters (incorrectly encoded characters) as per the W3C spec here https://www.w3.org/TR/REC-xml/#charsets

Found in Solr logs that these occur from time to time and prevent the docs to be indexed.