### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
     can be performed without hand-writing any boolean queries or building Solr parameters by hand.
   TEXT
 
-  s.rubyforge_project = "sunspot"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/sunspot_rails/sunspot_rails.gemspec
+++ b/sunspot_rails/sunspot_rails.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |s|
     Rails request.
   TEXT
 
-  s.rubyforge_project = "sunspot"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/sunspot_solr/sunspot_solr.gemspec
+++ b/sunspot_solr/sunspot_solr.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
     distribution is well suited to development and testing.
   TEXT
 
-  s.rubyforge_project = "sunspot"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property.

[1]: https://twitter.com/evanphx/status/399552820380053505
