### PR TITLE
Fix logging in sunspot_solr

### DIFF
--- a/sunspot_rails/Appraisals
+++ b/sunspot_rails/Appraisals
@@ -57,6 +57,7 @@ if ruby_version >= Gem::Version.new('2.2.0')
       gem 'sunspot', path: File.expand_path('sunspot', ENV['SUNSPOT_LIB_HOME'])
       gem 'sunspot_solr', path: File.expand_path('sunspot_solr', ENV['SUNSPOT_LIB_HOME'])
       gem 'rails', "~> #{rails_version}"
+      gem 'sprockets', '~> 3.0'
       gem 'progress_bar', '~> 1.0.5', require: false
     end
   end


### PR DESCRIPTION
Logging in sunspot_solr stopped working because the location of the log file was no longer passed as an option.

Add back and fix the option for a log4j config file.
The contents is copied from the log4j.properties example file.