### PR TITLE
Fix flaky time_range tests

### DIFF
--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -249,7 +249,7 @@ describe 'search faceting' do
     end
 
     it 'facets properly with the range specified as time_range' do
-      time_range = [Time.new(2020, 4, 1), Time.now]
+      time_range = [Time.new(2020, 4, 1), Time.new(2020, 7, 31)]
       search = Sunspot.search(Post) do
         with :blog_id, 1
         json_facet :published_at, time_range: time_range, gap: 1, gap_unit: 'MONTHS'
@@ -264,7 +264,7 @@ describe 'search faceting' do
     end
 
     it 'should use custom gap parameters if provided' do
-      time_range = [Time.new(2020, 4, 1), Time.now]
+      time_range = [Time.new(2020, 4, 1), Time.new(2020, 7, 31)]
       search = Sunspot.search(Post) do
         with :blog_id, 1
         json_facet :published_at, range: time_range, gap: 1, gap_unit: 'MONTHS'


### PR DESCRIPTION
I have the PR #972 pending from review since March. When I rebased it on master, to keep it up to date and ping someone to review it, the Travis CI has started to fail due to a flaky test introduced on master since them.

This PR fixes them, so you can merge this independently of the other PR. I'll rebase again the other PR when this gets merged.

Thanks!

Failing example on [Travis CI](https://travis-ci.org/github/sunspot/sunspot/jobs/727985442#L2021)
<details>
<summary>Click to expand!</summary>

```
Failures:

  1) search faceting date or time json facet facets properly with the range specified as time_range
     Failure/Error: expect(search.facet(:published_at).rows.map { |row| { count: row.count, value: row.value } }).to eq(expected_rows)
     
       expected: [{:count=>1, :value=>"2020-04-01T00:00:00Z"}, {:count=>1, :value=>"2020-05-01T00:00:00Z"}, {:count=>2, :value=>"2020-06-01T00:00:00Z"}, {:count=>1, :value=>"2020-07-01T00:00:00Z"}]
            got: [{:count=>1, :value=>"2020-04-01T00:00:00Z"}, {:count=>1, :value=>"2020-05-01T00:00:00Z"}, {:count=>2...:00:00Z"}, {:count=>1, :value=>"2020-08-01T00:00:00Z"}, {:count=>0, :value=>"2020-09-01T00:00:00Z"}]
    
       (compared using ==)

       Diff:
       @@ -1,5 +1,7 @@
        [{:count=>1, :value=>"2020-04-01T00:00:00Z"},
         {:count=>1, :value=>"2020-05-01T00:00:00Z"},
         {:count=>2, :value=>"2020-06-01T00:00:00Z"},
       - {:count=>1, :value=>"2020-07-01T00:00:00Z"}]
       + {:count=>1, :value=>"2020-07-01T00:00:00Z"},
       + {:count=>1, :value=>"2020-08-01T00:00:00Z"},
       + {:count=>0, :value=>"2020-09-01T00:00:00Z"}]

     # ./spec/integration/faceting_spec.rb:263:in `block (3 levels) in <top (required)>'

  2) search faceting date or time json facet should use custom gap parameters if provided
     Failure/Error: expect(search.facet(:published_at).rows.map { |row| { count: row.count, value: row.value } }).to eq(expected_rows)

       expected: [{:count=>1, :value=>"2020-04-01T00:00:00Z"}, {:count=>1, :value=>"2020-05-01T00:00:00Z"}, {:count=>2, :value=>"2020-06-01T00:00:00Z"}, {:count=>1, :value=>"2020-07-01T00:00:00Z"}]
            got: [{:count=>1, :value=>"2020-04-01T00:00:00Z"}, {:count=>1, :value=>"2020-05-01T00:00:00Z"}, {:count=>2...:00:00Z"}, {:count=>1, :value=>"2020-08-01T00:00:00Z"}, {:count=>0, :value=>"2020-09-01T00:00:00Z"}]

       (compared using ==)

       Diff:
       @@ -1,5 +1,7 @@
        [{:count=>1, :value=>"2020-04-01T00:00:00Z"},
         {:count=>1, :value=>"2020-05-01T00:00:00Z"},
         {:count=>2, :value=>"2020-06-01T00:00:00Z"},
       - {:count=>1, :value=>"2020-07-01T00:00:00Z"}]
       + {:count=>1, :value=>"2020-07-01T00:00:00Z"},
       + {:count=>1, :value=>"2020-08-01T00:00:00Z"},
       + {:count=>0, :value=>"2020-09-01T00:00:00Z"}]

     # ./spec/integration/faceting_spec.rb:278:in `block (3 levels) in <top (required)>'
```
</details>