### PR TITLE
Support atomic updates for Composite ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,13 @@ Post.atomic_update post1.id => {title: 'A New Title'}, post2.id => {body: 'A New
 post1.atomic_update body: 'A New Body', title: 'Another New Title'
 ```
 
+#### Important
+If you are using [Composite ID](#composite-id) you should pass instance as key, not id. 
+```ruby
+Post.atomic_update post1 => {title: 'A New Title'}, post2 => {body: 'A New Body'}
+```
+It's required only for atomic updates on class level.
+
 ### More Like This
 
 Sunspot can extract related items using more_like_this. When searching

--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -40,6 +40,9 @@ module Sunspot
   NoSetupError = Class.new(StandardError)
   IllegalSearchError = Class.new(StandardError)
   NotImplementedError = Class.new(StandardError)
+  AtomicUpdateWarningMessage = lambda do |class_name|
+    "WARNING: `id_prefix` is defined for #{class_name}. Use instance as key for `atomic_update` instead of ID."
+  end
 
   autoload :Installer, File.join(File.dirname(__FILE__), 'sunspot', 'installer')
 
@@ -208,6 +211,8 @@ module Sunspot
     #
     #   post1, post2 = new Array(2) { Post.create }
     #   Sunspot.atomic_update(Post, post1.id => {title: 'New Title'}, post2.id => {description: 'new description'})
+    #   Or
+    #   Sunspot.atomic_update(Post, post1 => {title: 'New Title'}, post2 => {description: 'new description'})
     #
     # Note that indexed objects won't be reflected in search until a commit is
     # sent - see Sunspot.index! and Sunspot.commit
@@ -223,7 +228,7 @@ module Sunspot
     # ==== Parameters
     #
     # clazz<Class>:: the class of the objects to be updated
-    # updates<Hash>:: hash of updates where keys are model ids
+    # updates<Hash>:: hash of updates where keys are models or model ids
     #                 and values are hash with property name/values to be updated
     #
     def atomic_update!(clazz, updates = {})

--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -40,10 +40,10 @@ module Sunspot
   NoSetupError = Class.new(StandardError)
   IllegalSearchError = Class.new(StandardError)
   NotImplementedError = Class.new(StandardError)
-  AtomicUpdateWarningMessage = lambda do |class_name|
+  AtomicUpdateRequireInstanceForCompositeIdMessage = lambda do |class_name|
     "WARNING: `id_prefix` is defined for #{class_name}. Use instance as key for `atomic_update` instead of ID."
   end
-  RemoveByIdWarningMessage = lambda do |class_name|
+  RemoveByIdNotSupportCompositeIdMessage = lambda do |class_name|
     "WARNING: `id_prefix` is defined for #{class_name}. `remove_by_id` does not support it. Use `remove` instead."
   end
 

--- a/sunspot/lib/sunspot.rb
+++ b/sunspot/lib/sunspot.rb
@@ -43,6 +43,9 @@ module Sunspot
   AtomicUpdateWarningMessage = lambda do |class_name|
     "WARNING: `id_prefix` is defined for #{class_name}. Use instance as key for `atomic_update` instead of ID."
   end
+  RemoveByIdWarningMessage = lambda do |class_name|
+    "WARNING: `id_prefix` is defined for #{class_name}. `remove_by_id` does not support it. Use `remove` instead."
+  end
 
   autoload :Installer, File.join(File.dirname(__FILE__), 'sunspot', 'installer')
 

--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -54,9 +54,19 @@ module Sunspot
     # Remove the model from the Solr index by specifying the class and ID
     #
     def remove_by_id(class_name, *ids)
+      id_prefix = nil
+      clazz_setup = setup_for_class(Util.full_const_get(class_name))
+      if clazz_setup.id_prefix_defined?
+        if clazz_setup.id_prefix_requires_instance?
+          warn(Sunspot::RemoveByIdWarningMessage.call(class_name))
+        else
+          id_prefix = clazz_setup.id_prefix_for_class
+        end
+      end
+
       ids.flatten!
       @connection.delete_by_id(
-        ids.map { |id| Adapters::InstanceAdapter.index_id_for(class_name, id) }
+        ids.map { |id| Adapters::InstanceAdapter.index_id_for("#{id_prefix}#{class_name}", id) }
       )
     end
 

--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -58,7 +58,7 @@ module Sunspot
       clazz_setup = setup_for_class(Util.full_const_get(class_name))
       if clazz_setup.id_prefix_defined?
         if clazz_setup.id_prefix_requires_instance?
-          warn(Sunspot::RemoveByIdWarningMessage.call(class_name))
+          warn(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(class_name))
         else
           id_prefix = clazz_setup.id_prefix_for_class
         end
@@ -166,7 +166,7 @@ module Sunspot
           if key.respond_to?(:id)
             id = Adapters::InstanceAdapter.adapt(key).index_id
           else
-            warn(Sunspot::AtomicUpdateWarningMessage.call(clazz.name))
+            warn(Sunspot::AtomicUpdateRequireInstanceForCompositeIdMessage.call(clazz.name))
           end
         else
           id_prefix = clazz_setup.id_prefix_for_class

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -302,6 +302,44 @@ module Sunspot
       end
     end
 
+    #
+    # Get value for `id_prefix` defined as String
+    #
+    # ==== Returns
+    #
+    # String:: value for `id_prefix`
+    #
+    def id_prefix_for_class
+      return if !id_prefix_defined? || id_prefix_requires_instance?
+
+      @id_prefix_extractor.value_for(nil)
+    end
+
+    #
+    # Check if `id_prefix` is defined for class associated with this setup.
+    #
+    # ==== Returns
+    #
+    # Boolean:: True if class associated with this setup has defined `id_prefix`
+    #
+    def id_prefix_defined?
+      !@id_prefix_extractor.nil?
+    end
+
+    #
+    # Check if instance is required to get `id_prefix` value (instance is required for Proc and
+    # Symbol `id_prefix` only. Value for String `id_prefix` can be get on class level)
+    #
+    # ==== Returns
+    #
+    # Boolean:: True if instance is required to get `id_prefix` value
+    #
+    def id_prefix_requires_instance?
+      return false unless id_prefix_defined?
+
+      !@id_prefix_extractor.is_a?(DataExtractor::Constant)
+    end
+
     protected
 
     # 

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -307,7 +307,7 @@ module Sunspot
     #
     # ==== Returns
     #
-    # String:: value for `id_prefix`
+    # String:: value for `id_prefix` defined as String
     #
     def id_prefix_for_class
       return if !id_prefix_defined? || id_prefix_requires_instance?

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -73,7 +73,7 @@ describe 'document removal', :type => :indexer do
         it 'prints warning' do
           expect do
             session.remove_by_id(clazz, post.id)
-          end.to output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+          end.to output(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(clazz) + "\n").to_stderr
         end
 
         it 'does not remove record' do
@@ -89,7 +89,7 @@ describe 'document removal', :type => :indexer do
         it 'prints warning' do
           expect do
             session.remove_by_id(clazz, post.id)
-          end.to output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+          end.to output(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(clazz) + "\n").to_stderr
         end
 
         it 'does not remove record' do
@@ -105,7 +105,7 @@ describe 'document removal', :type => :indexer do
         it 'does not print warning' do
           expect do
             session.remove_by_id(clazz, post.id)
-          end.to_not output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+          end.to_not output(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(clazz) + "\n").to_stderr
         end
 
         it 'removes record' do
@@ -122,7 +122,7 @@ describe 'document removal', :type => :indexer do
       it 'does not print warning' do
         expect do
           session.remove_by_id(clazz, post.id)
-        end.to_not output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+        end.to_not output(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(clazz) + "\n").to_stderr
       end
 
       it 'removes record' do

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -60,4 +60,75 @@ describe 'document removal', :type => :indexer do
     end
     expect(connection).to have_delete_by_query("(type:Post AND title_ss:monkeys)")
   end
+
+  context 'when call #remove_by_id' do
+    let(:post) { clazz.new(title: 'A Title') }
+    before(:each) { index_post(post) }
+
+    context 'and `id_prefix` is defined on model' do
+      context 'as Proc' do
+        let(:clazz) { PostWithProcPrefixId }
+        let(:id_prefix) { lambda { |post| "USERDATA-#{post.id}!" } }
+
+        it 'prints warning' do
+          expect do
+            session.remove_by_id(clazz, post.id)
+          end.to output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+        end
+
+        it 'does not remove record' do
+          session.remove_by_id(clazz, post.id)
+          expect(connection).to have_no_delete(post_solr_id)
+        end
+      end
+
+      context 'as Symbol' do
+        let(:clazz) { PostWithSymbolPrefixId }
+        let(:id_prefix) { lambda { |post| "#{post.title}!" } }
+
+        it 'prints warning' do
+          expect do
+            session.remove_by_id(clazz, post.id)
+          end.to output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+        end
+
+        it 'does not remove record' do
+          session.remove_by_id(clazz, post.id)
+          expect(connection).to have_no_delete(post_solr_id)
+        end
+      end
+
+      context 'as String' do
+        let(:clazz) { PostWithStringPrefixId }
+        let(:id_prefix) { 'USERDATA!' }
+
+        it 'does not print warning' do
+          expect do
+            session.remove_by_id(clazz, post.id)
+          end.to_not output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+        end
+
+        it 'removes record' do
+          session.remove_by_id(clazz, post.id)
+          expect(connection).to have_delete(post_solr_id)
+        end
+      end
+    end
+
+    context 'and `id_prefix` is not defined on model' do
+      let(:clazz) { PostWithoutPrefixId }
+      let(:id_prefix) { nil }
+
+      it 'does not print warning' do
+        expect do
+          session.remove_by_id(clazz, post.id)
+        end.to_not output(Sunspot::RemoveByIdWarningMessage.call(clazz) + "\n").to_stderr
+      end
+
+      it 'removes record' do
+        session.remove_by_id(clazz, post.id)
+        expect(connection).to have_delete(post_solr_id)
+      end
+    end
+  end
 end

--- a/sunspot/spec/api/setup_spec.rb
+++ b/sunspot/spec/api/setup_spec.rb
@@ -31,7 +31,7 @@ describe Sunspot::Setup do
     end
 
     context 'when `id_prefix` is not defined on model' do
-      let(:clazz) { Post }
+      let(:clazz) { PostWithoutPrefixId }
 
       it 'returns nil' do
         is_expected.to be_nil
@@ -51,7 +51,7 @@ describe Sunspot::Setup do
     end
 
     context 'when `id_prefix` is not defined on model' do
-      let(:clazz) { Post }
+      let(:clazz) { PostWithoutPrefixId }
 
       it 'returns false' do
         is_expected.to be_falsey
@@ -89,7 +89,7 @@ describe Sunspot::Setup do
     end
 
     context 'when `id_prefix` is not defined on model' do
-      let(:clazz) { Post }
+      let(:clazz) { PostWithoutPrefixId }
 
       it 'returns false' do
         is_expected.to be_falsey

--- a/sunspot/spec/api/setup_spec.rb
+++ b/sunspot/spec/api/setup_spec.rb
@@ -1,0 +1,99 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+
+describe Sunspot::Setup do
+  context '#id_prefix_for_class' do
+    subject { Sunspot::Setup.for(clazz).id_prefix_for_class }
+
+    context 'when `id_prefix` is defined on model' do
+      context 'as Proc' do
+        let(:clazz) { PostWithProcPrefixId }
+
+        it 'returns nil' do
+          is_expected.to be_nil
+        end
+      end
+
+      context 'as Symbol' do
+        let(:clazz) { PostWithSymbolPrefixId }
+
+        it 'returns nil' do
+          is_expected.to be_nil
+        end
+      end
+
+      context 'as String' do
+        let(:clazz) { PostWithStringPrefixId }
+
+        it 'returns `id_prefix` value' do
+          is_expected.to eq('USERDATA!')
+        end
+      end
+    end
+
+    context 'when `id_prefix` is not defined on model' do
+      let(:clazz) { Post }
+
+      it 'returns nil' do
+        is_expected.to be_nil
+      end
+    end
+  end
+
+  context '#id_prefix_defined?' do
+    subject { Sunspot::Setup.for(clazz).id_prefix_defined? }
+
+    context 'when `id_prefix` is defined on model' do
+      let(:clazz) { PostWithProcPrefixId }
+
+      it 'returns true' do
+        is_expected.to be_truthy
+      end
+    end
+
+    context 'when `id_prefix` is not defined on model' do
+      let(:clazz) { Post }
+
+      it 'returns false' do
+        is_expected.to be_falsey
+      end
+    end
+  end
+
+  context '#id_prefix_requires_instance?' do
+    subject { Sunspot::Setup.for(clazz).id_prefix_requires_instance? }
+
+    context 'when `id_prefix` is defined on model' do
+      context 'as Proc' do
+        let(:clazz) { PostWithProcPrefixId }
+
+        it 'returns true' do
+          is_expected.to be_truthy
+        end
+      end
+
+      context 'as Symbol' do
+        let(:clazz) { PostWithSymbolPrefixId }
+
+        it 'returns true' do
+          is_expected.to be_truthy
+        end
+      end
+
+      context 'as String' do
+        let(:clazz) { PostWithStringPrefixId }
+
+        it 'returns false' do
+          is_expected.to be_falsey
+        end
+      end
+    end
+
+    context 'when `id_prefix` is not defined on model' do
+      let(:clazz) { Post }
+
+      it 'returns false' do
+        is_expected.to be_falsey
+      end
+    end
+  end
+end

--- a/sunspot/spec/helpers/indexer_helper.rb
+++ b/sunspot/spec/helpers/indexer_helper.rb
@@ -14,4 +14,26 @@ module IndexerHelper
   def values_in_last_document_for(field_name)
     @connection.adds.last.last.fields_by_name(field_name).map { |field| field.value }
   end
+
+  def index_post(post)
+    Sunspot.index!(post)
+    hit = find_post(post)
+    expect(hit).not_to be_nil
+    hit
+  end
+
+  def find_post(post)
+    Sunspot.search(clazz).hits.find { |h| h.primary_key.to_i == post.id && h.id_prefix == id_prefix_value(post, id_prefix) }
+  end
+
+  def id_prefix_value(post, id_prefix)
+    return unless id_prefix
+    return id_prefix if id_prefix.is_a?(String)
+
+    id_prefix.call(post)
+  end
+
+  def post_solr_id
+    "#{id_prefix_value(post, id_prefix)}#{clazz} #{post.id}"
+  end
 end

--- a/sunspot/spec/integration/atomic_updates_spec.rb
+++ b/sunspot/spec/integration/atomic_updates_spec.rb
@@ -1,5 +1,78 @@
 require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
+shared_examples 'atomic update with instance as key' do
+  it 'updates record' do
+    post = clazz.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+    Sunspot.atomic_update!(clazz, post => { title: 'A New Title' })
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: 'A New Title', featured: true)
+
+    Sunspot.atomic_update!(clazz, post => { featured: false })
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: 'A New Title', featured: false)
+  end
+
+  it 'does not print warning' do
+    post = clazz.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+    expect do
+      Sunspot.atomic_update!(clazz, post => { title: 'A New Title' })
+    end.to_not output(Sunspot::AtomicUpdateWarningMessage.call(clazz)).to_stderr
+  end
+
+  it 'does not create duplicate document' do
+    post = clazz.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+    Sunspot.atomic_update!(clazz, post => { title: 'A New Title' })
+    hit = find_indexed_post_with_prefix_id(post, nil)
+    expect(hit).to be_nil
+  end
+end
+
+shared_examples 'atomic update with id as key' do
+  it 'does not update record' do
+    post = clazz.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+    Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: 'A Title', featured: true)
+
+    Sunspot.atomic_update!(clazz, post.id => { featured: false })
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: 'A Title', featured: true)
+  end
+
+  it 'prints warning' do
+    post = clazz.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+    expect do
+      Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
+    end.to output(Sunspot::AtomicUpdateWarningMessage.call(clazz) + "\n").to_stderr
+  end
+
+  it 'creates duplicate document that have only fields provided for update' do
+    post = clazz.new(title: 'A Title', featured: true)
+    Sunspot.index!(post)
+
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+    Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
+    validate_hit(find_and_validate_indexed_post_with_prefix_id(post, nil), title: 'A New Title', featured: nil)
+  end
+end
+
 describe 'Atomic Update feature' do
   before :all do
     Sunspot.remove_all
@@ -16,6 +89,23 @@ describe 'Atomic Update feature' do
     hit = Sunspot.search(Post).hits.find{ |h| h.primary_key.to_i == id }
     expect(hit).not_to be_nil
     hit
+  end
+
+  def find_and_validate_indexed_post_with_prefix_id(post, id_prefix)
+    hit = find_indexed_post_with_prefix_id(post, id_prefix_value(post, id_prefix))
+    expect(hit).not_to be_nil
+    hit
+  end
+
+  def find_indexed_post_with_prefix_id(post, id_prefix)
+    Sunspot.search(post.class).hits.find { |h| h.primary_key.to_i == post.id && h.id_prefix == id_prefix }
+  end
+
+  def id_prefix_value(post, id_prefix)
+    return unless id_prefix
+    return id_prefix if id_prefix.is_a?(String)
+
+    id_prefix.call(post)
   end
 
   it 'updates single record fields one by one' do
@@ -54,5 +144,79 @@ describe 'Atomic Update feature' do
 
     Sunspot.atomic_update!(Post, post.id => {featured: nil})
     validate_hit(find_indexed_post(post.id), title: post.title, tag_list: nil, featured: nil)
+  end
+
+  context 'when `id_prefix` is defined on model' do
+    context 'as Proc' do
+      let(:clazz) { PostWithProcPrefixId }
+      let(:id_prefix) { lambda { |post| "USERDATA-#{post.id}!" } }
+
+      context 'and instance passed as key' do
+        include_examples 'atomic update with instance as key'
+      end
+
+      context 'and id passed as key' do
+        include_examples 'atomic update with id as key'
+      end
+    end
+
+    context 'as Symbol' do
+      let(:clazz) { PostWithSymbolPrefixId }
+      let(:id_prefix) { lambda { |post| "#{post.title}!" } }
+
+      context 'and instance passed as key' do
+        include_examples 'atomic update with instance as key'
+      end
+
+      context 'and id passed as key' do
+        include_examples 'atomic update with id as key'
+      end
+    end
+
+    context 'as String' do
+      let(:clazz) { PostWithStringPrefixId }
+      let(:id_prefix) { 'USERDATA!' }
+
+      context 'and instance passed as key' do
+        include_examples 'atomic update with instance as key'
+      end
+
+      context 'and id passed as key' do
+        it 'updates record' do
+          post = clazz.new(title: 'A Title', featured: true)
+          Sunspot.index!(post)
+
+          validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+          Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
+          validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: 'A New Title', featured: true)
+
+          Sunspot.atomic_update!(clazz, post.id => { featured: false })
+          validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: 'A New Title', featured: false)
+        end
+
+        it 'does not print warning' do
+          post = clazz.new(title: 'A Title', featured: true)
+          Sunspot.index!(post)
+
+          validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+          expect do
+            Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
+          end.to_not output(Sunspot::AtomicUpdateWarningMessage.call(clazz) + "\n").to_stderr
+        end
+
+        it 'does not create duplicate document' do
+          post = clazz.new(title: 'A Title', featured: true)
+          Sunspot.index!(post)
+
+          validate_hit(find_and_validate_indexed_post_with_prefix_id(post, id_prefix), title: post.title, featured: post.featured)
+
+          Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
+          hit = find_indexed_post_with_prefix_id(post, nil)
+          expect(hit).to be_nil
+        end
+      end
+    end
   end
 end

--- a/sunspot/spec/integration/atomic_updates_spec.rb
+++ b/sunspot/spec/integration/atomic_updates_spec.rb
@@ -22,7 +22,7 @@ shared_examples 'atomic update with instance as key' do
 
     expect do
       Sunspot.atomic_update!(clazz, post => { title: 'A New Title' })
-    end.to_not output(Sunspot::AtomicUpdateWarningMessage.call(clazz)).to_stderr
+    end.to_not output(Sunspot::AtomicUpdateRequireInstanceForCompositeIdMessage.call(clazz)).to_stderr
   end
 
   it 'does not create duplicate document' do
@@ -59,7 +59,7 @@ shared_examples 'atomic update with id as key' do
 
     expect do
       Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
-    end.to output(Sunspot::AtomicUpdateWarningMessage.call(clazz) + "\n").to_stderr
+    end.to output(Sunspot::AtomicUpdateRequireInstanceForCompositeIdMessage.call(clazz) + "\n").to_stderr
   end
 
   it 'creates duplicate document that have only fields provided for update' do
@@ -111,7 +111,7 @@ describe 'Atomic Update feature' do
   it 'updates single record fields one by one' do
     post = Post.new(title: 'A Title', featured: true)
     Sunspot.index!(post)
-    
+
     validate_hit(find_indexed_post(post.id), title: post.title, featured: post.featured)
 
     Sunspot.atomic_update!(Post, post.id => {title: 'A New Title'})
@@ -203,7 +203,7 @@ describe 'Atomic Update feature' do
 
           expect do
             Sunspot.atomic_update!(clazz, post.id => { title: 'A New Title' })
-          end.to_not output(Sunspot::AtomicUpdateWarningMessage.call(clazz) + "\n").to_stderr
+          end.to_not output(Sunspot::AtomicUpdateRequireInstanceForCompositeIdMessage.call(clazz) + "\n").to_stderr
         end
 
         it 'does not create duplicate document' do

--- a/sunspot/spec/mocks/connection.rb
+++ b/sunspot/spec/mocks/connection.rb
@@ -92,6 +92,12 @@ module Mock
       end
     end
 
+    def has_no_delete?(*ids)
+      @deletes.none? do |delete|
+        delete & ids == ids
+      end
+    end
+
     def has_delete_by_query?(query)
       @deletes_by_query.include?(query)
     end

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -99,3 +99,29 @@ end
 class PhotoPost < Post
 end
 
+class PostWithProcPrefixId < Post
+end
+
+Sunspot.setup(PostWithProcPrefixId) do
+  id_prefix { "USERDATA-#{id}!" }
+  string :title, :stored => true
+  boolean :featured, :using => :featured?, :stored => true
+end
+
+class PostWithSymbolPrefixId < Post
+end
+
+Sunspot.setup(PostWithSymbolPrefixId) do
+  id_prefix :title
+  string :title, :stored => true
+  boolean :featured, :using => :featured?, :stored => true
+end
+
+class PostWithStringPrefixId < Post
+end
+
+Sunspot.setup(PostWithStringPrefixId) do
+  id_prefix 'USERDATA!'
+  string :title, :stored => true
+  boolean :featured, :using => :featured?, :stored => true
+end

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -125,3 +125,11 @@ Sunspot.setup(PostWithStringPrefixId) do
   string :title, :stored => true
   boolean :featured, :using => :featured?, :stored => true
 end
+
+class PostWithoutPrefixId < Post
+end
+
+Sunspot.setup(PostWithoutPrefixId) do
+  string :title, :stored => true
+  boolean :featured, :using => :featured?, :stored => true
+end

--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -287,7 +287,7 @@ module Sunspot #:nodoc:
         #
         # ==== Updates (passed as a hash)
         #
-        # updates should be specified as a hash, where key - is the object ID
+        # updates should be specified as a hash, where key - is the object or the object ID
         # and values is hash with property name/values to be updated.
         #
         # ==== Examples
@@ -303,6 +303,8 @@ module Sunspot #:nodoc:
         #
         #   # update single property
         #   Post.atomic_update(post1.id => {description: 'New post description'})
+        #   Or
+        #   Post.atomic_update(post1 => {description: 'New post description'})
         #
         # ==== Notice
         # all non-stored properties in Solr index will be lost after update.
@@ -453,7 +455,7 @@ module Sunspot #:nodoc:
         # you only need to pass hash with property changes
         #
         def solr_atomic_update(updates = {})
-          Sunspot.atomic_update(self.class, self.id => updates)
+          Sunspot.atomic_update(self.class, self => updates)
         end
 
         #
@@ -461,7 +463,7 @@ module Sunspot #:nodoc:
         # See #solr_atomic_update
         #
         def solr_atomic_update!(updates = {})
-          Sunspot.atomic_update!(self.class, self.id => updates)
+          Sunspot.atomic_update!(self.class, self => updates)
         end
         
         # 


### PR DESCRIPTION
@serggl PR for #958 

About atomic updates:
So, `atomic_update` and `atomic_update!` now accept instance as key to handle `id_prefix`.
If `id_prefix` defined as `String` - `atomic_update` can be used with ID as the key without any problem.
Also, I added the warning for situations when `id_prefix` is `Block` or `Symbol` and `atomic_update` is used with ID as key.

About remove by id:
The only thing I changed in `remove_by_id` method is adding support for `id_prefix` defined as `String` because we can fetch it on a class level.
Also, I added a similar warning for `id_prefix` defined as `Block` or `Symbol`.

All of the above changes are made for `sunspot` gem.
But there is also one small change for `sunspot_rails` gem:
I modified [solr_atomic_update](solr_atomic_update) and [solr_atomic_update!](https://github.com/sunspot/sunspot/blob/master/sunspot_rails/lib/sunspot/rails/searchable.rb#L320) methods to always pass instance as the key instead of ID. These methods stand for the atomic update on the instance level, so this change is required to handle `id_prefix`:
```ruby
post1.atomic_update body: 'A New Body', title: 'Another New Title'
```