### PR TITLE
Ability to explicitly provide ID prefix when deleting by ID.

### DIFF
--- a/sunspot/lib/sunspot/indexer.rb
+++ b/sunspot/lib/sunspot/indexer.rb
@@ -54,14 +54,20 @@ module Sunspot
     # Remove the model from the Solr index by specifying the class and ID
     #
     def remove_by_id(class_name, *ids)
-      clazz_setup = setup_for_class(Util.full_const_get(class_name))
-      id_prefix = if clazz_setup.id_prefix_defined?
-                    if clazz_setup.id_prefix_requires_instance?
-                      warn(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(class_name))
-                    else
-                      clazz_setup.id_prefix_for_class
+      if class_name.is_a?(String) and class_name.index("!")
+        partition  = class_name.rpartition("!")
+        id_prefix  = partition[0..1].join
+        class_name = partition[2]
+      else
+        clazz_setup = setup_for_class(Util.full_const_get(class_name))
+        id_prefix = if clazz_setup.id_prefix_defined?
+                      if clazz_setup.id_prefix_requires_instance?
+                        warn(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(class_name))
+                      else
+                        clazz_setup.id_prefix_for_class
+                      end
                     end
-                  end
+      end
 
       ids.flatten!
       @connection.delete_by_id(

--- a/sunspot/spec/api/indexer/removal_spec.rb
+++ b/sunspot/spec/api/indexer/removal_spec.rb
@@ -130,5 +130,21 @@ describe 'document removal', :type => :indexer do
         expect(connection).to have_delete(post_solr_id)
       end
     end
+
+    context 'and `id_prefix` is passed along with `class_name`' do
+      let(:clazz) { PostWithProcPrefixId }
+      let(:id_prefix) { lambda { |post| "USERDATA-#{post.id}!" } }
+
+      it 'does not print warning' do
+        expect do
+          session.remove_by_id("USERDATA-#{post.id}!#{clazz.name}", post.id)
+        end.to_not output(Sunspot::RemoveByIdNotSupportCompositeIdMessage.call(clazz) + "\n").to_stderr
+      end
+
+      it 'removes record' do
+        session.remove_by_id("USERDATA-#{post.id}!#{clazz.name}", post.id)
+        expect(connection).to have_delete(post_solr_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes ID prefix could be known and explicitly provided to the remove_by_id in this format "USERDATA!User".

Example use-case – indexing queues, when synchronization with Solr happens in background. Record being removed from the database and a corresponding event created in the queue with record_class_name, record_id, type of the operation, and ID prefix, which is calculated before removing the record.