### PR TITLE
JSONRangeFacet parameter issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,18 @@ Post.search do
 end
 ```
 
+## Eager Loading
+
+If you want to do eager loading on your sunspot search all you have to do is add this:
+
+Sunspot.search Post do
+  data_accessor_for(Post).include = [:comment]
+end
+
+This is as long as you have the relationship in the model as a has_many etc.
+
+In this case you could call the Post.comment and not have any sql queries
+
 ## Session Proxies
 
 TODO

--- a/sunspot/lib/sunspot/query/abstract_json_field_facet.rb
+++ b/sunspot/lib/sunspot/query/abstract_json_field_facet.rb
@@ -17,6 +17,9 @@ module Sunspot
         params[:sort] = { @options[:sort] => @options[:sort_type]||'desc' } unless @options[:sort].nil?
         params[:prefix] = @options[:prefix] unless @options[:prefix].nil?
         params[:offset] = @options[:offset] unless @options[:offset].nil?
+        params[:allBuckets] = @options[:all_buckets] unless @options[:all_buckets].nil?
+        params[:missing] = @options[:missing] unless @options[:missing].nil?
+        params[:method] = @options[:method] unless @options[:method].nil?
 
         if !@options[:distinct].nil?
           dist_opts = @options[:distinct]

--- a/sunspot/lib/sunspot/query/date_field_json_facet.rb
+++ b/sunspot/lib/sunspot/query/date_field_json_facet.rb
@@ -1,24 +1,10 @@
 module Sunspot
   module Query
-    class DateFieldJsonFacet < AbstractJsonFieldFacet
+    class DateFieldJsonFacet < RangeJsonFacet
 
       def initialize(field, options, setup)
-        raise Exception.new('Need to specify a time_range') if options[:time_range].nil?
-        @start = options[:time_range].first
-        @end = options[:time_range].last
-        @gap = "+#{options[:gap] || 86400}SECONDS"
         super
-      end
-
-      def field_name_with_local_params
-        params = {}
-        params[:type] = 'range'
-        params[:field] = @field.indexed_name
-        params[:start] = @field.to_indexed(@start)
-        params[:end] = @field.to_indexed(@end)
-        params[:gap] = @gap
-        params.merge!(init_params)
-        { @field.name => params }
+        @gap = "+#{@gap}#{options[:gap_unit] || 'SECONDS'}"
       end
     end
   end

--- a/sunspot/lib/sunspot/query/range_json_facet.rb
+++ b/sunspot/lib/sunspot/query/range_json_facet.rb
@@ -5,7 +5,8 @@ module Sunspot
       SECONDS_IN_DAY = 86400
 
       def initialize(field, options, setup)
-        raise Exception.new("Need to specify a range") if options[:range].nil? && options[:time_range].nil?
+        options[:range] ||= options[:time_range]
+        raise Exception.new("Need to specify a range") if options[:range].nil?
         @start = options[:range].first
         @end = options[:range].last
         @gap = options[:gap] || SECONDS_IN_DAY

--- a/sunspot/lib/sunspot/query/range_json_facet.rb
+++ b/sunspot/lib/sunspot/query/range_json_facet.rb
@@ -5,10 +5,11 @@ module Sunspot
       SECONDS_IN_DAY = 86400
 
       def initialize(field, options, setup)
-        raise Exception.new("Need to specify a range") if options[:range].nil?
+        raise Exception.new("Need to specify a range") if options[:range].nil? && options[:time_range].nil?
         @start = options[:range].first
         @end = options[:range].last
         @gap = options[:gap] || SECONDS_IN_DAY
+        @other = options[:other]
         super
       end
 
@@ -19,7 +20,8 @@ module Sunspot
             field: @field.indexed_name,
             start: @field.to_indexed(@start),
             end: @field.to_indexed(@end),
-            gap: @gap
+            gap: @gap,
+            other: @other
           }.merge!(init_params)
         }
       end

--- a/sunspot/lib/sunspot/util.rb
+++ b/sunspot/lib/sunspot/util.rb
@@ -190,22 +190,15 @@ module Sunspot
 
       def parse_json_facet(field_name, options, setup)
         field = setup.field(field_name)
-        if options[:time_range]
-          unless field.type.is_a?(Sunspot::Type::TimeType)
-            raise(
-              ArgumentError,
-              ':time_range can only be specified for Date or Time fields'
-            )
-          end
-          Sunspot::Query::DateFieldJsonFacet.new(field, options, setup)
-        elsif options[:range]
+        if options[:range] || options[:time_range]
           unless [Sunspot::Type::TimeType, Sunspot::Type::FloatType, Sunspot::Type::IntegerType ].find{|type| field.type.is_a?(type)}
             raise(
               ArgumentError,
-              ':range can only be specified for date or numeric fields'
+              ':range can only be specified for date, time, or numeric fields'
             )
           end
-          Sunspot::Query::RangeJsonFacet.new(field, options, setup)
+          facet_klass = field.type.is_a?(Sunspot::Type::TimeType) ? Sunspot::Query::DateFieldJsonFacet : Sunspot::Query::RangeJsonFacet
+          facet_klass.new(field, options, setup)
         else
           Sunspot::Query::FieldJsonFacet.new(field, options, setup)
         end

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -84,7 +84,7 @@ describe 'search faceting' do
       end
       expect(search.facet(:title).rows.map { |row| row.value }).to include('zero')
     end
-    
+
     it 'should return facet rows from an offset' do
       search = Sunspot.search(Post) do
         facet :title, :offset => 3
@@ -214,6 +214,15 @@ describe 'search faceting' do
       expect(search.facet(:title).rows.map { |row| row.value }).to eq(%w(four three two one))
     end
 
+    it 'should include allBuckets and missing' do
+      search = Sunspot.search(Post) do
+        with :blog_id, 1
+        json_facet :title, all_buckets: true, missing: true
+      end
+      expect(search.facet(:title).other_count('allBuckets')).to eq(10)
+      expect(search.facet(:title).other_count('missing')).to eq(1)
+    end
+
     it 'should limit facet values by prefix' do
       search = Sunspot.search(Post) do
         with :blog_id, 1
@@ -221,7 +230,49 @@ describe 'search faceting' do
       end
       expect(search.facet(:title).rows.map { |row| row.value }.sort).to eq(%w(three two))
     end
+  end
 
+  context 'date or time json facet' do
+    before :all do
+      Sunspot.remove_all
+      posts = [
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 8, 20)),
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 7, 20)),
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 6, 20)),
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 6, 15)),
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 5, 20)),
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 4, 20)),
+        Post.new(title: 'dt test', blog_id: 1, published_at: Time.new(2020, 3, 20))
+      ]
+      posts.each { |p| Sunspot.index(p) }
+      Sunspot.commit
+    end
+
+    it 'should use custom gap parameters if provided' do
+      time_range = [Time.new(2020, 4, 1), Time.now]
+      search = Sunspot.search(Post) do
+        with :blog_id, 1
+        json_facet :published_at, range: time_range, gap: 1, gap_unit: 'MONTHS'
+      end
+      expected_rows = [
+        { count: 1, value: Time.new(2020, 4, 1).utc.iso8601 },
+        { count: 1, value: Time.new(2020, 5, 1).utc.iso8601 },
+        { count: 2, value: Time.new(2020, 6, 1).utc.iso8601 },
+        { count: 1, value: Time.new(2020, 7, 1).utc.iso8601 }
+      ]
+      expect(search.facet(:published_at).rows.map { |row| { count: row.count, value: row.value } }).to eq(expected_rows)
+    end
+
+    it 'should support computing other statistics' do
+      time_range = [Time.new(2020, 5, 1), Time.new(2020, 7, 1)]
+      search = Sunspot.search(Post) do
+        with :blog_id, 1
+        json_facet :published_at, range: time_range, gap: 1, gap_unit: 'MONTHS', other: 'all'
+      end
+      expect(search.facet(:published_at).other_count('before')).to eq(2)
+      expect(search.facet(:published_at).other_count('after')).to eq(2)
+      expect(search.facet(:published_at).other_count('between')).to eq(3)
+    end
   end
 
   context 'nested json facet' do
@@ -237,7 +288,7 @@ describe 'search faceting' do
       end
 
       0.upto(9) { |i| Sunspot.index(Post.new(:title => 'zero', :author_name => "another#{i}", :blog_id => 1)) }
-      
+
       Sunspot.commit
     end
 
@@ -459,38 +510,6 @@ describe 'search faceting' do
       expect(search.facet(:published_at).rows.last.value).to eq((time + 60*60*24)..(time + 60*60*24*2))
       expect(search.facet(:published_at).rows.last.count).to eq(1)
     end
-
-    it 'json facet should return time ranges' do
-      days_diff = 15
-      time_from = Time.utc(2009, 7, 8)
-      time_to = Time.utc(2009, 7, 8 + days_diff)
-      search = Sunspot.search(Post) do
-        json_facet(
-            :published_at,
-            :time_range => time_from..time_to
-        )
-      end
-
-      expect(search.facet(:published_at).rows.size).to eq(days_diff)
-      expect(search.facet(:published_at).rows[0].count).to eq(2)
-      expect(search.facet(:published_at).rows[1].count).to eq(1)
-    end
-
-    it 'json facet should return time ranges with custom gap' do
-      days_diff = 10
-      time_from = Time.utc(2009, 7, 8)
-      time_to = Time.utc(2009, 7, 8 + days_diff)
-      search = Sunspot.search(Post) do
-        json_facet(
-            :published_at,
-            :time_range => time_from..time_to,
-            gap: 60*60*24*2
-        )
-      end
-      expect(search.facet(:published_at).rows.size).to eq(days_diff / 2)
-      expect(search.facet(:published_at).rows[0].count).to eq(3)
-    end
-
   end
 
   context 'class facets' do


### PR DESCRIPTION
Followup to #984. I addressed some duplication in `DateFieldJsonFacet`/`RangeJsonFacet` but it's not fully backwards compatible with the old naming of the `time_range` param. This ensures `range` always gets set properly.