### PR TITLE
JSONRangeFacet parameter naming issue

### DIFF
--- a/sunspot/lib/sunspot/query/range_json_facet.rb
+++ b/sunspot/lib/sunspot/query/range_json_facet.rb
@@ -5,6 +5,7 @@ module Sunspot
       SECONDS_IN_DAY = 86400
 
       def initialize(field, options, setup)
+        options[:range] ||= options[:time_range]
         raise Exception.new("Need to specify a range") if options[:range].nil? && options[:time_range].nil?
         @start = options[:range].first
         @end = options[:range].last

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -248,6 +248,21 @@ describe 'search faceting' do
       Sunspot.commit
     end
 
+    it 'facets properly with the range specified as time_range' do
+      time_range = [Time.new(2020, 4, 1), Time.now]
+      search = Sunspot.search(Post) do
+        with :blog_id, 1
+        json_facet :published_at, time_range: time_range, gap: 1, gap_unit: 'MONTHS'
+      end
+      expected_rows = [
+        { count: 1, value: Time.new(2020, 4, 1).utc.iso8601 },
+        { count: 1, value: Time.new(2020, 5, 1).utc.iso8601 },
+        { count: 2, value: Time.new(2020, 6, 1).utc.iso8601 },
+        { count: 1, value: Time.new(2020, 7, 1).utc.iso8601 }
+      ]
+      expect(search.facet(:published_at).rows.map { |row| { count: row.count, value: row.value } }).to eq(expected_rows)
+    end
+
     it 'should use custom gap parameters if provided' do
       time_range = [Time.new(2020, 4, 1), Time.now]
       search = Sunspot.search(Post) do


### PR DESCRIPTION
Followup to #984. I addressed some duplication in `DateFieldJsonFacet`/`RangeJsonFacet` but it's not fully backwards compatible with the old naming of the `time_range` param. This ensures `range` always gets set properly.