### PR TITLE
Connective boosts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,8 +1169,19 @@ Sunspot supports functions in two ways:
 #Posts with pizza, scored higher (square promotion field) if is_promoted
 Post.search do
   fulltext 'pizza' do
-    boost(function {sqrt(:promotion)}) { with(:is_promoted, true) }
+    boost(function { sqrt(:promotion) }) { with(:is_promoted, true) }
   end
+
+  # adds boost query (bq parameter)
+  boost(0.5) do
+    with(:is_promoted, true)
+  end
+
+  # adds a boost function (bf parameter)
+  boost(function { sqrt(:promotion) })
+
+  # adds a multiplicative boost function (boost parameter)
+  boost_multiplicative(function { sqrt(:promotion) })
 end
 ```
 

--- a/sunspot/lib/sunspot/dsl.rb
+++ b/sunspot/lib/sunspot/dsl.rb
@@ -1,5 +1,5 @@
-%w(spellcheckable fields scope paginatable adjustable field_query
-   standard_query query_facet functional fulltext restriction
+%w(spellcheckable fields functional scope paginatable adjustable field_query
+   standard_query query_facet fulltext restriction
    restriction_with_near search more_like_this_query function
    group field_stats).each do |file|
   require File.join(File.dirname(__FILE__), 'dsl', file)

--- a/sunspot/lib/sunspot/dsl/fulltext.rb
+++ b/sunspot/lib/sunspot/dsl/fulltext.rb
@@ -176,7 +176,7 @@ module Sunspot
           @query.add_additive_boost_function(factor_or_function)
         else
           Sunspot::Util.instance_eval_or_call(
-            Scope.new(@query.create_boost_query(factor_or_function), @setup),
+            Scope.new(@query.add_boost_query(factor_or_function), @setup),
             &block
           )
         end

--- a/sunspot/lib/sunspot/query/abstract_fulltext.rb
+++ b/sunspot/lib/sunspot/query/abstract_fulltext.rb
@@ -10,7 +10,7 @@ module Sunspot
       #
       # Assign a new boost query and return it.
       #
-      def create_boost_query(factor)
+      def add_boost_query(factor)
         @boost_queries << boost_query = BoostQuery.new(factor)
         boost_query
       end
@@ -19,14 +19,18 @@ module Sunspot
       # Add a boost function
       #
       def add_additive_boost_function(function_query)
-        @additive_boost_functions << function_query
+        unless @additive_boost_functions.include?(function_query)
+          @additive_boost_functions << function_query
+        end
       end
 
       #
       # Add a multiplicative boost function
       #
       def add_multiplicative_boost_function(function_query)
-        @multiplicative_boost_functions << function_query
+        unless @multiplicative_boost_functions.include?(function_query)
+          @multiplicative_boost_functions << function_query
+        end
       end
 
       #

--- a/sunspot/lib/sunspot/query/composite_fulltext.rb
+++ b/sunspot/lib/sunspot/query/composite_fulltext.rb
@@ -3,11 +3,30 @@ module Sunspot
     class CompositeFulltext
       def initialize
         @components = []
+        @dismax = nil
       end
 
       def add_fulltext(keywords)
-        @components << dismax = Dismax.new(keywords)
-        dismax
+        @components << @dismax = Dismax.new(keywords)
+        @dismax
+      end
+
+      def add_boost_query(factor)
+        @dismax ||= Dismax.new("*:*")
+        @components << @dismax unless @components.include?(@dismax)
+        @dismax.add_boost_query(factor)
+      end
+
+      def add_boost_function(function)
+        @dismax ||= Dismax.new("*:*")
+        @components << @dismax unless @components.include?(@dismax)
+        @dismax.add_additive_boost_function(function)
+      end
+
+      def add_multiplicative_boost_function(function)
+        @dismax ||= Dismax.new("*:*")
+        @components << @dismax unless @components.include?(@dismax)
+        @dismax.add_multiplicative_boost_function(function)
       end
 
       def add_join(keywords, target, from, to)

--- a/sunspot/lib/sunspot/query/dismax.rb
+++ b/sunspot/lib/sunspot/query/dismax.rb
@@ -28,10 +28,16 @@ module Sunspot
       # The query as Solr parameters
       #
       def to_params
-        params = { :q => @keywords }
-        params[:fl] = '* score'
-        params[:qf] = @fulltext_fields.values.map { |field| field.to_boosted_field }.join(' ')
-        params[:defType] = 'edismax'
+        params = {
+          :q => @keywords,
+          :defType => 'edismax',
+          :fl => '* score'
+        }
+
+        if @fulltext_fields.any?
+          params[:qf] = @fulltext_fields.values.map { |field| field.to_boosted_field }.join(' ')
+        end
+
         params[:mm] = @minimum_match if @minimum_match
         params[:ps] = @phrase_slop if @phrase_slop
         params[:qs] = @query_phrase_slop if @query_phrase_slop

--- a/sunspot/lib/sunspot/query/function_query.rb
+++ b/sunspot/lib/sunspot/query/function_query.rb
@@ -3,11 +3,16 @@ module Sunspot
     # 
     # Abstract class for function queries.
     #
-    class FunctionQuery 
+    class FunctionQuery
+      attr_reader :boost_amount
 
       def ^(y)
         @boost_amount = y
         self
+      end
+
+      def ==(other)
+        @boost_amount == other.boost_amount
       end
     end
 
@@ -15,6 +20,8 @@ module Sunspot
     # Function query which represents a constant.
     #
     class ConstantFunctionQuery < FunctionQuery
+      attr_reader :constant
+
       def initialize(constant)
         @constant = constant
       end
@@ -22,18 +29,28 @@ module Sunspot
       def to_s
         Type.to_literal(@constant) << (@boost_amount ? "^#{@boost_amount}" : "")
       end
+
+      def ==(other)
+        super and @constant == other.constant
+      end
     end
 
     #
     # Function query which represents a field.
     #
     class FieldFunctionQuery < FunctionQuery
+      attr_reader :field
+
       def initialize(field)
         @field = field
       end
 
       def to_s
         "#{Util.escape(@field.indexed_name)}" << (@boost_amount ? "^#{@boost_amount}" : "")
+      end
+
+      def ==(other)
+        super and @field == other.field
       end
     end
 
@@ -43,6 +60,8 @@ module Sunspot
     # Arguments are in turn FunctionQuery objects.
     #
     class FunctionalFunctionQuery < FunctionQuery
+      attr_reader :function_name, :function_args
+
       def initialize(function_name, function_args)
         @function_name, @function_args = function_name, function_args
       end
@@ -50,6 +69,11 @@ module Sunspot
       def to_s
         params = @function_args.map { |arg| arg.to_s }.join(",")
         "#{@function_name}(#{params})" << (@boost_amount ? "^#{@boost_amount}" : "")
+      end
+
+      def ==(other)
+        super and
+          @function_name == other.function_name and @function_args == other.function_args
       end
     end
   end

--- a/sunspot/lib/sunspot/query/join.rb
+++ b/sunspot/lib/sunspot/query/join.rb
@@ -52,7 +52,7 @@ module Sunspot
       #
       # Assign a new boost query and return it.
       #
-      def create_boost_query(factor)
+      def add_boost_query(factor)
       end
 
       #

--- a/sunspot/lib/sunspot/query/standard_query.rb
+++ b/sunspot/lib/sunspot/query/standard_query.rb
@@ -16,6 +16,18 @@ module Sunspot
         @fulltext.add_join(keywords, target, from, to)
       end
 
+      def add_boost_query(factor)
+        @fulltext.add_boost_query(factor)
+      end
+
+      def add_boost_function(function)
+        @fulltext.add_boost_function(function)
+      end
+
+      def add_multiplicative_boost_function(function)
+        @fulltext.add_multiplicative_boost_function(function)
+      end
+
       def disjunction
         parent_fulltext = @fulltext
         @fulltext = @fulltext.add_disjunction

--- a/sunspot/spec/api/query/connective_boost_examples.rb
+++ b/sunspot/spec/api/query/connective_boost_examples.rb
@@ -1,0 +1,85 @@
+shared_examples_for "query with connective scope and boost" do
+  it 'creates a boost query' do
+    search do
+      boost(10) do
+        any_of do
+          with(:coordinates_new).in_bounding_box([23, -46], [25, -44])
+          with(:coordinates_new).in_bounding_box([42, 56], [43, 58])
+        end
+      end
+    end
+
+    expect(connection).to have_last_search_including(
+      :bq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])^10'
+    )
+
+    expect(connection).to have_last_search_including(
+      :defType, 'edismax'
+    )
+  end
+
+  it 'creates a boost function' do
+    search do
+      boost(function() { field(:average_rating) })
+    end
+
+    expect(connection).to have_last_search_including(
+      :bf, 'field(average_rating_ft)'
+    )
+
+    expect(connection).to have_last_search_including(
+      :defType, 'edismax'
+    )
+  end
+
+  it 'creates a multiplicative boost function' do
+    search do
+      boost_multiplicative(function() { field(:average_rating) })
+    end
+
+    expect(connection).to have_last_search_including(
+      :boost, 'field(average_rating_ft)'
+    )
+
+    expect(connection).to have_last_search_including(
+      :defType, 'edismax'
+    )
+  end
+
+  it 'creates combined boost search' do
+    search do
+      boost(10) do
+        any_of do
+          with(:coordinates_new).in_bounding_box([23, -46], [25, -44])
+          with(:coordinates_new).in_bounding_box([42, 56], [43, 58])
+        end
+      end
+
+      boost(function() { field(:average_rating) })
+      boost_multiplicative(function() { field(:average_rating) })
+    end
+
+    expect(connection).to have_last_search_including(
+      :bq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])^10'
+    )
+
+    expect(connection).to have_last_search_including(
+      :bf, 'field(average_rating_ft)'
+    )
+
+    expect(connection).to have_last_search_including(
+      :boost, 'field(average_rating_ft)'
+    )
+  end
+
+  it 'avoids duplicate boost functions' do
+    search do
+      boost(function() { field(:average_rating) })
+      boost(function() { field(:average_rating) })
+      boost_multiplicative(function() { field(:average_rating) })
+    end
+
+    expect(connection.searches.last[:bf]).to eq ['field(average_rating_ft)']
+    expect(connection.searches.last[:boost]).to eq ['field(average_rating_ft)']
+  end
+end

--- a/sunspot/spec/api/query/standard_spec.rb
+++ b/sunspot/spec/api/query/standard_spec.rb
@@ -4,6 +4,7 @@ describe 'standard query', :type => :query do
   it_should_behave_like "scoped query"
   it_should_behave_like "query with advanced manipulation"
   it_should_behave_like "query with connective scope"
+  it_should_behave_like "query with connective scope and boost"
   it_should_behave_like "query with dynamic field support"
   it_should_behave_like "facetable query"
   it_should_behave_like "fulltext query"
@@ -18,6 +19,15 @@ describe 'standard query', :type => :query do
   it 'adds a no-op query to :q parameter when no :q provided' do
     session.search Post do
       with :title, 'My Pet Post'
+    end
+    expect(connection).to have_last_search_with(:q => '*:*')
+  end
+
+  it 'adds a no-op query to :q parameter when only a boost query provided' do
+    session.search Post do
+      boost(2) do
+        with :title, 'My Pet Post'
+      end
     end
     expect(connection).to have_last_search_with(:q => '*:*')
   end

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -605,10 +605,6 @@ describe 'scoped_search' do
         end
 
         boost(function() { div(field(:average_rating), 100) })
-
-        fulltext('Post') do
-          minimum_match 1
-        end
       end
 
       expect(search.results[0]).to eq(@p2)

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -605,6 +605,10 @@ describe 'scoped_search' do
         end
 
         boost(function() { div(field(:average_rating), 100) })
+
+        fulltext('Post') do
+          minimum_match 1
+        end
       end
 
       expect(search.results[0]).to eq(@p2)

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -37,7 +37,7 @@ end
 
 Sunspot.setup(Post) do
   text :title, :boost => 2
-  text :text_array, :boost => 3 do
+  text :text_array do
     [title, title]
   end
   text :body, :stored => true, :more_like_this => true


### PR DESCRIPTION
Currently, only full-text searches support boosts while these can be used with almost any searches that do not include full-text queries.

This patch adds support for boosts and injects an empty Dismax search to the scope with a no-op `*:*` query which adds `bf`, `bq`, and `boost` query parameters.

An example:
```ruby
Post.search do
  boost(0.5) do
    with(:is_promoted, true)
  end

  # adds a boost function (bf parameter)
  boost(function { sqrt(:promotion) })

  # adds a multiplicative boost function (boost parameter)
  boost_multiplicative(function { sqrt(:promotion) })
end
```