### PR TITLE
Fix backwards compatibility loading engine models on Rails 3.0

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -31,7 +31,6 @@ namespace :sunspot do
       # Load all the application's models. Models which invoke 'searchable' will register themselves
       # in Sunspot.searchable.
       Rails.application.eager_load!
-      Rails::Engine.subclasses.each{|engine| engine.instance.eager_load!}
 
       if args[:models].present?
         # Choose a specific subset of models, if requested

--- a/sunspot_rails/spec/rails_app/config/application.rb
+++ b/sunspot_rails/spec/rails_app/config/application.rb
@@ -4,6 +4,9 @@ require 'rails/all'
 
 Bundler.require(:default, Rails.env) if defined?(Bundler)
 
+# Load the test engine
+require File.expand_path('../../vendor/engines/test_engine/lib/test_engine', __FILE__)
+
 module RailsApp
   class Application < Rails::Application
     config.encoding = 'utf-8'

--- a/sunspot_rails/spec/rails_app/vendor/engines/test_engine/app/models/test_engine/rake_task_auto_load_test_model.rb
+++ b/sunspot_rails/spec/rails_app/vendor/engines/test_engine/app/models/test_engine/rake_task_auto_load_test_model.rb
@@ -1,0 +1,15 @@
+# This model should not be used for any test other than the spec test that
+# checks if all models are loaded. We don't want to pre-load this model in
+# another test because we're checking to see if it will be auto-loaded by
+# the reindex task
+module TestEngine
+  class RakeTaskAutoLoadTestModel < ActiveRecord::Base
+    def self.table_name
+      'posts'
+    end
+
+    searchable do
+      string :name
+    end
+  end
+end

--- a/sunspot_rails/spec/rails_app/vendor/engines/test_engine/lib/test_engine.rb
+++ b/sunspot_rails/spec/rails_app/vendor/engines/test_engine/lib/test_engine.rb
@@ -1,0 +1,4 @@
+require_relative "test_engine/engine"
+
+module TestEngine
+end

--- a/sunspot_rails/spec/rails_app/vendor/engines/test_engine/lib/test_engine/engine.rb
+++ b/sunspot_rails/spec/rails_app/vendor/engines/test_engine/lib/test_engine/engine.rb
@@ -1,0 +1,5 @@
+module TestEngine
+  class Engine < ::Rails::Engine
+    engine_name 'sunspot_rails_test_engine'
+  end
+end

--- a/sunspot_rails/spec/rake_task_spec.rb
+++ b/sunspot_rails/spec/rake_task_spec.rb
@@ -11,8 +11,8 @@ describe 'sunspot namespace rake task' do
     it "should reindex all models if none are specified" do
       run_rake_task("sunspot:reindex", '', '', true)
 
-      # This model should not be used by any other test and therefore should only be loaded by this test
-      expect(Sunspot.searchable.collect(&:name)).to include('RakeTaskAutoLoadTestModel')
+      # This models should not be used by any other test and therefore should only be loaded by this test
+      expect(Sunspot.searchable.collect(&:name)).to include('RakeTaskAutoLoadTestModel', 'TestEngine::RakeTaskAutoLoadTestModel')
     end
 
     it "should accept a space delimited list of models to reindex" do


### PR DESCRIPTION
Hi!

As mentioned in the issue #739, the rake task `sunspot:reindex` fails on Rails 3.0, because the `instance` method on the `Engine` is not implemented in this version.

The error is:

```
NoMethodError:
   undefined method `instance' for TestEngine::Engine:Class
```

The offending line is:

https://github.com/sunspot/sunspot/blob/aa236c157dac119781646f0453987714a0218c52/sunspot_rails/lib/sunspot/rails/tasks.rb#L34

But is possible that this line isn't really needed? I added a spec to check that engine models are loaded, can somebody else take a look?

And thank you all for the work on the gem!