### PR TITLE
Improve joins with filter queries so they join columns from the desired models only

### DIFF
--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -209,6 +209,10 @@ module Sunspot
       @default_boost = options.delete(:default_boost)
       @joined = true
 
+      if @target.is_a?(String)
+        @target = Util.full_const_get(@target)
+      end
+
       check_options(options)
     end
 
@@ -220,8 +224,10 @@ module Sunspot
       Sunspot::Setup.for(@clazz).field(@join[:to]).indexed_name
     end
 
-    def local_params
-      "{!join from=#{from} to=#{to}}"
+    def local_params(value)
+      query = ["type:\"#{@target.name}\""] | Util.Array(value)
+
+      "{!join from=#{from} to=#{to} v='#{query.join(' AND ')}'}"
     end
 
     def eql?(field)

--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -78,14 +78,14 @@ module Sunspot
         # on whether this restriction is negated.
         #
         def to_boolean_phrase
-          phrase = []
-          phrase << @field.local_params if @field.respond_to? :local_params
-          unless negated?
-            phrase << to_positive_boolean_phrase
-          else
-            phrase << to_negated_boolean_phrase
-          end
-          phrase.join
+          value = if negated?
+                    to_negated_boolean_phrase
+                  else
+                    to_positive_boolean_phrase
+                  end
+
+          @field.respond_to?(:local_params) ?
+            @field.local_params(value) : value
         end
 
         # 

--- a/sunspot/spec/api/query/join_spec.rb
+++ b/sunspot/spec/api/query/join_spec.rb
@@ -6,7 +6,7 @@ describe 'join' do
       with(:caption, 'blah')
     end
     expect(connection).to have_last_search_including(
-      :fq, "{!join from=photo_container_id_i to=id_i}caption_s:blah")
+      :fq, "{!join from=photo_container_id_i to=id_i v='type:\"Photo\" AND caption_s:blah'}")
   end
 
   it 'should greater_than search by join' do
@@ -14,6 +14,6 @@ describe 'join' do
       with(:photo_rating).greater_than(3)
     end
     expect(connection).to have_last_search_including(
-      :fq, "{!join from=photo_container_id_i to=id_i}average_rating_ft:{3\\.0 TO *}")
+      :fq, "{!join from=photo_container_id_i to=id_i v='type:\"Photo\" AND average_rating_ft:{3\\.0 TO *}'}")
   end
 end

--- a/sunspot/spec/integration/join_spec.rb
+++ b/sunspot/spec/integration/join_spec.rb
@@ -8,9 +8,9 @@ describe "searching by joined fields" do
     @container2 = PhotoContainer.new(:id => 2).tap { |c| allow(c).to receive(:id).and_return(2) }
     @container3 = PhotoContainer.new(:id => 3).tap { |c| allow(c).to receive(:id).and_return(3) }
 
-    @picture = Picture.new(:photo_container_id => @container1.id, :description => "one")
-    @photo1  = Photo.new(:photo_container_id => @container1.id, :description => "two")
-    @photo2  = Photo.new(:photo_container_id => @container2.id, :description => "three")
+    @picture = Picture.new(:photo_container_id => @container1.id, :description => "one", :published => true)
+    @photo1  = Photo.new(:photo_container_id => @container1.id, :description => "two", :published => true)
+    @photo2  = Photo.new(:photo_container_id => @container2.id, :description => "three", :published => false)
 
     Sunspot.index!(@container1, @container2, @photo1, @photo2, @picture)
   end
@@ -40,6 +40,25 @@ describe "searching by joined fields" do
       }.results
 
       expect(results).to eq res
+    end
+  end
+
+  it "matches by joined fields when using filter queries" do
+    {
+      :photo_published => [
+        [true,  [@container1]],
+        [false, [@container2]]
+      ],
+      :picture_published => [
+        [true,  [@container1]],
+        [false, []]
+      ]
+    }.each do |key, data|
+      data.each do |(value, res)|
+        results = Sunspot.search(PhotoContainer) { with(key, value) }.results
+
+        expect(results).to eq res
+      end
     end
   end
 end

--- a/sunspot/spec/mocks/photo.rb
+++ b/sunspot/spec/mocks/photo.rb
@@ -1,5 +1,5 @@
 class Photo < MockRecord
-  attr_accessor :caption, :description, :lat, :lng, :size, :average_rating, :created_at, :post_id, :photo_container_id
+  attr_accessor :caption, :description, :lat, :lng, :size, :average_rating, :created_at, :post_id, :photo_container_id, :published
 end
 
 Sunspot.setup(Photo) do
@@ -7,6 +7,7 @@ Sunspot.setup(Photo) do
   text :description
   string :caption
   integer :photo_container_id
+  boolean :published
   boost 0.75
   integer :size, :trie => true
   float :average_rating, :trie => true
@@ -14,12 +15,13 @@ Sunspot.setup(Photo) do
 end
 
 class Picture < MockRecord
-  attr_accessor :description, :photo_container_id
+  attr_accessor :description, :photo_container_id, :published
 end
 
 Sunspot.setup(Picture) do
   text :description
   integer :photo_container_id
+  boolean :published
 end
 
 class PhotoContainer < MockRecord
@@ -34,9 +36,11 @@ Sunspot.setup(PhotoContainer) do
   integer :id
   text :description, :default_boost => 1.2
 
-  join(:caption,      :target => Photo,   :type => :string,     :join => { :from => :photo_container_id, :to => :id })
-  join(:photo_rating, :target => Photo,   :type => :trie_float, :join => { :from => :photo_container_id, :to => :id }, :as => 'average_rating_ft')
-  join(:caption,      :target => Photo,   :type => :text,       :join => { :from => :photo_container_id, :to => :id })
-  join(:description,  :target => Photo,   :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "photo")
-  join(:description,  :target => Picture, :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "picture")
+  join(:caption,      :target => 'Photo',   :type => :string,     :join => { :from => :photo_container_id, :to => :id })
+  join(:photo_rating, :target => 'Photo',   :type => :trie_float, :join => { :from => :photo_container_id, :to => :id }, :as => 'average_rating_ft')
+  join(:caption,      :target => 'Photo',   :type => :text,       :join => { :from => :photo_container_id, :to => :id })
+  join(:description,  :target => 'Photo',   :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "photo")
+  join(:published,    :target => 'Photo',   :type => :boolean,    :join => { :from => :photo_container_id, :to => :id }, :prefix => "photo")
+  join(:description,  :target => 'Picture', :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "picture")
+  join(:published,    :target => 'Picture', :type => :boolean,    :join => { :from => :photo_container_id, :to => :id }, :prefix => "picture")
 end


### PR DESCRIPTION
This fixes the case when a few models have a column with the same name, e.g. "published". For example, a user has a Profile and Blog, both have published:boolean, but you need to filter users with a published Profile only.

The current implementation will fail and return users with both published Profile and Blog, since both have published_b and member_id_i columns in the index.

Additionally, allow join targets to be defined as strings to prevent circular dependency errors