### PR TITLE
Prevent circular dependency loading error

### DIFF
--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -195,7 +195,7 @@ module Sunspot
   # Could be of any type
   #
   class JoinField < Field #:nodoc:
-    attr_reader :default_boost, :target
+    attr_reader :default_boost
 
     def initialize(name, type, options = {})
       @multiple = !!options.delete(:multiple)
@@ -209,15 +209,11 @@ module Sunspot
       @default_boost = options.delete(:default_boost)
       @joined = true
 
-      if @target.is_a?(String)
-        @target = Util.full_const_get(@target)
-      end
-
       check_options(options)
     end
 
     def from
-      Sunspot::Setup.for(@target).field(@join[:from]).indexed_name
+      Sunspot::Setup.for(target).field(@join[:from]).indexed_name
     end
 
     def to
@@ -225,7 +221,7 @@ module Sunspot
     end
 
     def local_params(value)
-      query = ["type:\"#{@target.name}\""] | Util.Array(value)
+      query = ["type:\"#{target.name}\""] | Util.Array(value)
 
       "{!join from=#{from} to=#{to} v='#{query.join(' AND ')}'}"
     end
@@ -235,6 +231,11 @@ module Sunspot
     end
 
     alias_method :==, :eql?
+
+    def target
+      @target = Util.full_const_get(@target) if @target.is_a?(String)
+      @target
+    end
   end
 
   class TypeField #:nodoc:


### PR DESCRIPTION
With joins sometimes it could be when 2+ models reference each other in the searchable block which, in some circumstances, causes circular dependency loading error.

Additionally, may lead in a wrong constant being loaded, i.e. `Profile` instead of `Public::Profile`. For example, if you have both `Profile` and `Public::Profile` classes and one of the models references `Public::Profile` while only `Profile` was actually loaded at that time. In this case `Util.full_const_get("Public::Profile")` will return `Profile` instead of `Public::Profile`.