### PR TITLE
Update example core to work with Solr 8

### DIFF
--- a/examples/solr7_core/conf/schema.xml
+++ b/examples/solr7_core/conf/schema.xml
@@ -95,7 +95,6 @@
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>


### PR DESCRIPTION
`StandardFilterFactory` has been removed in Solr 8.

See https://stackoverflow.com/questions/56913835/upgrade-filter-in-schema-xml-with-solr-standardfilterfactory-from-existing-core