### PR TITLE
Restriction queries with joined fields have to be in double quotes

### DIFF
--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -226,6 +226,10 @@ module Sunspot
       "{!join from=#{from} to=#{to} v='#{query.join(' AND ')}'}"
     end
 
+    def to_solr_conditional(value)
+      "\"#{value}\""
+    end
+
     def eql?(field)
       super && target == field.target && from == field.from && to == field.to
     end

--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -208,7 +208,8 @@ module Sunspot
         private
 
         def to_solr_conditional
-          "#{solr_value}"
+          @field.respond_to?(:to_solr_conditional) ?
+            @field.to_solr_conditional(solr_value) : "#{solr_value}"
         end
       end
 

--- a/sunspot/spec/api/query/join_spec.rb
+++ b/sunspot/spec/api/query/join_spec.rb
@@ -6,7 +6,7 @@ describe 'join' do
       with(:caption, 'blah')
     end
     expect(connection).to have_last_search_including(
-      :fq, "{!join from=photo_container_id_i to=id_i v='type:\"Photo\" AND caption_s:blah'}")
+      :fq, "{!join from=photo_container_id_i to=id_i v='type:\"Photo\" AND caption_s:\"blah\"'}")
   end
 
   it 'should greater_than search by join' do


### PR DESCRIPTION
When using restrictions on joined fields and the value has space characters the query has to be in double-quotes.

An example that works properly:
```
fq: ["type:Public::Profile", "{!join from=id_i to=member_id_i v='type:"Member" AND tag_names_sm:"Awards Nominee"'}"]
```

This one doesn't:
```
fq: ["type:Public::Profile", "{!join from=id_i to=member_id_i v='type:"Member" AND tag_names_sm:Awards Nominee'}"]
```