### PR TITLE
Adding correct link for readme resource under Tutorials and Articles section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1692,7 +1692,7 @@ $ yardoc -o docs */lib/**/*.rb - README.md
 
 ## Tutorials and Articles
 
-* [Using Sunspot, Websolr, and Solr on Heroku](http://mrdanadams.com/2012/sunspot-websolr-solr-heroku/) (mrdanadams)
+* [Using Sunspot, Websolr, and Solr on Heroku](https://gist.github.com/mrdanadams/2230763/) (mrdanadams)
 * [Full Text Searching with Solr and Sunspot](http://collectiveidea.com/blog/archives/2011/03/08/full-text-searching-with-solr-and-sunspot/) (Collective Idea)
 * [Full-text search in Rails with Sunspot](http://tech.favoritemedium.com/2010/01/full-text-search-in-rails-with-sunspot.html) (Tropical Software Observations)
 * [Sunspot: A Solr-Powered Search Engine for Ruby](http://www.linux-mag.com/id/7341) (Linux Magazine)


### PR DESCRIPTION
The first link under Tutorials and Articles in ReadMe is "Using Sunspot, Websolr, and Solr on Heroku" which takes us to a website whose domain has expired. Looked on the internet for the relevant resource and found gist with the same name "Using Sunspot, Websolr, and Solr on Heroku" by the same person. 

Thus have changed the non-working link to the gist which seems to be relevant and proves to be a genuine resource for sunspot. 