### PR TITLE
Solr 8(.6) based update - do not merge yet

### DIFF
--- a/examples/solr_8/conf/managed-schema
+++ b/examples/solr_8/conf/managed-schema
@@ -1,0 +1,1031 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+
+ This example schema is the recommended starting point for users.
+ It should be kept correct and concise, usable out-of-the-box.
+
+
+ For more information, on how to customize this file, please see
+ http://lucene.apache.org/solr/guide/documents-fields-and-schema-design.html
+
+ PERFORMANCE NOTE: this schema includes many optional features and should not
+ be used for benchmarking.  To improve performance one could
+  - set stored="false" for all fields possible (esp large fields) when you
+    only need to search on the field but don't need to return the original
+    value.
+  - set indexed="false" if you don't need to search on the field, but only
+    return the field as a result of searching on other indexed fields.
+  - remove all unneeded copyField statements
+  - for best index size and searching performance, set "index" to false
+    for all general text fields, use copyField to copy them to the
+    catchall "text" field, and use that for searching.
+-->
+
+<schema name="default-config" version="1.6">
+    <!-- attribute "name" is the name of this schema and is only used for display purposes.
+       version="x.y" is Solr's version number for the schema syntax and 
+       semantics.  It should not normally be changed by applications.
+
+       1.0: multiValued attribute did not exist, all fields are multiValued 
+            by nature
+       1.1: multiValued attribute introduced, false by default 
+       1.2: omitTermFreqAndPositions attribute introduced, true by default 
+            except for text fields.
+       1.3: removed optional field compress feature
+       1.4: autoGeneratePhraseQueries attribute introduced to drive QueryParser
+            behavior when a single string produces multiple tokens.  Defaults 
+            to off for version >= 1.4
+       1.5: omitNorms defaults to true for primitive field types 
+            (int, float, boolean, string...)
+       1.6: useDocValuesAsStored defaults to true.
+    -->
+
+    <!-- Valid attributes for fields:
+     name: mandatory - the name for the field
+     type: mandatory - the name of a field type from the 
+       fieldTypes section
+     indexed: true if this field should be indexed (searchable or sortable)
+     stored: true if this field should be retrievable
+     docValues: true if this field should have doc values. Doc Values is
+       recommended (required, if you are using *Point fields) for faceting,
+       grouping, sorting and function queries. Doc Values will make the index
+       faster to load, more NRT-friendly and more memory-efficient. 
+       They are currently only supported by StrField, UUIDField, all 
+       *PointFields, and depending on the field type, they might require
+       the field to be single-valued, be required or have a default value
+       (check the documentation of the field type you're interested in for
+       more information)
+     multiValued: true if this field may contain multiple values per document
+     omitNorms: (expert) set to true to omit the norms associated with
+       this field (this disables length normalization and index-time
+       boosting for the field, and saves some memory).  Only full-text
+       fields or fields that need an index-time boost need norms.
+       Norms are omitted for primitive (non-analyzed) types by default.
+     termVectors: [false] set to true to store the term vector for a
+       given field.
+       When using MoreLikeThis, fields used for similarity should be
+       stored for best performance.
+     termPositions: Store position information with the term vector.  
+       This will increase storage costs.
+     termOffsets: Store offset information with the term vector. This 
+       will increase storage costs.
+     required: The field is required.  It will throw an error if the
+       value does not exist
+     default: a value that should be used if no value is specified
+       when adding a document.
+    -->
+
+    <!-- field names should consist of alphanumeric or underscore characters only and
+      not start with a digit.  This is not currently strictly enforced,
+      but other field names will not have first class support from all components
+      and back compatibility is not guaranteed.  Names with both leading and
+      trailing underscores (e.g. _version_) are reserved.
+    -->
+
+    <!-- In this _default configset, only four fields are pre-declared:
+         id, _version_, and _text_ and _root_. All other fields will be type guessed and added via the
+         "add-unknown-fields-to-the-schema" update request processor chain declared in solrconfig.xml.
+         
+         Note that many dynamic fields are also defined - you can use them to specify a 
+         field's type via field naming conventions - see below.
+  
+         WARNING: The _text_ catch-all field will significantly increase your index size.
+         If you don't need it, consider removing it and the corresponding copyField directive.
+    -->
+
+    <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
+    <!-- docValues are enabled by default for long type so we don't need to index the version field  -->
+    <field name="_version_" type="plong" indexed="false" stored="false"/>
+
+    <!-- If you don't use child/nested documents, then you should remove the next two fields:  -->
+    <!-- for nested documents (minimal; points to root document) -->
+    <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
+    <!-- for nested documents (relationship tracking) -->
+    <field name="_nest_path_" type="_nest_path_" /><fieldType name="_nest_path_" class="solr.NestPathField" />
+
+    <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
+
+    <!-- This can be enabled, in case the client does not know what fields may be searched. It isn't enabled by default
+         because it's very expensive to index everything twice. -->
+    <!-- <copyField source="*" dest="_text_"/> -->
+
+    <!-- Dynamic field definitions allow using convention over configuration
+       for fields via the specification of patterns to match field names.
+       EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
+       RESTRICTION: the glob-like pattern in the name attribute must have a "*" only at the start or the end.  -->
+   
+    <dynamicField name="*_i"  type="pint"    indexed="true"  stored="true"/>
+    <dynamicField name="*_is" type="pints"    indexed="true"  stored="true"/>
+    <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
+    <dynamicField name="*_ss" type="strings"  indexed="true"  stored="true"/>
+    <dynamicField name="*_l"  type="plong"   indexed="true"  stored="true"/>
+    <dynamicField name="*_ls" type="plongs"   indexed="true"  stored="true"/>
+    <dynamicField name="*_t" type="text_general" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_txt" type="text_general" indexed="true" stored="true"/>
+    <dynamicField name="*_b"  type="boolean" indexed="true" stored="true"/>
+    <dynamicField name="*_bs" type="booleans" indexed="true" stored="true"/>
+    <dynamicField name="*_f"  type="pfloat"  indexed="true"  stored="true"/>
+    <dynamicField name="*_fs" type="pfloats"  indexed="true"  stored="true"/>
+    <dynamicField name="*_d"  type="pdouble" indexed="true"  stored="true"/>
+    <dynamicField name="*_ds" type="pdoubles" indexed="true"  stored="true"/>
+    <dynamicField name="random_*" type="random"/>
+    <dynamicField name="ignored_*" type="ignored"/>
+
+    <!-- Type used for data-driven schema, to add a string copy for each text field -->
+    <dynamicField name="*_str" type="strings" stored="false" docValues="true" indexed="false" useDocValuesAsStored="false"/>
+
+    <dynamicField name="*_dt"  type="pdate"    indexed="true"  stored="true"/>
+    <dynamicField name="*_dts" type="pdate"    indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_p"  type="location" indexed="true" stored="true"/>
+    <dynamicField name="*_srpt"  type="location_rpt" indexed="true" stored="true"/>
+
+    <!-- payloaded dynamic fields -->
+    <dynamicField name="*_dpf" type="delimited_payloads_float" indexed="true"  stored="true"/>
+    <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
+    <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
+
+    <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
+
+    <!-- Field to use to determine and enforce document uniqueness.
+      Unless this field is marked with required="false", it will be a required field
+    -->
+    <uniqueKey>id</uniqueKey>
+
+    <!-- copyField commands copy one field to another at the time a document
+       is added to the index.  It's used either to index the same field differently,
+       or to add multiple fields to the same field for easier/faster searching.
+
+    <copyField source="sourceFieldName" dest="destinationFieldName"/>
+    -->
+
+    <!-- field type definitions. The "name" attribute is
+       just a label to be used by field definitions.  The "class"
+       attribute and any other attributes determine the real
+       behavior of the fieldType.
+         Class names starting with "solr" refer to java classes in a
+       standard package such as org.apache.solr.analysis
+    -->
+
+    <!-- sortMissingLast and sortMissingFirst attributes are optional attributes are
+         currently supported on types that are sorted internally as strings
+         and on numeric types.
+       This includes "string", "boolean", "pint", "pfloat", "plong", "pdate", "pdouble".
+       - If sortMissingLast="true", then a sort on this field will cause documents
+         without the field to come after documents with the field,
+         regardless of the requested sort order (asc or desc).
+       - If sortMissingFirst="true", then a sort on this field will cause documents
+         without the field to come before documents with the field,
+         regardless of the requested sort order.
+       - If sortMissingLast="false" and sortMissingFirst="false" (the default),
+         then default lucene sorting will be used which places docs without the
+         field first in an ascending sort and last in a descending sort.
+    -->
+
+    <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
+    <fieldType name="strings" class="solr.StrField" sortMissingLast="true" multiValued="true" docValues="true" />
+
+    <!-- boolean type: "true" or "false" -->
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
+
+    <!--
+      Numeric field types that index values using KD-trees.
+      Point fields don't support FieldCache, so they must have docValues="true" if needed for sorting, faceting, functions, etc.
+    -->
+    <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+
+    <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
+    <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
+    <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
+    <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
+    <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
+
+    <!-- since fields of this type are by default not stored or indexed,
+       any data added to them will be ignored outright.  -->
+    <fieldType name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
+
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
+         is a more restricted form of the canonical representation of dateTime
+         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         The trailing "Z" designates UTC time and is mandatory.
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
+         All other components are mandatory.
+
+         Expressions can also be used to denote calculations that should be
+         performed relative to "NOW" to determine the value, ie...
+
+               NOW/HOUR
+                  ... Round to the start of the current hour
+               NOW-1DAY
+                  ... Exactly 1 day prior to now
+               NOW/DAY+6MONTHS+3DAYS
+                  ... 6 months and 3 days in the future from the start of
+                      the current day
+                      
+      -->
+    <!-- KD-tree versions of date fields -->
+    <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+    <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
+    
+    <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
+    <fieldType name="binary" class="solr.BinaryField"/>
+    
+    <!-- 
+    RankFields can be used to store scoring factors to improve document ranking. They should be used
+    in combination with RankQParserPlugin.
+    (experimental)
+    --> 
+    <fieldType name="rank" class="solr.RankField"/>
+
+    <!-- solr.TextField allows the specification of custom text analyzers
+         specified as a tokenizer and a list of token filters. Different
+         analyzers may be specified for indexing and querying.
+
+         The optional positionIncrementGap puts space between multiple fields of
+         this type on the same document, with the purpose of preventing false phrase
+         matching across fields.
+
+         For more info on customizing your analyzer chain, please see
+         http://lucene.apache.org/solr/guide/understanding-analyzers-tokenizers-and-filters.html#understanding-analyzers-tokenizers-and-filters
+     -->
+
+    <!-- One can also specify an existing Analyzer class that has a
+         default constructor via the class attribute on the analyzer element.
+         Example:
+    <fieldType name="text_greek" class="solr.TextField">
+      <analyzer class="org.apache.lucene.analysis.el.GreekAnalyzer"/>
+    </fieldType>
+    -->
+
+    <!-- A text field that only splits on whitespace for exact matching of words -->
+    <dynamicField name="*_ws" type="text_ws"  indexed="true"  stored="true"/>
+    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A general text field that has reasonable, generic
+         cross-language defaults: it tokenizes with StandardTokenizer,
+	       removes stop words from case-insensitive "stopwords.txt"
+	       (empty by default), and down cases.  At query time only, it
+	       also applies synonyms.
+	  -->
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+        -->
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    
+    <!-- SortableTextField generaly functions exactly like TextField,
+         except that it supports, and by default uses, docValues for sorting (or faceting)
+         on the first 1024 characters of the original field values (which is configurable).
+         
+         This makes it a bit more useful then TextField in many situations, but the trade-off
+         is that it takes up more space on disk; which is why it's not used in place of TextField
+         for every fieldType in this _default schema.
+	  -->
+    <dynamicField name="*_t_sort" type="text_gen_sort" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_txt_sort" type="text_gen_sort" indexed="true" stored="true"/>
+    <fieldType name="text_gen_sort" class="solr.SortableTextField" positionIncrementGap="100" multiValued="true">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A text field with defaults appropriate for English: it tokenizes with StandardTokenizer,
+         removes English stop words (lang/stopwords_en.txt), down cases, protects words from protwords.txt, and
+         finally applies Porter's stemming.  The query time analyzer also applies synonyms from synonyms.txt. -->
+    <dynamicField name="*_txt_en" type="text_en"  indexed="true"  stored="true"/>
+    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+        -->
+        <!-- Case insensitive stop word removal.
+        -->
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+            />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+	      -->
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+        />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+	      -->
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A text field with defaults appropriate for English, plus
+         aggressive word-splitting and autophrase features enabled.
+         This field is just like text_en, except it adds
+         WordDelimiterGraphFilter to enable splitting and matching of
+         words on case-change, alpha numeric boundaries, and
+         non-alphanumeric chars.  This means certain compound word
+         cases will work, for example query "wi fi" will match
+         document "WiFi" or "wi-fi".
+    -->
+    <dynamicField name="*_txt_en_split" type="text_en_splitting"  indexed="true"  stored="true"/>
+    <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        -->
+        <!-- Case insensitive stop word removal.
+        -->
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+        />
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+        />
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
+         but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->
+    <dynamicField name="*_txt_en_split_tight" type="text_en_splitting_tight"  indexed="true"  stored="true"/>
+    <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
+             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
+             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Just like text_general except it reverses the characters of
+	       each token, to enable more efficient leading wildcard queries.
+    -->
+    <dynamicField name="*_txt_rev" type="text_general_rev"  indexed="true"  stored="true"/>
+    <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
+                maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <dynamicField name="*_phon_en" type="phonetic_en"  indexed="true"  stored="true"/>
+    <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- lowercases the entire field value, keeping it as a single token.  -->
+    <dynamicField name="*_s_lower" type="lowercase"  indexed="true"  stored="true"/>
+    <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- 
+      Example of using PathHierarchyTokenizerFactory at index time, so
+      queries for paths match documents at that path, or in descendent paths
+    -->
+    <dynamicField name="*_descendent_path" type="descendent_path"  indexed="true"  stored="true"/>
+    <fieldType name="descendent_path" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!--
+      Example of using PathHierarchyTokenizerFactory at query time, so
+      queries for paths match documents at that path, or in ancestor paths
+    -->
+    <dynamicField name="*_ancestor_path" type="ancestor_path"  indexed="true"  stored="true"/>
+    <fieldType name="ancestor_path" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+      </analyzer>
+    </fieldType>
+
+    <!-- This point type indexes the coordinates as separate fields (subFields)
+      If subFieldType is defined, it references a type, and a dynamic field
+      definition is created matching *___<typename>.  Alternately, if 
+      subFieldSuffix is defined, that is used to create the subFields.
+      Example: if subFieldType="double", then the coordinates would be
+        indexed in fields myloc_0___double,myloc_1___double.
+      Example: if subFieldSuffix="_d" then the coordinates would be indexed
+        in fields myloc_0_d,myloc_1_d
+      The subFields are an implementation detail of the fieldType, and end
+      users normally should not need to know about them.
+     -->
+    <dynamicField name="*_point" type="point"  indexed="true"  stored="true"/>
+    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+
+    <!-- A specialized field for geospatial search filters and distance sorting. -->
+    <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
+
+    <!-- A geospatial field type that supports multiValued and polygon shapes.
+      For more information about this and other spatial fields see:
+      http://lucene.apache.org/solr/guide/spatial-search.html
+    -->
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+               geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers" />
+
+    <!-- Payloaded field types -->
+    <fieldType name="delimited_payloads_float" stored="false" indexed="true" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
+      </analyzer>
+    </fieldType>
+    <fieldType name="delimited_payloads_int" stored="false" indexed="true" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="integer"/>
+      </analyzer>
+    </fieldType>
+    <fieldType name="delimited_payloads_string" stored="false" indexed="true" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="identity"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- some examples for different languages (generally ordered by ISO code) -->
+
+    <!-- Arabic -->
+    <dynamicField name="*_txt_ar" type="text_ar"  indexed="true"  stored="true"/>
+    <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- for any non-arabic -->
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ar.txt" />
+        <!-- normalizes ﻯ to ﻱ, etc -->
+        <filter class="solr.ArabicNormalizationFilterFactory"/>
+        <filter class="solr.ArabicStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Bulgarian -->
+    <dynamicField name="*_txt_bg" type="text_bg"  indexed="true"  stored="true"/>
+    <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/> 
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" /> 
+        <filter class="solr.BulgarianStemFilterFactory"/>       
+      </analyzer>
+    </fieldType>
+    
+    <!-- Catalan -->
+    <dynamicField name="*_txt_ca" type="text_ca"  indexed="true"  stored="true"/>
+    <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- removes l', etc -->
+        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>       
+      </analyzer>
+    </fieldType>
+    
+    <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
+    <dynamicField name="*_txt_cjk" type="text_cjk"  indexed="true"  stored="true"/>
+    <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- normalize width before bigram, as e.g. half-width dakuten combine  -->
+        <filter class="solr.CJKWidthFilterFactory"/>
+        <!-- for any non-CJK -->
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.CJKBigramFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Czech -->
+    <dynamicField name="*_txt_cz" type="text_cz"  indexed="true"  stored="true"/>
+    <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
+        <filter class="solr.CzechStemFilterFactory"/>       
+      </analyzer>
+    </fieldType>
+    
+    <!-- Danish -->
+    <dynamicField name="*_txt_da" type="text_da"  indexed="true"  stored="true"/>
+    <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>       
+      </analyzer>
+    </fieldType>
+    
+    <!-- German -->
+    <dynamicField name="*_txt_de" type="text_de"  indexed="true"  stored="true"/>
+    <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
+        <filter class="solr.GermanNormalizationFilterFactory"/>
+        <filter class="solr.GermanLightStemFilterFactory"/>
+        <!-- less aggressive: <filter class="solr.GermanMinimalStemFilterFactory"/> -->
+        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Greek -->
+    <dynamicField name="*_txt_el" type="text_el"  indexed="true"  stored="true"/>
+    <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- greek specific lowercase for sigma -->
+        <filter class="solr.GreekLowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_el.txt" />
+        <filter class="solr.GreekStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Spanish -->
+    <dynamicField name="*_txt_es" type="text_es"  indexed="true"  stored="true"/>
+    <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
+        <filter class="solr.SpanishLightStemFilterFactory"/>
+        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
+      </analyzer>
+    </fieldType>
+
+    <!-- Estonian -->
+    <dynamicField name="*_txt_et" type="text_et"  indexed="true"  stored="true"/>
+    <fieldType name="text_et" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_et.txt" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Estonian"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Basque -->
+    <dynamicField name="*_txt_eu" type="text_eu"  indexed="true"  stored="true"/>
+    <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Persian -->
+    <dynamicField name="*_txt_fa" type="text_fa"  indexed="true"  stored="true"/>
+    <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <!-- for ZWNJ -->
+        <charFilter class="solr.PersianCharFilterFactory"/>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ArabicNormalizationFilterFactory"/>
+        <filter class="solr.PersianNormalizationFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
+      </analyzer>
+    </fieldType>
+    
+    <!-- Finnish -->
+    <dynamicField name="*_txt_fi" type="text_fi"  indexed="true"  stored="true"/>
+    <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Finnish"/>
+        <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- French -->
+    <dynamicField name="*_txt_fr" type="text_fr"  indexed="true"  stored="true"/>
+    <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- removes l', etc -->
+        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
+        <filter class="solr.FrenchLightStemFilterFactory"/>
+        <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
+        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Irish -->
+    <dynamicField name="*_txt_ga" type="text_ga"  indexed="true"  stored="true"/>
+    <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- removes d', etc -->
+        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
+        <!-- removes n-, etc. position increments is intentionally false! -->
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/hyphenations_ga.txt"/>
+        <filter class="solr.IrishLowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ga.txt"/>
+        <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Galician -->
+    <dynamicField name="*_txt_gl" type="text_gl"  indexed="true"  stored="true"/>
+    <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
+        <filter class="solr.GalicianStemFilterFactory"/>
+        <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Hindi -->
+    <dynamicField name="*_txt_hi" type="text_hi"  indexed="true"  stored="true"/>
+    <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <!-- normalizes unicode representation -->
+        <filter class="solr.IndicNormalizationFilterFactory"/>
+        <!-- normalizes variation in spelling -->
+        <filter class="solr.HindiNormalizationFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hi.txt" />
+        <filter class="solr.HindiStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Hungarian -->
+    <dynamicField name="*_txt_hu" type="text_hu"  indexed="true"  stored="true"/>
+    <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
+        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->   
+      </analyzer>
+    </fieldType>
+    
+    <!-- Armenian -->
+    <dynamicField name="*_txt_hy" type="text_hy"  indexed="true"  stored="true"/>
+    <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Indonesian -->
+    <dynamicField name="*_txt_id" type="text_id"  indexed="true"  stored="true"/>
+    <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
+        <!-- for a less aggressive approach (only inflectional suffixes), set stemDerivational to false -->
+        <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Italian -->
+  <dynamicField name="*_txt_it" type="text_it"  indexed="true"  stored="true"/>
+  <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- removes l', etc -->
+        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_it.txt" format="snowball" />
+        <filter class="solr.ItalianLightStemFilterFactory"/>
+        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
+
+         NOTE: If you want to optimize search for precision, use default operator AND in your request
+         handler config (q.op) Use OR if you would like to optimize for recall (default).
+    -->
+    <dynamicField name="*_txt_ja" type="text_ja"  indexed="true"  stored="true"/>
+    <fieldType name="text_ja" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="false">
+      <analyzer>
+        <!-- Kuromoji Japanese morphological analyzer/tokenizer (JapaneseTokenizer)
+
+           Kuromoji has a search mode (default) that does segmentation useful for search.  A heuristic
+           is used to segment compounds into its parts and the compound itself is kept as synonym.
+
+           Valid values for attribute mode are:
+              normal: regular segmentation
+              search: segmentation useful for search with synonyms compounds (default)
+            extended: same as search mode, but unigrams unknown words (experimental)
+
+           For some applications it might be good to use search mode for indexing and normal mode for
+           queries to reduce recall and prevent parts of compounds from being matched and highlighted.
+           Use <analyzer type="index"> and <analyzer type="query"> for this and mode normal in query.
+
+           Kuromoji also has a convenient user dictionary feature that allows overriding the statistical
+           model with your own entries for segmentation, part-of-speech tags and readings without a need
+           to specify weights.  Notice that user dictionaries have not been subject to extensive testing.
+
+           User dictionary attributes are:
+                     userDictionary: user dictionary filename
+             userDictionaryEncoding: user dictionary encoding (default is UTF-8)
+
+           See lang/userdict_ja.txt for a sample user dictionary file.
+
+           Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
+        -->
+        <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
+        <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
+        <!-- Reduces inflected verbs and adjectives to their base/dictionary forms (辞書形) -->
+        <filter class="solr.JapaneseBaseFormFilterFactory"/>
+        <!-- Removes tokens with certain part-of-speech tags -->
+        <filter class="solr.JapanesePartOfSpeechStopFilterFactory" tags="lang/stoptags_ja.txt" />
+        <!-- Normalizes full-width romaji to half-width and half-width kana to full-width (Unicode NFKC subset) -->
+        <filter class="solr.CJKWidthFilterFactory"/>
+        <!-- Removes common tokens typically not useful for search, but have a negative effect on ranking -->
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ja.txt" />
+        <!-- Normalizes common katakana spelling variations by removing any last long sound character (U+30FC) -->
+        <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4"/>
+        <!-- Lower-cases romaji characters -->
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Korean morphological analysis -->
+    <dynamicField name="*_txt_ko" type="text_ko"  indexed="true"  stored="true"/>
+    <fieldType name="text_ko" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <!-- Nori Korean morphological analyzer/tokenizer (KoreanTokenizer)
+          The Korean (nori) analyzer integrates Lucene nori analysis module into Solr.
+          It uses the mecab-ko-dic dictionary to perform morphological analysis of Korean texts.
+
+          This dictionary was built with MeCab, it defines a format for the features adapted
+          for the Korean language.
+          
+          Nori also has a convenient user dictionary feature that allows overriding the statistical
+          model with your own entries for segmentation, part-of-speech tags and readings without a need
+          to specify weights. Notice that user dictionaries have not been subject to extensive testing.
+
+          The tokenizer supports multiple schema attributes:
+            * userDictionary: User dictionary path.
+            * userDictionaryEncoding: User dictionary encoding.
+            * decompoundMode: Decompound mode. Either 'none', 'discard', 'mixed'. Default is 'discard'.
+            * outputUnknownUnigrams: If true outputs unigrams for unknown words.
+        -->
+        <tokenizer class="solr.KoreanTokenizerFactory" decompoundMode="discard" outputUnknownUnigrams="false"/>
+        <!-- Removes some part of speech stuff like EOMI (Pos.E), you can add a parameter 'tags',
+          listing the tags to remove. By default it removes: 
+          E, IC, J, MAG, MAJ, MM, SP, SSC, SSO, SC, SE, XPN, XSA, XSN, XSV, UNA, NA, VSV
+          This is basically an equivalent to stemming.
+        -->
+        <filter class="solr.KoreanPartOfSpeechStopFilterFactory" />
+        <!-- Replaces term text with the Hangul transcription of Hanja characters, if applicable: -->
+        <filter class="solr.KoreanReadingFormFilterFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- Latvian -->
+    <dynamicField name="*_txt_lv" type="text_lv"  indexed="true"  stored="true"/>
+    <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
+        <filter class="solr.LatvianStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Dutch -->
+    <dynamicField name="*_txt_nl" type="text_nl"  indexed="true"  stored="true"/>
+    <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
+        <filter class="solr.StemmerOverrideFilterFactory" dictionary="lang/stemdict_nl.txt" ignoreCase="false"/>
+        <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Norwegian -->
+    <dynamicField name="*_txt_no" type="text_no"  indexed="true"  stored="true"/>
+    <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Norwegian"/>
+        <!-- less aggressive: <filter class="solr.NorwegianLightStemFilterFactory"/> -->
+        <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Portuguese -->
+  <dynamicField name="*_txt_pt" type="text_pt"  indexed="true"  stored="true"/>
+  <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
+        <filter class="solr.PortugueseLightStemFilterFactory"/>
+        <!-- less aggressive: <filter class="solr.PortugueseMinimalStemFilterFactory"/> -->
+        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Portuguese"/> -->
+        <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Romanian -->
+    <dynamicField name="*_txt_ro" type="text_ro"  indexed="true"  stored="true"/>
+    <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
+      </analyzer>
+    </fieldType>
+    
+    <!-- Russian -->
+    <dynamicField name="*_txt_ru" type="text_ru"  indexed="true"  stored="true"/>
+    <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Russian"/>
+        <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Swedish -->
+    <dynamicField name="*_txt_sv" type="text_sv"  indexed="true"  stored="true"/>
+    <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Swedish"/>
+        <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
+      </analyzer>
+    </fieldType>
+    
+    <!-- Thai -->
+    <dynamicField name="*_txt_th" type="text_th"  indexed="true"  stored="true"/>
+    <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.ThaiTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
+      </analyzer>
+    </fieldType>
+    
+    <!-- Turkish -->
+    <dynamicField name="*_txt_tr" type="text_tr"  indexed="true"  stored="true"/>
+    <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
+      <analyzer> 
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.TurkishLowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
+        <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Similarity is the scoring routine for each document vs. a query.
+       A custom Similarity or SimilarityFactory may be specified here, but 
+       the default is fine for most applications.  
+       For more info: http://lucene.apache.org/solr/guide/other-schema-elements.html#OtherSchemaElements-Similarity
+    -->
+    <!--
+     <similarity class="com.example.solr.CustomSimilarityFactory">
+       <str name="paramkey">param value</str>
+     </similarity>
+    -->
+
+</schema>

--- a/examples/solr_8/conf/managed-schema
+++ b/examples/solr_8/conf/managed-schema
@@ -153,10 +153,10 @@
     <dynamicField name="*_drs" type="rdate" indexed="true" stored="true" multiValued="false"/>
     <dynamicField name="*_drms" type="rdate" indexed="true" stored="true" multiValued="true"/>
 
-    <dynamicField name="*_text" type="text" indexed="true" stored="false" multiValued="true"/>
-    <dynamicField name="*_textv" type="text" indexed="true" stored="false" termVectors="true" multiValued="true"/>
-    <dynamicField name="*_texts" type="text" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="*_textsv" type="text" indexed="true" stored="true" termVectors="true" multiValued="true"/>
+    <dynamicField name="*_text" type="text" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_textv" type="text" indexed="true" stored="false" multiValued="true" termVectors="true"  omitNorms="false"/>
+    <dynamicField name="*_texts" type="text" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_textsv" type="text" indexed="true" stored="true" multiValued="true" termVectors="true"  omitNorms="false"/>
 
     <dynamicField name="*_p" type="location" indexed="true" stored="false" multiValued="false"/>
     <dynamicField name="*_pm" type="location" indexed="true" stored="false" multiValued="true"/>

--- a/examples/solr_8/conf/managed-schema
+++ b/examples/solr_8/conf/managed-schema
@@ -38,7 +38,7 @@
     catchall "text" field, and use that for searching.
 -->
 
-<schema name="default-config" version="1.6">
+<schema name="sunspot" version="1.6">
     <!-- attribute "name" is the name of this schema and is only used for display purposes.
        version="x.y" is Solr's version number for the schema syntax and 
        semantics.  It should not normally be changed by applications.
@@ -99,69 +99,95 @@
       trailing underscores (e.g. _version_) are reserved.
     -->
 
-    <!-- In this _default configset, only four fields are pre-declared:
-         id, _version_, and _text_ and _root_. All other fields will be type guessed and added via the
-         "add-unknown-fields-to-the-schema" update request processor chain declared in solrconfig.xml.
-         
-         Note that many dynamic fields are also defined - you can use them to specify a 
-         field's type via field naming conventions - see below.
-  
-         WARNING: The _text_ catch-all field will significantly increase your index size.
-         If you don't need it, consider removing it and the corresponding copyField directive.
-    -->
-
-    <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
+    <!-- id field is implicitly marked required="true" by using it as <uniqueKey> -->
+    <field name="id" type="string" indexed="true" stored="true" multiValued="false"/>
     <!-- docValues are enabled by default for long type so we don't need to index the version field  -->
     <field name="_version_" type="plong" indexed="false" stored="false"/>
-
-    <!-- If you don't use child/nested documents, then you should remove the next two fields:  -->
-    <!-- for nested documents (minimal; points to root document) -->
-    <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
-    <!-- for nested documents (relationship tracking) -->
-    <field name="_nest_path_" type="_nest_path_" /><fieldType name="_nest_path_" class="solr.NestPathField" />
-
-    <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
-
-    <!-- This can be enabled, in case the client does not know what fields may be searched. It isn't enabled by default
-         because it's very expensive to index everything twice. -->
-    <!-- <copyField source="*" dest="_text_"/> -->
+    <field name="text" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="type" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="class_name" type="string" indexed="true" stored="false" multiValued="false"/>
+    <field name="textSpell" stored="false" type="textSpell" multiValued="true" indexed="true"/>
 
     <!-- Dynamic field definitions allow using convention over configuration
        for fields via the specification of patterns to match field names.
        EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
        RESTRICTION: the glob-like pattern in the name attribute must have a "*" only at the start or the end.  -->
-   
-    <dynamicField name="*_i"  type="pint"    indexed="true"  stored="true"/>
-    <dynamicField name="*_is" type="pints"    indexed="true"  stored="true"/>
-    <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
-    <dynamicField name="*_ss" type="strings"  indexed="true"  stored="true"/>
-    <dynamicField name="*_l"  type="plong"   indexed="true"  stored="true"/>
-    <dynamicField name="*_ls" type="plongs"   indexed="true"  stored="true"/>
-    <dynamicField name="*_t" type="text_general" indexed="true" stored="true" multiValued="false"/>
-    <dynamicField name="*_txt" type="text_general" indexed="true" stored="true"/>
-    <dynamicField name="*_b"  type="boolean" indexed="true" stored="true"/>
-    <dynamicField name="*_bs" type="booleans" indexed="true" stored="true"/>
-    <dynamicField name="*_f"  type="pfloat"  indexed="true"  stored="true"/>
-    <dynamicField name="*_fs" type="pfloats"  indexed="true"  stored="true"/>
-    <dynamicField name="*_d"  type="pdouble" indexed="true"  stored="true"/>
-    <dynamicField name="*_ds" type="pdoubles" indexed="true"  stored="true"/>
-    <dynamicField name="random_*" type="random"/>
+
+    <dynamicField name="*_b" type="boolean" indexed="true" stored="false" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_bm" type="boolean" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_bs" type="boolean" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_bms" type="boolean" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+
+    <dynamicField name="*_dt" type="pdate" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_dtm" type="pdate" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="*_dts" type="pdate" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_dtms" type="pdate" indexed="true" stored="true" multiValued="true"/>
+
+    <dynamicField name="*_d" type="pdouble" indexed="true" stored="false" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_dm" type="pdouble" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_ds" type="pdouble" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_dms" type="pdouble" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+
+    <dynamicField name="*_f" type="pfloat" indexed="true" stored="false" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_fm" type="pfloat" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_fs" type="pfloat" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_fms" type="pfloat" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+
+    <dynamicField name="*_i" type="pint" indexed="true" stored="false" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_im" type="pint" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_is" type="pint" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_ims" type="pint" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+
+    <dynamicField name="*_l" type="plong" indexed="true" stored="false" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_lm" type="plong" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_ls" type="plong" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_lms" type="plong" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+
+    <dynamicField name="*_s" type="string" indexed="true" stored="false" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_sm" type="string" indexed="true" stored="false" multiValued="true" omitNorms="false"/>
+    <dynamicField name="*_ss" type="string" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
+    <dynamicField name="*_sms" type="string" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
+
+    <dynamicField name="*_dr" type="rdate" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_drm" type="rdate" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="*_drs" type="rdate" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_drms" type="rdate" indexed="true" stored="true" multiValued="true"/>
+
+    <dynamicField name="*_text" type="text" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="*_textv" type="text" indexed="true" stored="false" termVectors="true" multiValued="true"/>
+    <dynamicField name="*_texts" type="text" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_textsv" type="text" indexed="true" stored="true" termVectors="true" multiValued="true"/>
+
+    <dynamicField name="*_p" type="location" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_pm" type="location" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="*_ps" type="location" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_pms" type="location" indexed="true" stored="true" multiValued="true"/>
+
+    <dynamicField name="random_*" type="random" indexed="true"/>
+<!--
     <dynamicField name="ignored_*" type="ignored"/>
+-->
 
     <!-- Type used for data-driven schema, to add a string copy for each text field -->
     <dynamicField name="*_str" type="strings" stored="false" docValues="true" indexed="false" useDocValuesAsStored="false"/>
+    <!--
+    <dynamicField name="*_c"  type="currency" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_cs" type="currency" indexed="true" stored="true" multiValued="false"/>
+    -->
 
-    <dynamicField name="*_dt"  type="pdate"    indexed="true"  stored="true"/>
-    <dynamicField name="*_dts" type="pdate"    indexed="true"  stored="true" multiValued="true"/>
-    <dynamicField name="*_p"  type="location" indexed="true" stored="true"/>
-    <dynamicField name="*_srpt"  type="location_rpt" indexed="true" stored="true"/>
+    <dynamicField name="*_uuid" type="uuid" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_uuidm" type="uuid" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="*_uuids" type="uuid" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_uuidms" type="uuid" indexed="true" stored="true" multiValued="true"/>
 
-    <!-- payloaded dynamic fields -->
+<!--
+    &lt;!&ndash; payloaded dynamic fields &ndash;&gt;
     <dynamicField name="*_dpf" type="delimited_payloads_float" indexed="true"  stored="true"/>
     <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
     <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
 
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
+-->
 
     <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field
@@ -215,8 +241,10 @@
     <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
     <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
 
+<!--
     <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
     <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
+-->
     <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
     <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
     <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
@@ -258,6 +286,14 @@
     --> 
     <fieldType name="rank" class="solr.RankField"/>
 
+    <!-- https://lucene.apache.org/solr/guide/8_6/field-types-included-with-solr.html -->
+    <fieldType name="rdate" class="solr.DateRangeField"/>
+    <fieldType name="uuid" class="solr.UUIDField" docValues="true"/>
+    <!--
+    <fieldType name="currency" class="solr.CurrencyFieldType" defaultCurrency="EUR"
+               amountLongSuffix="_l" codeStrSuffix="_s" currencyConfig="currency.xml"/>
+    -->
+
     <!-- solr.TextField allows the specification of custom text analyzers
          specified as a tokenizer and a list of token filters. Different
          analyzers may be specified for indexing and querying.
@@ -277,14 +313,6 @@
       <analyzer class="org.apache.lucene.analysis.el.GreekAnalyzer"/>
     </fieldType>
     -->
-
-    <!-- A text field that only splits on whitespace for exact matching of words -->
-    <dynamicField name="*_ws" type="text_ws"  indexed="true"  stored="true"/>
-    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      </analyzer>
-    </fieldType>
 
     <!-- A general text field that has reasonable, generic
          cross-language defaults: it tokenizes with StandardTokenizer,
@@ -310,211 +338,6 @@
       </analyzer>
     </fieldType>
 
-    
-    <!-- SortableTextField generaly functions exactly like TextField,
-         except that it supports, and by default uses, docValues for sorting (or faceting)
-         on the first 1024 characters of the original field values (which is configurable).
-         
-         This makes it a bit more useful then TextField in many situations, but the trade-off
-         is that it takes up more space on disk; which is why it's not used in place of TextField
-         for every fieldType in this _default schema.
-	  -->
-    <dynamicField name="*_t_sort" type="text_gen_sort" indexed="true" stored="true" multiValued="false"/>
-    <dynamicField name="*_txt_sort" type="text_gen_sort" indexed="true" stored="true"/>
-    <fieldType name="text_gen_sort" class="solr.SortableTextField" positionIncrementGap="100" multiValued="true">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- A text field with defaults appropriate for English: it tokenizes with StandardTokenizer,
-         removes English stop words (lang/stopwords_en.txt), down cases, protects words from protwords.txt, and
-         finally applies Porter's stemming.  The query time analyzer also applies synonyms from synonyms.txt. -->
-    <dynamicField name="*_txt_en" type="text_en"  indexed="true"  stored="true"/>
-    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.FlattenGraphFilterFactory"/>
-        -->
-        <!-- Case insensitive stop word removal.
-        -->
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-            />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-	      -->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-	      -->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- A text field with defaults appropriate for English, plus
-         aggressive word-splitting and autophrase features enabled.
-         This field is just like text_en, except it adds
-         WordDelimiterGraphFilter to enable splitting and matching of
-         words on case-change, alpha numeric boundaries, and
-         non-alphanumeric chars.  This means certain compound word
-         cases will work, for example query "wi fi" will match
-         document "WiFi" or "wi-fi".
-    -->
-    <dynamicField name="*_txt_en_split" type="text_en_splitting"  indexed="true"  stored="true"/>
-    <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal.
-        -->
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        />
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        />
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
-         but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->
-    <dynamicField name="*_txt_en_split_tight" type="text_en_splitting_tight"  indexed="true"  stored="true"/>
-    <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Just like text_general except it reverses the characters of
-	       each token, to enable more efficient leading wildcard queries.
-    -->
-    <dynamicField name="*_txt_rev" type="text_general_rev"  indexed="true"  stored="true"/>
-    <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
-                maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <dynamicField name="*_phon_en" type="phonetic_en"  indexed="true"  stored="true"/>
-    <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- lowercases the entire field value, keeping it as a single token.  -->
-    <dynamicField name="*_s_lower" type="lowercase"  indexed="true"  stored="true"/>
-    <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!-- 
-      Example of using PathHierarchyTokenizerFactory at index time, so
-      queries for paths match documents at that path, or in descendent paths
-    -->
-    <dynamicField name="*_descendent_path" type="descendent_path"  indexed="true"  stored="true"/>
-    <fieldType name="descendent_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!--
-      Example of using PathHierarchyTokenizerFactory at query time, so
-      queries for paths match documents at that path, or in ancestor paths
-    -->
-    <dynamicField name="*_ancestor_path" type="ancestor_path"  indexed="true"  stored="true"/>
-    <fieldType name="ancestor_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-    </fieldType>
-
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
       definition is created matching *___<typename>.  Alternately, if 
@@ -526,8 +349,10 @@
       The subFields are an implementation detail of the fieldType, and end
       users normally should not need to know about them.
      -->
+    <!--
     <dynamicField name="*_point" type="point"  indexed="true"  stored="true"/>
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+    -->
 
     <!-- A specialized field for geospatial search filters and distance sorting. -->
     <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
@@ -536,10 +361,13 @@
       For more information about this and other spatial fields see:
       http://lucene.apache.org/solr/guide/spatial-search.html
     -->
+    <!--
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers" />
+    -->
 
-    <!-- Payloaded field types -->
+<!--
+    &lt;!&ndash; Payloaded field types &ndash;&gt;
     <fieldType name="delimited_payloads_float" stored="false" indexed="true" class="solr.TextField">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
@@ -558,463 +386,19 @@
         <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="identity"/>
       </analyzer>
     </fieldType>
+-->
 
-    <!-- some examples for different languages (generally ordered by ISO code) -->
-
-    <!-- Arabic -->
-    <dynamicField name="*_txt_ar" type="text_ar"  indexed="true"  stored="true"/>
-    <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- for any non-arabic -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ar.txt" />
-        <!-- normalizes ﻯ to ﻱ, etc -->
-        <filter class="solr.ArabicNormalizationFilterFactory"/>
-        <filter class="solr.ArabicStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Bulgarian -->
-    <dynamicField name="*_txt_bg" type="text_bg"  indexed="true"  stored="true"/>
-    <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/> 
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" /> 
-        <filter class="solr.BulgarianStemFilterFactory"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- Catalan -->
-    <dynamicField name="*_txt_ca" type="text_ca"  indexed="true"  stored="true"/>
-    <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
-    <dynamicField name="*_txt_cjk" type="text_cjk"  indexed="true"  stored="true"/>
-    <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- normalize width before bigram, as e.g. half-width dakuten combine  -->
-        <filter class="solr.CJKWidthFilterFactory"/>
-        <!-- for any non-CJK -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.CJKBigramFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Czech -->
-    <dynamicField name="*_txt_cz" type="text_cz"  indexed="true"  stored="true"/>
-    <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
-        <filter class="solr.CzechStemFilterFactory"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- Danish -->
-    <dynamicField name="*_txt_da" type="text_da"  indexed="true"  stored="true"/>
-    <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- German -->
-    <dynamicField name="*_txt_de" type="text_de"  indexed="true"  stored="true"/>
-    <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
-        <filter class="solr.GermanNormalizationFilterFactory"/>
-        <filter class="solr.GermanLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.GermanMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Greek -->
-    <dynamicField name="*_txt_el" type="text_el"  indexed="true"  stored="true"/>
-    <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- greek specific lowercase for sigma -->
-        <filter class="solr.GreekLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_el.txt" />
-        <filter class="solr.GreekStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Spanish -->
-    <dynamicField name="*_txt_es" type="text_es"  indexed="true"  stored="true"/>
-    <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
-        <filter class="solr.SpanishLightStemFilterFactory"/>
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
-      </analyzer>
-    </fieldType>
-
-    <!-- Estonian -->
-    <dynamicField name="*_txt_et" type="text_et"  indexed="true"  stored="true"/>
-    <fieldType name="text_et" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_et.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Estonian"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Basque -->
-    <dynamicField name="*_txt_eu" type="text_eu"  indexed="true"  stored="true"/>
-    <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Persian -->
-    <dynamicField name="*_txt_fa" type="text_fa"  indexed="true"  stored="true"/>
-    <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <!-- for ZWNJ -->
-        <charFilter class="solr.PersianCharFilterFactory"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ArabicNormalizationFilterFactory"/>
-        <filter class="solr.PersianNormalizationFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
-      </analyzer>
-    </fieldType>
-    
-    <!-- Finnish -->
-    <dynamicField name="*_txt_fi" type="text_fi"  indexed="true"  stored="true"/>
-    <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Finnish"/>
-        <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- French -->
-    <dynamicField name="*_txt_fr" type="text_fr"  indexed="true"  stored="true"/>
-    <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
-        <filter class="solr.FrenchLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Irish -->
-    <dynamicField name="*_txt_ga" type="text_ga"  indexed="true"  stored="true"/>
-    <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes d', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
-        <!-- removes n-, etc. position increments is intentionally false! -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/hyphenations_ga.txt"/>
-        <filter class="solr.IrishLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ga.txt"/>
-        <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Galician -->
-    <dynamicField name="*_txt_gl" type="text_gl"  indexed="true"  stored="true"/>
-    <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
-        <filter class="solr.GalicianStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Hindi -->
-    <dynamicField name="*_txt_hi" type="text_hi"  indexed="true"  stored="true"/>
-    <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <!-- normalizes unicode representation -->
-        <filter class="solr.IndicNormalizationFilterFactory"/>
-        <!-- normalizes variation in spelling -->
-        <filter class="solr.HindiNormalizationFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hi.txt" />
-        <filter class="solr.HindiStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Hungarian -->
-    <dynamicField name="*_txt_hu" type="text_hu"  indexed="true"  stored="true"/>
-    <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
-        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->   
-      </analyzer>
-    </fieldType>
-    
-    <!-- Armenian -->
-    <dynamicField name="*_txt_hy" type="text_hy"  indexed="true"  stored="true"/>
-    <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Indonesian -->
-    <dynamicField name="*_txt_id" type="text_id"  indexed="true"  stored="true"/>
-    <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
-        <!-- for a less aggressive approach (only inflectional suffixes), set stemDerivational to false -->
-        <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Italian -->
-  <dynamicField name="*_txt_it" type="text_it"  indexed="true"  stored="true"/>
-  <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_it.txt" format="snowball" />
-        <filter class="solr.ItalianLightStemFilterFactory"/>
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
-
-         NOTE: If you want to optimize search for precision, use default operator AND in your request
-         handler config (q.op) Use OR if you would like to optimize for recall (default).
-    -->
-    <dynamicField name="*_txt_ja" type="text_ja"  indexed="true"  stored="true"/>
-    <fieldType name="text_ja" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="false">
-      <analyzer>
-        <!-- Kuromoji Japanese morphological analyzer/tokenizer (JapaneseTokenizer)
-
-           Kuromoji has a search mode (default) that does segmentation useful for search.  A heuristic
-           is used to segment compounds into its parts and the compound itself is kept as synonym.
-
-           Valid values for attribute mode are:
-              normal: regular segmentation
-              search: segmentation useful for search with synonyms compounds (default)
-            extended: same as search mode, but unigrams unknown words (experimental)
-
-           For some applications it might be good to use search mode for indexing and normal mode for
-           queries to reduce recall and prevent parts of compounds from being matched and highlighted.
-           Use <analyzer type="index"> and <analyzer type="query"> for this and mode normal in query.
-
-           Kuromoji also has a convenient user dictionary feature that allows overriding the statistical
-           model with your own entries for segmentation, part-of-speech tags and readings without a need
-           to specify weights.  Notice that user dictionaries have not been subject to extensive testing.
-
-           User dictionary attributes are:
-                     userDictionary: user dictionary filename
-             userDictionaryEncoding: user dictionary encoding (default is UTF-8)
-
-           See lang/userdict_ja.txt for a sample user dictionary file.
-
-           Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
-        -->
-        <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
-        <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
-        <!-- Reduces inflected verbs and adjectives to their base/dictionary forms (辞書形) -->
-        <filter class="solr.JapaneseBaseFormFilterFactory"/>
-        <!-- Removes tokens with certain part-of-speech tags -->
-        <filter class="solr.JapanesePartOfSpeechStopFilterFactory" tags="lang/stoptags_ja.txt" />
-        <!-- Normalizes full-width romaji to half-width and half-width kana to full-width (Unicode NFKC subset) -->
-        <filter class="solr.CJKWidthFilterFactory"/>
-        <!-- Removes common tokens typically not useful for search, but have a negative effect on ranking -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ja.txt" />
-        <!-- Normalizes common katakana spelling variations by removing any last long sound character (U+30FC) -->
-        <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4"/>
-        <!-- Lower-cases romaji characters -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Korean morphological analysis -->
-    <dynamicField name="*_txt_ko" type="text_ko"  indexed="true"  stored="true"/>
-    <fieldType name="text_ko" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <!-- Nori Korean morphological analyzer/tokenizer (KoreanTokenizer)
-          The Korean (nori) analyzer integrates Lucene nori analysis module into Solr.
-          It uses the mecab-ko-dic dictionary to perform morphological analysis of Korean texts.
-
-          This dictionary was built with MeCab, it defines a format for the features adapted
-          for the Korean language.
-          
-          Nori also has a convenient user dictionary feature that allows overriding the statistical
-          model with your own entries for segmentation, part-of-speech tags and readings without a need
-          to specify weights. Notice that user dictionaries have not been subject to extensive testing.
-
-          The tokenizer supports multiple schema attributes:
-            * userDictionary: User dictionary path.
-            * userDictionaryEncoding: User dictionary encoding.
-            * decompoundMode: Decompound mode. Either 'none', 'discard', 'mixed'. Default is 'discard'.
-            * outputUnknownUnigrams: If true outputs unigrams for unknown words.
-        -->
-        <tokenizer class="solr.KoreanTokenizerFactory" decompoundMode="discard" outputUnknownUnigrams="false"/>
-        <!-- Removes some part of speech stuff like EOMI (Pos.E), you can add a parameter 'tags',
-          listing the tags to remove. By default it removes: 
-          E, IC, J, MAG, MAJ, MM, SP, SSC, SSO, SC, SE, XPN, XSA, XSN, XSV, UNA, NA, VSV
-          This is basically an equivalent to stemming.
-        -->
-        <filter class="solr.KoreanPartOfSpeechStopFilterFactory" />
-        <!-- Replaces term text with the Hangul transcription of Hanja characters, if applicable: -->
-        <filter class="solr.KoreanReadingFormFilterFactory" />
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!-- Latvian -->
-    <dynamicField name="*_txt_lv" type="text_lv"  indexed="true"  stored="true"/>
-    <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
-        <filter class="solr.LatvianStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Dutch -->
-    <dynamicField name="*_txt_nl" type="text_nl"  indexed="true"  stored="true"/>
-    <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
-        <filter class="solr.StemmerOverrideFilterFactory" dictionary="lang/stemdict_nl.txt" ignoreCase="false"/>
-        <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Norwegian -->
-    <dynamicField name="*_txt_no" type="text_no"  indexed="true"  stored="true"/>
-    <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Norwegian"/>
-        <!-- less aggressive: <filter class="solr.NorwegianLightStemFilterFactory"/> -->
-        <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Portuguese -->
-  <dynamicField name="*_txt_pt" type="text_pt"  indexed="true"  stored="true"/>
-  <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
-        <filter class="solr.PortugueseLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.PortugueseMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Portuguese"/> -->
-        <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Romanian -->
-    <dynamicField name="*_txt_ro" type="text_ro"  indexed="true"  stored="true"/>
-    <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Russian -->
-    <dynamicField name="*_txt_ru" type="text_ru"  indexed="true"  stored="true"/>
-    <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Russian"/>
-        <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Swedish -->
-    <dynamicField name="*_txt_sv" type="text_sv"  indexed="true"  stored="true"/>
-    <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Swedish"/>
-        <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Thai -->
-    <dynamicField name="*_txt_th" type="text_th"  indexed="true"  stored="true"/>
-    <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.ThaiTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
-      </analyzer>
-    </fieldType>
-    
-    <!-- Turkish -->
-    <dynamicField name="*_txt_tr" type="text_tr"  indexed="true"  stored="true"/>
-    <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.TurkishLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
-      </analyzer>
+    <!-- Special field type for spell correction. Be careful about
+         adding filters here, as they apply *before* your values go in
+         the spellcheck. For example, the lowercase filter here means
+         all spelling suggestions will be lower case (without it,
+         though, you'd have duplicate suggestions for lower and proper
+         cased words). -->
+    <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Similarity is the scoring routine for each document vs. a query.
@@ -1028,4 +412,22 @@
      </similarity>
     -->
 
+    <fieldType name="text" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+            <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="25"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- Use copyField to copy the fields you want to run spell checking
+         on into one field. For example: -->
+    <copyField source="*_text" dest="textSpell"/>
+    <copyField source="*_s" dest="textSpell"/>
 </schema>

--- a/examples/solr_8/conf/solrconfig.xml
+++ b/examples/solr_8/conf/solrconfig.xml
@@ -1,0 +1,1226 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+     For more details about configurations options that may appear in
+     this file, see http://wiki.apache.org/solr/SolrConfigXml.
+-->
+<config>
+  <!-- In all configuration below, a prefix of "solr." for class names
+       is an alias that causes solr to search appropriate packages,
+       including org.apache.solr.(search|update|request|core|analysis)
+
+       You may also specify a fully qualified Java classname if you
+       have your own custom plugins.
+    -->
+
+  <!-- Controls what version of Lucene various components of Solr
+       adhere to.  Generally, you want to use the latest version to
+       get all bug fixes and improvements. It is highly recommended
+       that you fully re-index after changing this setting as it can
+       affect both how text is indexed and queried.
+  -->
+  <luceneMatchVersion>8.6.2</luceneMatchVersion>
+
+  <!-- <lib/> directives can be used to instruct Solr to load any Jars
+       identified and use them to resolve any "plugins" specified in
+       your solrconfig.xml or schema.xml (ie: Analyzers, Request
+       Handlers, etc...).
+
+       All directories and paths are resolved relative to the
+       instanceDir.
+
+       Please note that <lib/> directives are processed in the order
+       that they appear in your solrconfig.xml file, and are "stacked"
+       on top of each other when building a ClassLoader - so if you have
+       plugin jars with dependencies on other jars, the "lower level"
+       dependency jars should be loaded first.
+
+       If a "./lib" directory exists in your instanceDir, all files
+       found in it are included as if you had used the following
+       syntax...
+
+              <lib dir="./lib" />
+    -->
+
+  <!-- A 'dir' option by itself adds any files found in the directory
+       to the classpath, this is useful for including all jars in a
+       directory.
+
+       When a 'regex' is specified in addition to a 'dir', only the
+       files in that directory which completely match the regex
+       (anchored on both ends) will be included.
+
+       If a 'dir' option (with or without a regex) is used and nothing
+       is found that matches, a warning will be logged.
+
+       The example below can be used to load a solr-contrib along
+       with their external dependencies.
+    -->
+    <!-- <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" /> -->
+
+  <!-- an exact 'path' can be used instead of a 'dir' to specify a
+       specific jar file.  This will cause a serious error to be logged
+       if it can't be loaded.
+    -->
+  <!--
+     <lib path="../a-jar-that-does-not-exist.jar" />
+  -->
+
+  <!-- Data Directory
+
+       Used to specify an alternate directory to hold all index data
+       other than the default ./data under the Solr home.  If
+       replication is in use, this should match the replication
+       configuration.
+    -->
+  <dataDir>${solr.data.dir:}</dataDir>
+
+
+  <!-- The DirectoryFactory to use for indexes.
+
+       solr.StandardDirectoryFactory is filesystem
+       based and tries to pick the best implementation for the current
+       JVM and platform.  solr.NRTCachingDirectoryFactory, the default,
+       wraps solr.StandardDirectoryFactory and caches small files in memory
+       for better NRT performance.
+
+       One can force a particular implementation via solr.MMapDirectoryFactory,
+       solr.NIOFSDirectoryFactory, or solr.SimpleFSDirectoryFactory.
+
+       solr.RAMDirectoryFactory is memory based and not persistent.
+    -->
+  <directoryFactory name="DirectoryFactory"
+                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+
+  <!-- The CodecFactory for defining the format of the inverted index.
+       The default implementation is SchemaCodecFactory, which is the official Lucene
+       index format, but hooks into the schema to provide per-field customization of
+       the postings lists and per-document values in the fieldType element
+       (postingsFormat/docValuesFormat). Note that most of the alternative implementations
+       are experimental, so if you choose to customize the index format, it's a good
+       idea to convert back to the official format e.g. via IndexWriter.addIndexes(IndexReader)
+       before upgrading to a newer version to avoid unnecessary reindexing.
+       A "compressionMode" string element can be added to <codecFactory> to choose
+       between the existing compression modes in the default codec: "BEST_SPEED" (default)
+       or "BEST_COMPRESSION".
+  -->
+  <codecFactory class="solr.SchemaCodecFactory"/>
+
+  <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       Index Config - These settings control low-level behavior of indexing
+       Most example settings here show the default value, but are commented
+       out, to more easily see where customizations have been made.
+
+       Note: This replaces <indexDefaults> and <mainIndex> from older versions
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <indexConfig>
+    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a
+         LimitTokenCountFilterFactory in your fieldType definition. E.g.
+     <filter class="solr.LimitTokenCountFilterFactory" maxTokenCount="10000"/>
+    -->
+    <!-- Maximum time to wait for a write lock (ms) for an IndexWriter. Default: 1000 -->
+    <!-- <writeLockTimeout>1000</writeLockTimeout>  -->
+
+    <!-- Expert: Enabling compound file will use less files for the index,
+         using fewer file descriptors on the expense of performance decrease.
+         Default in Lucene is "true". Default in Solr is "false" (since 3.6) -->
+    <!-- <useCompoundFile>false</useCompoundFile> -->
+
+    <!-- ramBufferSizeMB sets the amount of RAM that may be used by Lucene
+         indexing for buffering added documents and deletions before they are
+         flushed to the Directory.
+         maxBufferedDocs sets a limit on the number of documents buffered
+         before flushing.
+         If both ramBufferSizeMB and maxBufferedDocs is set, then
+         Lucene will flush based on whichever limit is hit first.  -->
+    <!-- <ramBufferSizeMB>100</ramBufferSizeMB> -->
+    <!-- <maxBufferedDocs>1000</maxBufferedDocs> -->
+
+    <!-- Expert: ramPerThreadHardLimitMB sets the maximum amount of RAM that can be consumed
+         per thread before they are flushed. When limit is exceeded, this triggers a forced
+         flush even if ramBufferSizeMB has not been exceeded.
+         This is a safety limit to prevent Lucene's DocumentsWriterPerThread from address space
+         exhaustion due to its internal 32 bit signed integer based memory addressing.
+         The specified value should be greater than 0 and less than 2048MB. When not specified,
+         Solr uses Lucene's default value 1945. -->
+    <!-- <ramPerThreadHardLimitMB>1945</ramPerThreadHardLimitMB> -->
+
+    <!-- Expert: Merge Policy
+         The Merge Policy in Lucene controls how merging of segments is done.
+         The default since Solr/Lucene 3.3 is TieredMergePolicy.
+         The default since Lucene 2.3 was the LogByteSizeMergePolicy,
+         Even older versions of Lucene used LogDocMergePolicy.
+      -->
+    <!--
+        <mergePolicyFactory class="org.apache.solr.index.TieredMergePolicyFactory">
+          <int name="maxMergeAtOnce">10</int>
+          <int name="segmentsPerTier">10</int>
+          <double name="noCFSRatio">0.1</double>
+        </mergePolicyFactory>
+      -->
+
+    <!-- Expert: Merge Scheduler
+         The Merge Scheduler in Lucene controls how merges are
+         performed.  The ConcurrentMergeScheduler (Lucene 2.3 default)
+         can perform merges in the background using separate threads.
+         The SerialMergeScheduler (Lucene 2.2 default) does not.
+     -->
+    <!--
+       <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler"/>
+       -->
+
+    <!-- LockFactory
+
+         This option specifies which Lucene LockFactory implementation
+         to use.
+
+         single = SingleInstanceLockFactory - suggested for a
+                  read-only index or when there is no possibility of
+                  another process trying to modify the index.
+         native = NativeFSLockFactory - uses OS native file locking.
+                  Do not use when multiple solr webapps in the same
+                  JVM are attempting to share a single index.
+         simple = SimpleFSLockFactory  - uses a plain file for locking
+
+         Defaults: 'native' is default for Solr3.6 and later, otherwise
+                   'simple' is the default
+
+         More details on the nuances of each LockFactory...
+         http://wiki.apache.org/lucene-java/AvailableLockFactories
+    -->
+    <lockType>${solr.lock.type:native}</lockType>
+
+    <!-- Commit Deletion Policy
+         Custom deletion policies can be specified here. The class must
+         implement org.apache.lucene.index.IndexDeletionPolicy.
+
+         The default Solr IndexDeletionPolicy implementation supports
+         deleting index commit points on number of commits, age of
+         commit point and optimized status.
+
+         The latest commit point should always be preserved regardless
+         of the criteria.
+    -->
+    <!--
+    <deletionPolicy class="solr.SolrDeletionPolicy">
+    -->
+    <!-- The number of commit points to be kept -->
+    <!-- <str name="maxCommitsToKeep">1</str> -->
+    <!-- The number of optimized commit points to be kept -->
+    <!-- <str name="maxOptimizedCommitsToKeep">0</str> -->
+    <!--
+        Delete all commit points once they have reached the given age.
+        Supports DateMathParser syntax e.g.
+      -->
+    <!--
+       <str name="maxCommitAge">30MINUTES</str>
+       <str name="maxCommitAge">1DAY</str>
+    -->
+    <!--
+    </deletionPolicy>
+    -->
+
+    <!-- Lucene Infostream
+
+         To aid in advanced debugging, Lucene provides an "InfoStream"
+         of detailed information when indexing.
+
+         Setting The value to true will instruct the underlying Lucene
+         IndexWriter to write its debugging info the specified file
+      -->
+    <!-- <infoStream file="INFOSTREAM.txt">false</infoStream> -->
+  </indexConfig>
+
+
+  <!-- JMX
+
+       This example enables JMX if and only if an existing MBeanServer
+       is found, use this if you want to configure JMX through JVM
+       parameters. Remove this to disable exposing Solr configuration
+       and statistics to JMX.
+
+       For more details see http://wiki.apache.org/solr/SolrJmx
+    -->
+  <jmx />
+  <!-- If you want to connect to a particular server, specify the
+       agentId
+    -->
+  <!-- <jmx agentId="myAgent" /> -->
+  <!-- If you want to start a new MBeanServer, specify the serviceUrl -->
+  <!-- <jmx serviceUrl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr"/>
+    -->
+
+  <!-- The default high-performance update handler -->
+  <updateHandler class="solr.DirectUpdateHandler2">
+
+    <!-- Enables a transaction log, used for real-time get, durability, and
+         and solr cloud replica recovery.  The log can grow as big as
+         uncommitted changes to the index, so use of a hard autoCommit
+         is recommended (see below).
+         "dir" - the target directory for transaction logs, defaults to the
+                solr data directory.
+         "numVersionBuckets" - sets the number of buckets used to keep
+                track of max version values when checking for re-ordered
+                updates; increase this value to reduce the cost of
+                synchronizing access to version buckets during high-volume
+                indexing, this requires 8 bytes (long) * numVersionBuckets
+                of heap space per Solr core.
+    -->
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+      <int name="numVersionBuckets">${solr.ulog.numVersionBuckets:65536}</int>
+    </updateLog>
+
+    <!-- AutoCommit
+
+         Perform a hard commit automatically under certain conditions.
+         Instead of enabling autoCommit, consider using "commitWithin"
+         when adding documents.
+
+         http://wiki.apache.org/solr/UpdateXmlMessages
+
+         maxDocs - Maximum number of documents to add since the last
+                   commit before automatically triggering a new commit.
+
+         maxTime - Maximum amount of time in ms that is allowed to pass
+                   since a document was added before automatically
+                   triggering a new commit.
+         openSearcher - if false, the commit causes recent index changes
+           to be flushed to stable storage, but does not cause a new
+           searcher to be opened to make those changes visible.
+
+         If the updateLog is enabled, then it's highly recommended to
+         have some sort of hard autoCommit to limit the log size.
+      -->
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+    <!-- softAutoCommit is like autoCommit except it causes a
+         'soft' commit which only ensures that changes are visible
+         but does not ensure that data is synced to disk.  This is
+         faster and more near-realtime friendly than a hard commit.
+      -->
+
+    <autoSoftCommit>
+      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+    </autoSoftCommit>
+
+    <!-- Update Related Event Listeners
+
+         Various IndexWriter related events can trigger Listeners to
+         take actions.
+
+         postCommit - fired after every commit or optimize command
+         postOptimize - fired after every optimize command
+      -->
+
+  </updateHandler>
+
+  <!-- IndexReaderFactory
+
+       Use the following format to specify a custom IndexReaderFactory,
+       which allows for alternate IndexReader implementations.
+
+       ** Experimental Feature **
+
+       Please note - Using a custom IndexReaderFactory may prevent
+       certain other features from working. The API to
+       IndexReaderFactory may change without warning or may even be
+       removed from future releases if the problems cannot be
+       resolved.
+
+
+       ** Features that may not work with custom IndexReaderFactory **
+
+       The ReplicationHandler assumes a disk-resident index. Using a
+       custom IndexReader implementation may cause incompatibility
+       with ReplicationHandler and may cause replication to not work
+       correctly. See SOLR-1366 for details.
+
+    -->
+  <!--
+  <indexReaderFactory name="IndexReaderFactory" class="package.class">
+    <str name="someArg">Some Value</str>
+  </indexReaderFactory >
+  -->
+
+  <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       Query section - these settings control query time things like caches
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <query>
+
+    <!-- Maximum number of clauses allowed when parsing a boolean query string.
+         
+         This limit only impacts boolean queries specified by a user as part of a query string,
+         and provides per-collection controls on how complex user specified boolean queries can
+         be.  Query strings that specify more clauses then this will result in an error.
+         
+         If this per-collection limit is greater then the global `maxBooleanClauses` limit
+         specified in `solr.xml`, it will have no effect, as that setting also limits the size
+         of user specified boolean queries.
+      -->
+    <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
+
+    <!-- Solr Internal Query Caches
+
+         There are four implementations of cache available for Solr:
+         LRUCache, based on a synchronized LinkedHashMap, 
+         LFUCache and FastLRUCache, based on a ConcurrentHashMap, and CaffeineCache -
+         a modern and robust cache implementation. Note that in Solr 9.0
+         only CaffeineCache will be available, other implementations are now
+         deprecated.
+
+         FastLRUCache has faster gets and slower puts in single
+         threaded operation and thus is generally faster than LRUCache
+         when the hit ratio of the cache is high (> 75%), and may be
+         faster under other scenarios on multi-cpu systems.
+    -->
+
+    <!-- Filter Cache
+
+         Cache used by SolrIndexSearcher for filters (DocSets),
+         unordered sets of *all* documents that match a query.  When a
+         new searcher is opened, its caches may be prepopulated or
+         "autowarmed" using data from caches in the old searcher.
+         autowarmCount is the number of items to prepopulate.  For
+         LRUCache, the autowarmed items will be the most recently
+         accessed items.
+
+         Parameters:
+           class - the SolrCache implementation LRUCache or
+               (LRUCache or FastLRUCache)
+           size - the maximum number of entries in the cache
+           initialSize - the initial capacity (number of entries) of
+               the cache.  (see java.util.HashMap)
+           autowarmCount - the number of entries to prepopulate from
+               and old cache.
+           maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
+                      to occupy. Note that when this option is specified, the size
+                      and initialSize parameters are ignored.
+      -->
+    <filterCache class="solr.FastLRUCache"
+                 size="512"
+                 initialSize="512"
+                 autowarmCount="0"/>
+
+    <!-- Query Result Cache
+
+         Caches results of searches - ordered lists of document ids
+         (DocList) based on a query, a sort, and the range of documents requested.
+         Additional supported parameter by LRUCache:
+            maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
+                       to occupy
+      -->
+    <queryResultCache class="solr.LRUCache"
+                      size="512"
+                      initialSize="512"
+                      autowarmCount="0"/>
+
+    <!-- Document Cache
+
+         Caches Lucene Document objects (the stored fields for each
+         document).  Since Lucene internal document ids are transient,
+         this cache will not be autowarmed.
+      -->
+    <documentCache class="solr.LRUCache"
+                   size="512"
+                   initialSize="512"
+                   autowarmCount="0"/>
+
+    <!-- custom cache currently used by block join -->
+    <cache name="perSegFilter"
+           class="solr.search.LRUCache"
+           size="10"
+           initialSize="0"
+           autowarmCount="10"
+           regenerator="solr.NoOpRegenerator" />
+
+    <!-- Field Value Cache
+
+         Cache used to hold field values that are quickly accessible
+         by document id.  The fieldValueCache is created by default
+         even if not configured here.
+      -->
+    <!--
+       <fieldValueCache class="solr.FastLRUCache"
+                        size="512"
+                        autowarmCount="128"
+                        showItems="32" />
+      -->
+
+    <!-- Custom Cache
+
+         Example of a generic cache.  These caches may be accessed by
+         name through SolrIndexSearcher.getCache(),cacheLookup(), and
+         cacheInsert().  The purpose is to enable easy caching of
+         user/application level data.  The regenerator argument should
+         be specified as an implementation of solr.CacheRegenerator
+         if autowarming is desired.
+      -->
+    <!--
+       <cache name="myUserCache"
+              class="solr.LRUCache"
+              size="4096"
+              initialSize="1024"
+              autowarmCount="1024"
+              regenerator="com.mycompany.MyRegenerator"
+              />
+      -->
+
+
+    <!-- Lazy Field Loading
+
+         If true, stored fields that are not requested will be loaded
+         lazily.  This can result in a significant speed improvement
+         if the usual case is to not load all stored fields,
+         especially if the skipped fields are large compressed text
+         fields.
+    -->
+    <enableLazyFieldLoading>true</enableLazyFieldLoading>
+
+    <!-- Use Filter For Sorted Query
+
+         A possible optimization that attempts to use a filter to
+         satisfy a search.  If the requested sort does not include
+         score, then the filterCache will be checked for a filter
+         matching the query. If found, the filter will be used as the
+         source of document ids, and then the sort will be applied to
+         that.
+
+         For most situations, this will not be useful unless you
+         frequently get the same search repeatedly with different sort
+         options, and none of them ever use "score"
+      -->
+    <!--
+       <useFilterForSortedQuery>true</useFilterForSortedQuery>
+      -->
+
+    <!-- Result Window Size
+
+         An optimization for use with the queryResultCache.  When a search
+         is requested, a superset of the requested number of document ids
+         are collected.  For example, if a search for a particular query
+         requests matching documents 10 through 19, and queryWindowSize is 50,
+         then documents 0 through 49 will be collected and cached.  Any further
+         requests in that range can be satisfied via the cache.
+      -->
+    <queryResultWindowSize>20</queryResultWindowSize>
+
+    <!-- Maximum number of documents to cache for any entry in the
+         queryResultCache.
+      -->
+    <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
+
+    <!-- Query Related Event Listeners
+
+         Various IndexSearcher related events can trigger Listeners to
+         take actions.
+
+         newSearcher - fired whenever a new searcher is being prepared
+         and there is a current searcher handling requests (aka
+         registered).  It can be used to prime certain caches to
+         prevent long request times for certain requests.
+
+         firstSearcher - fired whenever a new searcher is being
+         prepared but there is no current registered searcher to handle
+         requests or to gain autowarming data from.
+
+
+      -->
+    <!-- QuerySenderListener takes an array of NamedList and executes a
+         local query request for each NamedList in sequence.
+      -->
+    <listener event="newSearcher" class="solr.QuerySenderListener">
+      <arr name="queries">
+        <!--
+           <lst><str name="q">solr</str><str name="sort">price asc</str></lst>
+           <lst><str name="q">rocks</str><str name="sort">weight asc</str></lst>
+          -->
+      </arr>
+    </listener>
+    <listener event="firstSearcher" class="solr.QuerySenderListener">
+      <arr name="queries">
+        <!--
+        <lst>
+          <str name="q">static firstSearcher warming in solrconfig.xml</str>
+        </lst>
+        -->
+      </arr>
+    </listener>
+
+    <!-- Use Cold Searcher
+
+         If a search request comes in and there is no current
+         registered searcher, then immediately register the still
+         warming searcher and use it.  If "false" then all requests
+         will block until the first searcher is done warming.
+      -->
+    <useColdSearcher>false</useColdSearcher>
+
+  </query>
+
+
+  <!-- Request Dispatcher
+
+       This section contains instructions for how the SolrDispatchFilter
+       should behave when processing requests for this SolrCore.
+
+    -->
+  <requestDispatcher>
+    <!-- Request Parsing
+
+         These settings indicate how Solr Requests may be parsed, and
+         what restrictions may be placed on the ContentStreams from
+         those requests
+
+         enableRemoteStreaming - enables use of the stream.file
+         and stream.url parameters for specifying remote streams.
+
+         multipartUploadLimitInKB - specifies the max size (in KiB) of
+         Multipart File Uploads that Solr will allow in a Request.
+
+         formdataUploadLimitInKB - specifies the max size (in KiB) of
+         form data (application/x-www-form-urlencoded) sent via
+         POST. You can use POST to pass request parameters not
+         fitting into the URL.
+
+         addHttpRequestToContext - if set to true, it will instruct
+         the requestParsers to include the original HttpServletRequest
+         object in the context map of the SolrQueryRequest under the
+         key "httpRequest". It will not be used by any of the existing
+         Solr components, but may be useful when developing custom
+         plugins.
+
+         *** WARNING ***
+         Before enabling remote streaming, you should make sure your
+         system has authentication enabled.
+
+    <requestParsers enableRemoteStreaming="false"
+                    multipartUploadLimitInKB="-1"
+                    formdataUploadLimitInKB="-1"
+                    addHttpRequestToContext="false"/>
+      -->
+
+    <!-- HTTP Caching
+
+         Set HTTP caching related parameters (for proxy caches and clients).
+
+         The options below instruct Solr not to output any HTTP Caching
+         related headers
+      -->
+    <httpCaching never304="true" />
+    <!-- If you include a <cacheControl> directive, it will be used to
+         generate a Cache-Control header (as well as an Expires header
+         if the value contains "max-age=")
+
+         By default, no Cache-Control header is generated.
+
+         You can use the <cacheControl> option even if you have set
+         never304="true"
+      -->
+    <!--
+       <httpCaching never304="true" >
+         <cacheControl>max-age=30, public</cacheControl>
+       </httpCaching>
+      -->
+    <!-- To enable Solr to respond with automatically generated HTTP
+         Caching headers, and to response to Cache Validation requests
+         correctly, set the value of never304="false"
+
+         This will cause Solr to generate Last-Modified and ETag
+         headers based on the properties of the Index.
+
+         The following options can also be specified to affect the
+         values of these headers...
+
+         lastModFrom - the default value is "openTime" which means the
+         Last-Modified value (and validation against If-Modified-Since
+         requests) will all be relative to when the current Searcher
+         was opened.  You can change it to lastModFrom="dirLastMod" if
+         you want the value to exactly correspond to when the physical
+         index was last modified.
+
+         etagSeed="..." is an option you can change to force the ETag
+         header (and validation against If-None-Match requests) to be
+         different even if the index has not changed (ie: when making
+         significant changes to your config file)
+
+         (lastModifiedFrom and etagSeed are both ignored if you use
+         the never304="true" option)
+      -->
+    <!--
+       <httpCaching lastModifiedFrom="openTime"
+                    etagSeed="Solr">
+         <cacheControl>max-age=30, public</cacheControl>
+       </httpCaching>
+      -->
+  </requestDispatcher>
+
+  <!-- Request Handlers
+
+       http://wiki.apache.org/solr/SolrRequestHandler
+
+       Incoming queries will be dispatched to a specific handler by name
+       based on the path specified in the request.
+
+       If a Request Handler is declared with startup="lazy", then it will
+       not be initialized until the first request that uses it.
+
+    -->
+  <!-- SearchHandler
+
+       http://wiki.apache.org/solr/SearchHandler
+
+       For processing Search Queries, the primary Request Handler
+       provided with Solr is "SearchHandler" It delegates to a sequent
+       of SearchComponents (see below) and supports distributed
+       queries across multiple shards
+    -->
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <int name="rows">10</int>
+      <!-- Default search field
+         <str name="df">text</str> 
+        -->
+      <!-- Change from JSON to XML format (the default prior to Solr 7.0)
+         <str name="wt">xml</str> 
+        -->
+    </lst>
+    <!-- In addition to defaults, "appends" params can be specified
+         to identify values which should be appended to the list of
+         multi-val params from the query (or the existing "defaults").
+      -->
+    <!-- In this example, the param "fq=instock:true" would be appended to
+         any query time fq params the user may specify, as a mechanism for
+         partitioning the index, independent of any user selected filtering
+         that may also be desired (perhaps as a result of faceted searching).
+
+         NOTE: there is *absolutely* nothing a client can do to prevent these
+         "appends" values from being used, so don't use this mechanism
+         unless you are sure you always want it.
+      -->
+    <!--
+       <lst name="appends">
+         <str name="fq">inStock:true</str>
+       </lst>
+      -->
+    <!-- "invariants" are a way of letting the Solr maintainer lock down
+         the options available to Solr clients.  Any params values
+         specified here are used regardless of what values may be specified
+         in either the query, the "defaults", or the "appends" params.
+
+         In this example, the facet.field and facet.query params would
+         be fixed, limiting the facets clients can use.  Faceting is
+         not turned on by default - but if the client does specify
+         facet=true in the request, these are the only facets they
+         will be able to see counts for; regardless of what other
+         facet.field or facet.query params they may specify.
+
+         NOTE: there is *absolutely* nothing a client can do to prevent these
+         "invariants" values from being used, so don't use this mechanism
+         unless you are sure you always want it.
+      -->
+    <!--
+       <lst name="invariants">
+         <str name="facet.field">cat</str>
+         <str name="facet.field">manu_exact</str>
+         <str name="facet.query">price:[* TO 500]</str>
+         <str name="facet.query">price:[500 TO *]</str>
+       </lst>
+      -->
+    <!-- If the default list of SearchComponents is not desired, that
+         list can either be overridden completely, or components can be
+         prepended or appended to the default list.  (see below)
+      -->
+    <!--
+       <arr name="components">
+         <str>nameOfCustomComponent1</str>
+         <str>nameOfCustomComponent2</str>
+       </arr>
+      -->
+  </requestHandler>
+
+  <!-- A request handler that returns indented JSON by default -->
+  <requestHandler name="/query" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="wt">json</str>
+      <str name="indent">true</str>
+    </lst>
+  </requestHandler>
+
+  <initParams path="/update/**,/query,/select,/spell">
+    <lst name="defaults">
+      <str name="df">_text_</str>
+    </lst>
+  </initParams>
+
+  <!-- Search Components
+
+       Search components are registered to SolrCore and used by
+       instances of SearchHandler (which can access them by name)
+
+       By default, the following components are available:
+
+       <searchComponent name="query"     class="solr.QueryComponent" />
+       <searchComponent name="facet"     class="solr.FacetComponent" />
+       <searchComponent name="mlt"       class="solr.MoreLikeThisComponent" />
+       <searchComponent name="highlight" class="solr.HighlightComponent" />
+       <searchComponent name="stats"     class="solr.StatsComponent" />
+       <searchComponent name="debug"     class="solr.DebugComponent" />
+
+       Default configuration in a requestHandler would look like:
+
+       <arr name="components">
+         <str>query</str>
+         <str>facet</str>
+         <str>mlt</str>
+         <str>highlight</str>
+         <str>stats</str>
+         <str>debug</str>
+       </arr>
+
+       If you register a searchComponent to one of the standard names,
+       that will be used instead of the default.
+
+       To insert components before or after the 'standard' components, use:
+
+       <arr name="first-components">
+         <str>myFirstComponentName</str>
+       </arr>
+
+       <arr name="last-components">
+         <str>myLastComponentName</str>
+       </arr>
+
+       NOTE: The component registered with the name "debug" will
+       always be executed after the "last-components"
+
+     -->
+
+  <!-- Spell Check
+
+       The spell check component can return a list of alternative spelling
+       suggestions.
+
+       http://wiki.apache.org/solr/SpellCheckComponent
+    -->
+  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+
+    <str name="queryAnalyzerFieldType">text_general</str>
+
+    <!-- Multiple "Spell Checkers" can be declared and used by this
+         component
+      -->
+
+    <!-- a spellchecker built from a field of the main index -->
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">_text_</str>
+      <str name="classname">solr.DirectSolrSpellChecker</str>
+      <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
+      <str name="distanceMeasure">internal</str>
+      <!-- minimum accuracy needed to be considered a valid spellcheck suggestion -->
+      <float name="accuracy">0.5</float>
+      <!-- the maximum #edits we consider when enumerating terms: can be 1 or 2 -->
+      <int name="maxEdits">2</int>
+      <!-- the minimum shared prefix when enumerating terms -->
+      <int name="minPrefix">1</int>
+      <!-- maximum number of inspections per result. -->
+      <int name="maxInspections">5</int>
+      <!-- minimum length of a query term to be considered for correction -->
+      <int name="minQueryLength">4</int>
+      <!-- maximum threshold of documents a query term can appear to be considered for correction -->
+      <float name="maxQueryFrequency">0.01</float>
+      <!-- uncomment this to require suggestions to occur in 1% of the documents
+        <float name="thresholdTokenFrequency">.01</float>
+      -->
+    </lst>
+
+    <!-- a spellchecker that can break or combine words.  See "/spell" handler below for usage -->
+    <!--
+    <lst name="spellchecker">
+      <str name="name">wordbreak</str>
+      <str name="classname">solr.WordBreakSolrSpellChecker</str>
+      <str name="field">name</str>
+      <str name="combineWords">true</str>
+      <str name="breakWords">true</str>
+      <int name="maxChanges">10</int>
+    </lst>
+    -->
+  </searchComponent>
+
+  <!-- A request handler for demonstrating the spellcheck component.
+
+       NOTE: This is purely as an example.  The whole purpose of the
+       SpellCheckComponent is to hook it into the request handler that
+       handles your normal user queries so that a separate request is
+       not needed to get suggestions.
+
+       IN OTHER WORDS, THERE IS REALLY GOOD CHANCE THE SETUP BELOW IS
+       NOT WHAT YOU WANT FOR YOUR PRODUCTION SYSTEM!
+
+       See http://wiki.apache.org/solr/SpellCheckComponent for details
+       on the request parameters.
+    -->
+  <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <!-- Solr will use suggestions from both the 'default' spellchecker
+           and from the 'wordbreak' spellchecker and combine them.
+           collations (re-written queries) can include a combination of
+           corrections from both spellcheckers -->
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck">on</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.alternativeTermCount">5</str>
+      <str name="spellcheck.maxResultsForSuggest">5</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.maxCollationTries">10</str>
+      <str name="spellcheck.maxCollations">5</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <!-- Terms Component
+
+       http://wiki.apache.org/solr/TermsComponent
+
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <!-- A request handler for demonstrating the terms component -->
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <bool name="terms">true</bool>
+      <bool name="distrib">false</bool>
+    </lst>
+    <arr name="components">
+      <str>terms</str>
+    </arr>
+  </requestHandler>
+
+  <!-- Highlighting Component
+
+       http://wiki.apache.org/solr/HighlightingParameters
+    -->
+  <searchComponent class="solr.HighlightComponent" name="highlight">
+    <highlighting>
+      <!-- Configure the standard fragmenter -->
+      <!-- This could most likely be commented out in the "default" case -->
+      <fragmenter name="gap"
+                  default="true"
+                  class="solr.highlight.GapFragmenter">
+        <lst name="defaults">
+          <int name="hl.fragsize">100</int>
+        </lst>
+      </fragmenter>
+
+      <!-- A regular-expression-based fragmenter
+           (for sentence extraction)
+        -->
+      <fragmenter name="regex"
+                  class="solr.highlight.RegexFragmenter">
+        <lst name="defaults">
+          <!-- slightly smaller fragsizes work better because of slop -->
+          <int name="hl.fragsize">70</int>
+          <!-- allow 50% slop on fragment sizes -->
+          <float name="hl.regex.slop">0.5</float>
+          <!-- a basic sentence pattern -->
+          <str name="hl.regex.pattern">[-\w ,/\n\&quot;&apos;]{20,200}</str>
+        </lst>
+      </fragmenter>
+
+      <!-- Configure the standard formatter -->
+      <formatter name="html"
+                 default="true"
+                 class="solr.highlight.HtmlFormatter">
+        <lst name="defaults">
+          <str name="hl.simple.pre"><![CDATA[<em>]]></str>
+          <str name="hl.simple.post"><![CDATA[</em>]]></str>
+        </lst>
+      </formatter>
+
+      <!-- Configure the standard encoder -->
+      <encoder name="html"
+               class="solr.highlight.HtmlEncoder" />
+
+      <!-- Configure the standard fragListBuilder -->
+      <fragListBuilder name="simple"
+                       class="solr.highlight.SimpleFragListBuilder"/>
+
+      <!-- Configure the single fragListBuilder -->
+      <fragListBuilder name="single"
+                       class="solr.highlight.SingleFragListBuilder"/>
+
+      <!-- Configure the weighted fragListBuilder -->
+      <fragListBuilder name="weighted"
+                       default="true"
+                       class="solr.highlight.WeightedFragListBuilder"/>
+
+      <!-- default tag FragmentsBuilder -->
+      <fragmentsBuilder name="default"
+                        default="true"
+                        class="solr.highlight.ScoreOrderFragmentsBuilder">
+        <!--
+        <lst name="defaults">
+          <str name="hl.multiValuedSeparatorChar">/</str>
+        </lst>
+        -->
+      </fragmentsBuilder>
+
+      <!-- multi-colored tag FragmentsBuilder -->
+      <fragmentsBuilder name="colored"
+                        class="solr.highlight.ScoreOrderFragmentsBuilder">
+        <lst name="defaults">
+          <str name="hl.tag.pre"><![CDATA[
+               <b style="background:yellow">,<b style="background:lawgreen">,
+               <b style="background:aquamarine">,<b style="background:magenta">,
+               <b style="background:palegreen">,<b style="background:coral">,
+               <b style="background:wheat">,<b style="background:khaki">,
+               <b style="background:lime">,<b style="background:deepskyblue">]]></str>
+          <str name="hl.tag.post"><![CDATA[</b>]]></str>
+        </lst>
+      </fragmentsBuilder>
+
+      <boundaryScanner name="default"
+                       default="true"
+                       class="solr.highlight.SimpleBoundaryScanner">
+        <lst name="defaults">
+          <str name="hl.bs.maxScan">10</str>
+          <str name="hl.bs.chars">.,!? &#9;&#10;&#13;</str>
+        </lst>
+      </boundaryScanner>
+
+      <boundaryScanner name="breakIterator"
+                       class="solr.highlight.BreakIteratorBoundaryScanner">
+        <lst name="defaults">
+          <!-- type should be one of CHARACTER, WORD(default), LINE and SENTENCE -->
+          <str name="hl.bs.type">WORD</str>
+          <!-- language and country are used when constructing Locale object.  -->
+          <!-- And the Locale object will be used when getting instance of BreakIterator -->
+          <str name="hl.bs.language">en</str>
+          <str name="hl.bs.country">US</str>
+        </lst>
+      </boundaryScanner>
+    </highlighting>
+  </searchComponent>
+
+  <!-- Update Processors
+
+       Chains of Update Processor Factories for dealing with Update
+       Requests can be declared, and then used by name in Update
+       Request Processors
+
+       http://wiki.apache.org/solr/UpdateRequestProcessor
+
+    -->
+
+  <!-- Add unknown fields to the schema
+
+       Field type guessing update processors that will
+       attempt to parse string-typed field values as Booleans, Longs,
+       Doubles, or Dates, and then add schema fields with the guessed
+       field types. Text content will be indexed as "text_general" as
+       well as a copy to a plain string version in *_str.
+
+       These require that the schema is both managed and mutable, by
+       declaring schemaFactory as ManagedIndexSchemaFactory, with
+       mutable specified as true.
+
+       See http://wiki.apache.org/solr/GuessingFieldTypes
+    -->
+  <updateProcessor class="solr.UUIDUpdateProcessorFactory" name="uuid"/>
+  <updateProcessor class="solr.RemoveBlankFieldUpdateProcessorFactory" name="remove-blank"/>
+  <updateProcessor class="solr.FieldNameMutatingUpdateProcessorFactory" name="field-name-mutating">
+    <str name="pattern">[^\w-\.]</str>
+    <str name="replacement">_</str>
+  </updateProcessor>
+  <updateProcessor class="solr.ParseBooleanFieldUpdateProcessorFactory" name="parse-boolean"/>
+  <updateProcessor class="solr.ParseLongFieldUpdateProcessorFactory" name="parse-long"/>
+  <updateProcessor class="solr.ParseDoubleFieldUpdateProcessorFactory" name="parse-double"/>
+  <updateProcessor class="solr.ParseDateFieldUpdateProcessorFactory" name="parse-date">
+    <arr name="format">
+      <str>yyyy-MM-dd['T'[HH:mm[:ss[.SSS]][z</str>
+      <str>yyyy-MM-dd['T'[HH:mm[:ss[,SSS]][z</str>
+      <str>yyyy-MM-dd HH:mm[:ss[.SSS]][z</str>
+      <str>yyyy-MM-dd HH:mm[:ss[,SSS]][z</str>
+      <str>[EEE, ]dd MMM yyyy HH:mm[:ss] z</str>
+      <str>EEEE, dd-MMM-yy HH:mm:ss z</str>
+      <str>EEE MMM ppd HH:mm:ss [z ]yyyy</str>
+    </arr>
+  </updateProcessor>
+  <updateProcessor class="solr.AddSchemaFieldsUpdateProcessorFactory" name="add-schema-fields">
+    <lst name="typeMapping">
+      <str name="valueClass">java.lang.String</str>
+      <str name="fieldType">text_general</str>
+      <lst name="copyField">
+        <str name="dest">*_str</str>
+        <int name="maxChars">256</int>
+      </lst>
+      <!-- Use as default mapping instead of defaultFieldType -->
+      <bool name="default">true</bool>
+    </lst>
+    <lst name="typeMapping">
+      <str name="valueClass">java.lang.Boolean</str>
+      <str name="fieldType">booleans</str>
+    </lst>
+    <lst name="typeMapping">
+      <str name="valueClass">java.util.Date</str>
+      <str name="fieldType">pdates</str>
+    </lst>
+    <lst name="typeMapping">
+      <str name="valueClass">java.lang.Long</str>
+      <str name="valueClass">java.lang.Integer</str>
+      <str name="fieldType">plongs</str>
+    </lst>
+    <lst name="typeMapping">
+      <str name="valueClass">java.lang.Number</str>
+      <str name="fieldType">pdoubles</str>
+    </lst>
+  </updateProcessor>
+
+  <!-- The update.autoCreateFields property can be turned to false to disable schemaless mode -->
+  <updateRequestProcessorChain name="add-unknown-fields-to-the-schema" default="${update.autoCreateFields:true}"
+           processor="uuid,remove-blank,field-name-mutating,parse-boolean,parse-long,parse-double,parse-date,add-schema-fields">
+    <processor class="solr.LogUpdateProcessorFactory"/>
+    <processor class="solr.DistributedUpdateProcessorFactory"/>
+    <processor class="solr.RunUpdateProcessorFactory"/>
+  </updateRequestProcessorChain>
+
+  <!-- Deduplication
+
+       An example dedup update processor that creates the "id" field
+       on the fly based on the hash code of some other fields.  This
+       example has overwriteDupes set to false since we are using the
+       id field as the signatureField and Solr will maintain
+       uniqueness based on that anyway.
+
+    -->
+  <!--
+     <updateRequestProcessorChain name="dedupe">
+       <processor class="solr.processor.SignatureUpdateProcessorFactory">
+         <bool name="enabled">true</bool>
+         <str name="signatureField">id</str>
+         <bool name="overwriteDupes">false</bool>
+         <str name="fields">name,features,cat</str>
+         <str name="signatureClass">solr.processor.Lookup3Signature</str>
+       </processor>
+       <processor class="solr.LogUpdateProcessorFactory" />
+       <processor class="solr.RunUpdateProcessorFactory" />
+     </updateRequestProcessorChain>
+    -->
+
+  <!-- Response Writers
+
+       http://wiki.apache.org/solr/QueryResponseWriter
+
+       Request responses will be written using the writer specified by
+       the 'wt' request parameter matching the name of a registered
+       writer.
+
+       The "default" writer is the default and will be used if 'wt' is
+       not specified in the request.
+    -->
+  <!-- The following response writers are implicitly configured unless
+       overridden...
+    -->
+  <!--
+     <queryResponseWriter name="xml"
+                          default="true"
+                          class="solr.XMLResponseWriter" />
+     <queryResponseWriter name="json" class="solr.JSONResponseWriter"/>
+     <queryResponseWriter name="python" class="solr.PythonResponseWriter"/>
+     <queryResponseWriter name="ruby" class="solr.RubyResponseWriter"/>
+     <queryResponseWriter name="php" class="solr.PHPResponseWriter"/>
+     <queryResponseWriter name="phps" class="solr.PHPSerializedResponseWriter"/>
+     <queryResponseWriter name="csv" class="solr.CSVResponseWriter"/>
+     <queryResponseWriter name="schema.xml" class="solr.SchemaXmlResponseWriter"/>
+    -->
+
+  <queryResponseWriter name="json" class="solr.JSONResponseWriter">
+    <!-- For the purposes of the tutorial, JSON responses are written as
+     plain text so that they are easy to read in *any* browser.
+     If you expect a MIME type of "application/json" just remove this override.
+    -->
+    <str name="content-type">text/plain; charset=UTF-8</str>
+  </queryResponseWriter>
+
+  <!-- Query Parsers
+
+       https://lucene.apache.org/solr/guide/query-syntax-and-parsing.html
+
+       Multiple QParserPlugins can be registered by name, and then
+       used in either the "defType" param for the QueryComponent (used
+       by SearchHandler) or in LocalParams
+    -->
+  <!-- example of registering a query parser -->
+  <!--
+     <queryParser name="myparser" class="com.mycompany.MyQParserPlugin"/>
+    -->
+
+  <!-- Function Parsers
+
+       http://wiki.apache.org/solr/FunctionQuery
+
+       Multiple ValueSourceParsers can be registered by name, and then
+       used as function names when using the "func" QParser.
+    -->
+  <!-- example of registering a custom function parser  -->
+  <!--
+     <valueSourceParser name="myfunc"
+                        class="com.mycompany.MyValueSourceParser" />
+    -->
+
+
+  <!-- Document Transformers
+       http://wiki.apache.org/solr/DocTransformers
+    -->
+  <!--
+     Could be something like:
+     <transformer name="db" class="com.mycompany.LoadFromDatabaseTransformer" >
+       <int name="connection">jdbc://....</int>
+     </transformer>
+
+     To add a constant value to all docs, use:
+     <transformer name="mytrans2" class="org.apache.solr.response.transform.ValueAugmenterFactory" >
+       <int name="value">5</int>
+     </transformer>
+
+     If you want the user to still be able to change it with _value:something_ use this:
+     <transformer name="mytrans3" class="org.apache.solr.response.transform.ValueAugmenterFactory" >
+       <double name="defaultValue">5</double>
+     </transformer>
+
+      If you are using the QueryElevationComponent, you may wish to mark documents that get boosted.  The
+      EditorialMarkerFactory will do exactly that:
+     <transformer name="qecBooster" class="org.apache.solr.response.transform.EditorialMarkerFactory" />
+    -->
+</config>

--- a/examples/solr_8/conf/solrconfig.xml
+++ b/examples/solr_8/conf/solrconfig.xml
@@ -779,6 +779,9 @@
       <str name="df">text</str>
       <str name="q.op">AND</str>
     </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
   </requestHandler>
 
   <initParams path="/update/**,/query,/select,/spell">

--- a/examples/solr_8/conf/solrconfig.xml
+++ b/examples/solr_8/conf/solrconfig.xml
@@ -699,11 +699,16 @@
          will be overridden by parameters in the request
       -->
     <lst name="defaults">
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="q.op">AND</str>
+<!--
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
-      <!-- Default search field
-         <str name="df">text</str> 
-        -->
+-->
+      <!-- Default search field -->
+      <str name="df">text</str>
       <!-- Change from JSON to XML format (the default prior to Solr 7.0)
          <str name="wt">xml</str> 
         -->
@@ -760,6 +765,9 @@
          <str>nameOfCustomComponent2</str>
        </arr>
       -->
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
   </requestHandler>
 
   <!-- A request handler that returns indented JSON by default -->
@@ -768,12 +776,14 @@
       <str name="echoParams">explicit</str>
       <str name="wt">json</str>
       <str name="indent">true</str>
+      <str name="df">text</str>
+      <str name="q.op">AND</str>
     </lst>
   </requestHandler>
 
   <initParams path="/update/**,/query,/select,/spell">
     <lst name="defaults">
-      <str name="df">_text_</str>
+      <str name="df">text</str>
     </lst>
   </initParams>
 
@@ -829,38 +839,46 @@
     -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 
-    <str name="queryAnalyzerFieldType">text_general</str>
+    <str name="queryAnalyzerFieldType">textSpell</str>
 
     <!-- Multiple "Spell Checkers" can be declared and used by this
          component
       -->
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <!-- change field to textSpell and use copyField in schema.xml
+      to spellcheck multiple fields -->
+      <str name="field">textSpell</str>
+      <str name="buildOnCommit">true</str>
+    </lst>
 
     <!-- a spellchecker built from a field of the main index -->
+<!--
     <lst name="spellchecker">
       <str name="name">default</str>
       <str name="field">_text_</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
-      <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
+      &lt;!&ndash; the spellcheck distance measure used, the default is the internal levenshtein &ndash;&gt;
       <str name="distanceMeasure">internal</str>
-      <!-- minimum accuracy needed to be considered a valid spellcheck suggestion -->
+      &lt;!&ndash; minimum accuracy needed to be considered a valid spellcheck suggestion &ndash;&gt;
       <float name="accuracy">0.5</float>
-      <!-- the maximum #edits we consider when enumerating terms: can be 1 or 2 -->
+      &lt;!&ndash; the maximum #edits we consider when enumerating terms: can be 1 or 2 &ndash;&gt;
       <int name="maxEdits">2</int>
-      <!-- the minimum shared prefix when enumerating terms -->
+      &lt;!&ndash; the minimum shared prefix when enumerating terms &ndash;&gt;
       <int name="minPrefix">1</int>
-      <!-- maximum number of inspections per result. -->
+      &lt;!&ndash; maximum number of inspections per result. &ndash;&gt;
       <int name="maxInspections">5</int>
-      <!-- minimum length of a query term to be considered for correction -->
+      &lt;!&ndash; minimum length of a query term to be considered for correction &ndash;&gt;
       <int name="minQueryLength">4</int>
-      <!-- maximum threshold of documents a query term can appear to be considered for correction -->
+      &lt;!&ndash; maximum threshold of documents a query term can appear to be considered for correction &ndash;&gt;
       <float name="maxQueryFrequency">0.01</float>
-      <!-- uncomment this to require suggestions to occur in 1% of the documents
+      &lt;!&ndash; uncomment this to require suggestions to occur in 1% of the documents
         <float name="thresholdTokenFrequency">.01</float>
-      -->
+      &ndash;&gt;
     </lst>
+-->
 
     <!-- a spellchecker that can break or combine words.  See "/spell" handler below for usage -->
-    <!--
     <lst name="spellchecker">
       <str name="name">wordbreak</str>
       <str name="classname">solr.WordBreakSolrSpellChecker</str>
@@ -869,7 +887,6 @@
       <str name="breakWords">true</str>
       <int name="maxChanges">10</int>
     </lst>
-    -->
   </searchComponent>
 
   <!-- A request handler for demonstrating the spellcheck component.
@@ -885,12 +902,13 @@
        See http://wiki.apache.org/solr/SpellCheckComponent for details
        on the request parameters.
     -->
+<!--
   <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
     <lst name="defaults">
-      <!-- Solr will use suggestions from both the 'default' spellchecker
+      &lt;!&ndash; Solr will use suggestions from both the 'default' spellchecker
            and from the 'wordbreak' spellchecker and combine them.
            collations (re-written queries) can include a combination of
-           corrections from both spellcheckers -->
+           corrections from both spellcheckers &ndash;&gt;
       <str name="spellcheck.dictionary">default</str>
       <str name="spellcheck">on</str>
       <str name="spellcheck.extendedResults">true</str>
@@ -906,6 +924,7 @@
       <str>spellcheck</str>
     </arr>
   </requestHandler>
+-->
 
   <!-- Terms Component
 
@@ -925,6 +944,13 @@
     <arr name="components">
       <str>terms</str>
     </arr>
+  </requestHandler>
+
+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
+    <lst name="defaults">
+      <str name="mlt.mintf">1</str>
+      <str name="mlt.mindf">2</str>
+    </lst>
   </requestHandler>
 
   <!-- Highlighting Component

--- a/sunspot/lib/sunspot/dsl/fields.rb
+++ b/sunspot/lib/sunspot/dsl/fields.rb
@@ -90,17 +90,11 @@ module Sunspot
         join = method.to_s == 'join'
         type_string = join ? options.delete(:type).to_s : method.to_s
         type_const_name = "#{Util.camel_case(type_string.sub(/^dynamic_/, ''))}Type"
-        trie = options.delete(:trie)
-        type_const_name = "Trie#{type_const_name}" if trie
 
         begin
           type_class = Type.const_get(type_const_name)
         rescue NameError
-          if trie
-            raise ArgumentError, "Trie fields are only valid for numeric and time types"
-          else
-            super(method, *args, &block)
-          end
+          super(method, *args, &block)
         end
 
         type = type_class.instance

--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -132,7 +132,7 @@ module Sunspot
       def initialize(name, type, options = {}, &block)
         super(name, options, &block)
         @type, @options = type, options
-        @separator = @options.delete(:separator) || ':'
+        @separator = @options.delete(:separator) || '__'
       end
 
       #

--- a/sunspot/lib/sunspot/query/date_field_facet.rb
+++ b/sunspot/lib/sunspot/query/date_field_facet.rb
@@ -3,10 +3,10 @@ module Sunspot
     class DateFieldFacet < AbstractFieldFacet
       def to_params
         params = super
-        params[:"facet.date"] = [@field.indexed_name]
-        params[qualified_param('date.start')] = @field.to_indexed(@options[:time_range].first)
-        params[qualified_param('date.end')] = @field.to_indexed(@options[:time_range].last)
-        params[qualified_param('date.gap')] = "+#{@options[:time_interval] || 86400}SECONDS"
+        params[:"facet.range"] = [@field.indexed_name]
+        params[qualified_param('range.start')] = @field.to_indexed(@options[:time_range].first)
+        params[qualified_param('range.end')] = @field.to_indexed(@options[:time_range].last)
+        params[qualified_param('range.gap')] = "+#{@options[:time_interval] || 86400}SECONDS"
         params
       end
     end

--- a/sunspot/lib/sunspot/query/sort.rb
+++ b/sunspot/lib/sunspot/query/sort.rb
@@ -31,13 +31,19 @@ module Sunspot
       end
 
       # 
-      # Base class for sorts. All subclasses should implement the #to_param
+      # Base class for sorts. All subclasses must either implement a #to_param
       # method, which is a string that is then concatenated with other sort
-      # strings by the SortComposite to form the sort parameter.
+      # strings by the SortComposite to form the sort parameter or a #to_params
+      # method which returns a hash of all solr query parameters the sorting
+      # class requires, containing at least the key :sort.
       #
       class Abstract
         def initialize(direction)
           @direction = (direction || :asc).to_sym
+        end
+
+        def to_params
+          { sort: to_param }
         end
 
         private
@@ -110,8 +116,12 @@ module Sunspot
           super(field, direction)
         end
 
-        def to_param
-          "geodist(#{@field.indexed_name.to_sym},#{@lat},#{@lon}) #{direction_for_solr}"
+        def to_params
+          {
+            sfield: @field.indexed_name.to_s,
+            pt: "#{@lat},#{@lon}",
+            sort: "geodist() #{direction_for_solr}"
+          }
         end
       end
 

--- a/sunspot/lib/sunspot/query/sort_composite.rb
+++ b/sunspot/lib/sunspot/query/sort_composite.rb
@@ -22,16 +22,30 @@ module Sunspot
       # Check sort presence
       #
       def include?(sort)
-        @sorts.any? { |s| s.to_param.include?(sort) }
+        @sorts.any? { |s| s.to_params[:sort].include?(sort) }
       end
 
       # 
-      # Combine the sorts into a single param by joining them
+      # Combine the sorts into a single sort-param by joining them and add
+      # possible custom additional params
       #
       def to_params(prefix = "")
         unless @sorts.empty?
           key = "#{prefix}sort".to_sym
-          { key => @sorts.map { |sort| sort.to_param } * ', ' }
+          params = { key => @sorts.map { |sort| sort.to_params[:sort] } * ', ' }
+          @sorts.each do |sort|
+            sort.to_params.each do |param, value|
+              next if param == :sort
+              param = param.to_sym
+              if params.has_key?(param) && params[param] != value
+                raise "encountered duplicate additional sort param '#{param}' with different values ('#{params[param]}' vs. '#{value}')"
+              end
+
+              params[param] = value
+            end
+          end
+
+          params
         else
           {}
         end

--- a/sunspot/lib/sunspot/schema.rb
+++ b/sunspot/lib/sunspot/schema.rb
@@ -21,9 +21,6 @@ module Sunspot
       FieldType.new('string', 'Str', 's'),
       FieldType.new('sdouble', 'SortableDouble', 'e'),
       FieldType.new('slong', 'SortableLong', 'l'),
-      FieldType.new('tint', 'TrieInteger', 'it'),
-      FieldType.new('tfloat', 'TrieFloat', 'ft'),
-      FieldType.new('tdate', 'TrieInt', 'dt'),
       FieldType.new('daterange', 'DateRange', 'dr')
 
     ]

--- a/sunspot/lib/sunspot/search/date_facet.rb
+++ b/sunspot/lib/sunspot/search/date_facet.rb
@@ -12,10 +12,10 @@ module Sunspot
       def rows
         @rows ||=
           begin
-            data = @search.facet_response['facet_dates'][@field.indexed_name]
+            data = @search.facet_response['facet_ranges'][@field.indexed_name]['counts']
             gap = (@options[:time_interval] || 86400).to_i
             rows = []
-            data.each_pair do |value, count|
+            data.each_slice(2) do |value, count|
               if value =~ /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/
                 start_time = @field.cast(value)
                 end_time = start_time + gap

--- a/sunspot/lib/sunspot/type.rb
+++ b/sunspot/lib/sunspot/type.rb
@@ -189,7 +189,7 @@ module Sunspot
     #
     class DoubleType < FloatType
       def indexed_name(name)
-        "#{name}_e"
+        "#{name}_d"
       end
     end
 
@@ -201,7 +201,7 @@ module Sunspot
       XMLSCHEMA = "%Y-%m-%dT%H:%M:%SZ"
 
       def indexed_name(name) #:nodoc:
-        "#{name}_d"
+        "#{name}_dt"
       end
 
       def to_indexed(value) #:nodoc:
@@ -325,7 +325,7 @@ module Sunspot
 
     # 
     # The Latlon type encodes geographical coordinates in the native
-    # Solr LatLonType.
+    # Solr LatLonPointSpatialField.
     #
     # The data for this type must respond to the `lat` and `lng` methods; you
     # can use Sunspot::Util::Coordinates as a wrapper if your source data does
@@ -336,7 +336,7 @@ module Sunspot
     #
     class LatlonType < AbstractType
       def indexed_name(name)
-        "#{name}_ll"
+        "#{name}_p"
       end
 
       def to_indexed(value)

--- a/sunspot/lib/sunspot/type.rb
+++ b/sunspot/lib/sunspot/type.rb
@@ -267,38 +267,7 @@ module Sunspot
     end
     register DateType, Date
 
-    # 
-    # Store integers in a TrieField, which makes range queries much faster.
     #
-    class TrieIntegerType < IntegerType
-      def indexed_name(name)
-        "#{super}t"
-      end
-    end
-
-    # 
-    # Store floats in a TrieField, which makes range queries much faster.
-    #
-    class TrieFloatType < FloatType
-      def indexed_name(name)
-        "#{super}t"
-      end
-    end
-
-    # 
-    # Index times using a TrieField. Internally, trie times are indexed as
-    # Unix timestamps in a trie integer field, as TrieField does not support
-    # datetime types natively. This distinction should have no effect from the
-    # standpoint of the library's API.
-    #
-    class TrieTimeType < TimeType
-      def indexed_name(name)
-        "#{super}t"
-      end
-    end
-
-
-    # 
     # The boolean type represents true/false values. Note that +nil+ will not be
     # indexed at all; only +false+ will be indexed with a false value.
     #

--- a/sunspot/spec/api/indexer/attributes_spec.rb
+++ b/sunspot/spec/api/indexer/attributes_spec.rb
@@ -83,7 +83,7 @@ describe 'indexing attribute fields', :type => :indexer do
 
   it 'should index latitude and longitude passed as non-Floats' do
     coordinates = Sunspot::Util::Coordinates.new(
-      BigDecimal.new('40.7'), BigDecimal.new('-73.5'))
+      BigDecimal('40.7'), BigDecimal('-73.5'))
     session.index(post(:coordinates => coordinates))
     expect(connection).to have_add_with(:coordinates_s => 'dr5xx3nytvgs')
   end

--- a/sunspot/spec/api/indexer/attributes_spec.rb
+++ b/sunspot/spec/api/indexer/attributes_spec.rb
@@ -24,7 +24,7 @@ describe 'indexing attribute fields', :type => :indexer do
 
   it 'should correctly index a double attribute field' do
     session.index(Namespaced::Comment.new(:average_rating => 2.23))
-    expect(connection).to have_add_with(:average_rating_e => '2.23')
+    expect(connection).to have_add_with(:average_rating_d => '2.23')
   end
 
   it 'should allow indexing by a multiple-value field' do
@@ -53,7 +53,7 @@ describe 'indexing attribute fields', :type => :indexer do
 
   it 'should correctly index a date field' do
     session.index(post(:expire_date => Date.new(2009, 07, 13)))
-    expect(connection).to have_add_with(:expire_date_d => '2009-07-13T00:00:00Z')
+    expect(connection).to have_add_with(:expire_date_dt => '2009-07-13T00:00:00Z')
   end
 
   it 'should correctly index a date range field' do

--- a/sunspot/spec/api/indexer/attributes_spec.rb
+++ b/sunspot/spec/api/indexer/attributes_spec.rb
@@ -19,27 +19,12 @@ describe 'indexing attribute fields', :type => :indexer do
 
   it 'should correctly index a float attribute field' do
     session.index(post(:ratings_average => 2.23))
-    expect(connection).to have_add_with(:average_rating_ft => '2.23')
+    expect(connection).to have_add_with(:average_rating_f => '2.23')
   end
 
   it 'should correctly index a double attribute field' do
     session.index(Namespaced::Comment.new(:average_rating => 2.23))
     expect(connection).to have_add_with(:average_rating_e => '2.23')
-  end
-
-  it 'should correctly index a trie integer attribute field' do
-    session.index(Photo.new(:size => 104856))
-    expect(connection).to have_add_with(:size_it => '104856')
-  end
-
-  it 'should correctly index a trie float attribute field' do
-    session.index(Photo.new(:average_rating => 2.23))
-    expect(connection).to have_add_with(:average_rating_ft => '2.23')
-  end
-
-  it 'should correctly index a trie time attribute field' do
-    session.index(Photo.new(:created_at => Time.parse('2009-12-16 15:00:00 -0400')))
-    expect(connection).to have_add_with(:created_at_dt => '2009-12-16T19:00:00Z')
   end
 
   it 'should allow indexing by a multiple-value field' do

--- a/sunspot/spec/api/indexer/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/indexer/dynamic_fields_spec.rb
@@ -18,7 +18,7 @@ describe 'indexing dynamic fields' do
 
   it 'indexes time data' do
     session.index(post(:custom_time => { :test => Time.parse('2009-05-18 18:05:00 -0400') }))
-    expect(connection).to have_add_with(:"custom_time:test_d" => '2009-05-18T22:05:00Z')
+    expect(connection).to have_add_with(:"custom_time:test_dt" => '2009-05-18T22:05:00Z')
   end
 
   it 'indexes boolean data' do

--- a/sunspot/spec/api/indexer/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/indexer/dynamic_fields_spec.rb
@@ -3,32 +3,32 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 describe 'indexing dynamic fields' do
   it 'indexes string data' do
     session.index(post(:custom_string => { :test => 'string' }))
-    expect(connection).to have_add_with(:"custom_string:test_ss" => 'string')
+    expect(connection).to have_add_with(:"custom_string__test_ss" => 'string')
   end
 
   it 'indexes integer data with virtual accessor' do
     session.index(post(:category_ids => [1, 2]))
-    expect(connection).to have_add_with(:"custom_integer:1_i" => '1', :"custom_integer:2_i" => '1')
+    expect(connection).to have_add_with(:"custom_integer__1_i" => '1', :"custom_integer__2_i" => '1')
   end
 
   it 'indexes float data' do
     session.index(post(:custom_fl => { :test => 1.5 }))
-    expect(connection).to have_add_with(:"custom_float:test_fm" => '1.5')
+    expect(connection).to have_add_with(:"custom_float__test_fm" => '1.5')
   end
 
   it 'indexes time data' do
     session.index(post(:custom_time => { :test => Time.parse('2009-05-18 18:05:00 -0400') }))
-    expect(connection).to have_add_with(:"custom_time:test_dt" => '2009-05-18T22:05:00Z')
+    expect(connection).to have_add_with(:"custom_time__test_dt" => '2009-05-18T22:05:00Z')
   end
 
   it 'indexes boolean data' do
     session.index(post(:custom_boolean => { :test => false }))
-    expect(connection).to have_add_with(:"custom_boolean:test_b" => 'false')
+    expect(connection).to have_add_with(:"custom_boolean__test_b" => 'false')
   end
 
   it 'indexes multiple values for a field' do
     session.index(post(:custom_fl => { :test => [1.0, 2.1, 3.2] }))
-    expect(connection).to have_add_with(:"custom_float:test_fm" => %w(1.0 2.1 3.2))
+    expect(connection).to have_add_with(:"custom_float__test_fm" => %w(1.0 2.1 3.2))
   end
 
   it 'should throw a NoMethodError if dynamic text field defined' do

--- a/sunspot/spec/api/query/connective_boost_examples.rb
+++ b/sunspot/spec/api/query/connective_boost_examples.rb
@@ -10,7 +10,7 @@ shared_examples_for "query with connective scope and boost" do
     end
 
     expect(connection).to have_last_search_including(
-      :bq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])^10'
+      :bq, '(coordinates_new_p:[23,-46 TO 25,-44] OR coordinates_new_p:[42,56 TO 43,58])^10'
     )
 
     expect(connection).to have_last_search_including(
@@ -60,7 +60,7 @@ shared_examples_for "query with connective scope and boost" do
     end
 
     expect(connection).to have_last_search_including(
-      :bq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])^10'
+      :bq, '(coordinates_new_p:[23,-46 TO 25,-44] OR coordinates_new_p:[42,56 TO 43,58])^10'
     )
 
     expect(connection).to have_last_search_including(

--- a/sunspot/spec/api/query/connective_boost_examples.rb
+++ b/sunspot/spec/api/query/connective_boost_examples.rb
@@ -24,7 +24,7 @@ shared_examples_for "query with connective scope and boost" do
     end
 
     expect(connection).to have_last_search_including(
-      :bf, 'field(average_rating_ft)'
+      :bf, 'field(average_rating_f)'
     )
 
     expect(connection).to have_last_search_including(
@@ -38,7 +38,7 @@ shared_examples_for "query with connective scope and boost" do
     end
 
     expect(connection).to have_last_search_including(
-      :boost, 'field(average_rating_ft)'
+      :boost, 'field(average_rating_f)'
     )
 
     expect(connection).to have_last_search_including(
@@ -64,11 +64,11 @@ shared_examples_for "query with connective scope and boost" do
     )
 
     expect(connection).to have_last_search_including(
-      :bf, 'field(average_rating_ft)'
+      :bf, 'field(average_rating_f)'
     )
 
     expect(connection).to have_last_search_including(
-      :boost, 'field(average_rating_ft)'
+      :boost, 'field(average_rating_f)'
     )
   end
 
@@ -79,7 +79,7 @@ shared_examples_for "query with connective scope and boost" do
       boost_multiplicative(function() { field(:average_rating) })
     end
 
-    expect(connection.searches.last[:bf]).to eq ['field(average_rating_ft)']
-    expect(connection.searches.last[:boost]).to eq ['field(average_rating_ft)']
+    expect(connection.searches.last[:bf]).to eq ['field(average_rating_f)']
+    expect(connection.searches.last[:boost]).to eq ['field(average_rating_f)']
   end
 end

--- a/sunspot/spec/api/query/connectives_examples.rb
+++ b/sunspot/spec/api/query/connectives_examples.rb
@@ -23,7 +23,7 @@ shared_examples_for "query with connective scope" do
     end
     expect(connection).to have_last_search_including(
       :fq,
-      '(blog_id_i:2 OR (category_ids_im:1 AND average_rating_ft:{3\.0 TO *}))'
+      '(blog_id_i:2 OR (category_ids_im:1 AND average_rating_f:{3\.0 TO *}))'
     )
   end
 
@@ -38,7 +38,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '(category_ids_im:1 OR (-average_rating_ft:{3\.0 TO *} AND blog_id_i:1))'
+      :fq, '(category_ids_im:1 OR (-average_rating_f:{3\.0 TO *} AND blog_id_i:1))'
     )
   end
 
@@ -62,7 +62,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '-(-category_ids_im:1 AND average_rating_ft:{3\.0 TO *})'
+      :fq, '-(-category_ids_im:1 AND average_rating_f:{3\.0 TO *})'
     )
   end
 
@@ -80,7 +80,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '-(title_ss:Yes AND -(blog_id_i:1 AND -(-category_ids_im:4 AND average_rating_ft:2\.0)))'
+      :fq, '-(title_ss:Yes AND -(blog_id_i:1 AND -(-category_ids_im:4 AND average_rating_f:2\.0)))'
     )
   end
   it 'creates a disjunction with nested conjunction with nested disjunction with negated restriction' do
@@ -97,7 +97,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '(title_ss:Yes OR (blog_id_i:1 AND -(-category_ids_im:4 AND average_rating_ft:2\.0)))'
+      :fq, '(title_ss:Yes OR (blog_id_i:1 AND -(-category_ids_im:4 AND average_rating_f:2\.0)))'
     )
   end
 
@@ -149,7 +149,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '-(average_rating_ft:[* TO *] AND -average_rating_ft:{3\.0 TO *})'
+      :fq, '-(average_rating_f:[* TO *] AND -average_rating_f:{3\.0 TO *})'
     )
   end
 
@@ -162,7 +162,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, "(id:(Post\\ #{post.id}) OR average_rating_ft:{3\\.0 TO *})"
+      :fq, "(id:(Post\\ #{post.id}) OR average_rating_f:{3\\.0 TO *})"
     )
   end
 

--- a/sunspot/spec/api/query/connectives_examples.rb
+++ b/sunspot/spec/api/query/connectives_examples.rb
@@ -195,7 +195,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '(_query_:"{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}" OR _query_:"{!geofilt sfield=coordinates_new_ll pt=42,56 d=50}")'
+      :fq, '(_query_:"{!geofilt sfield=coordinates_new_p pt=23,-46 d=100}" OR _query_:"{!geofilt sfield=coordinates_new_p pt=42,56 d=50}")'
     )
   end
   
@@ -207,7 +207,7 @@ shared_examples_for "query with connective scope" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '(coordinates_new_ll:[23,-46 TO 25,-44] OR coordinates_new_ll:[42,56 TO 43,58])'
+      :fq, '(coordinates_new_p:[23,-46 TO 25,-44] OR coordinates_new_p:[42,56 TO 43,58])'
     )
   end
 end

--- a/sunspot/spec/api/query/dynamic_fields_examples.rb
+++ b/sunspot/spec/api/query/dynamic_fields_examples.rb
@@ -5,7 +5,7 @@ shared_examples_for "query with dynamic field support" do
         with :test, 'string'
       end
     end
-    expect(connection).to have_last_search_including(:fq, 'custom_string\:test_ss:string')
+    expect(connection).to have_last_search_including(:fq, 'custom_string__test_ss:string')
   end
 
   it 'restricts by dynamic integer field with less than restriction' do
@@ -14,7 +14,7 @@ shared_examples_for "query with dynamic field support" do
         with(:test).less_than(1)
       end
     end
-    expect(connection).to have_last_search_including(:fq, 'custom_integer\:test_i:{* TO 1}')
+    expect(connection).to have_last_search_including(:fq, 'custom_integer__test_i:{* TO 1}')
   end
 
   it 'restricts by dynamic float field with between restriction' do
@@ -23,7 +23,7 @@ shared_examples_for "query with dynamic field support" do
         with(:test).between(2.2..3.3)
       end
     end
-    expect(connection).to have_last_search_including(:fq, 'custom_float\:test_fm:[2\.2 TO 3\.3]')
+    expect(connection).to have_last_search_including(:fq, 'custom_float__test_fm:[2\.2 TO 3\.3]')
   end
 
   it 'restricts by dynamic time field with any of restriction' do
@@ -33,7 +33,7 @@ shared_examples_for "query with dynamic field support" do
                             Time.parse('2009-02-13 18:00:00 UTC')])
       end
     end
-    expect(connection).to have_last_search_including(:fq, 'custom_time\:test_d:(2009\-02\-10T14\:00\:00Z OR 2009\-02\-13T18\:00\:00Z)')
+    expect(connection).to have_last_search_including(:fq, 'custom_time__test_dt:(2009\-02\-10T14\:00\:00Z OR 2009\-02\-13T18\:00\:00Z)')
   end
 
   it 'restricts by dynamic boolean field with equality restriction' do
@@ -42,7 +42,7 @@ shared_examples_for "query with dynamic field support" do
         with :test, false
       end
     end
-    expect(connection).to have_last_search_including(:fq, 'custom_boolean\:test_b:false')
+    expect(connection).to have_last_search_including(:fq, 'custom_boolean__test_b:false')
   end
 
   it 'negates a dynamic field restriction' do
@@ -51,7 +51,7 @@ shared_examples_for "query with dynamic field support" do
         without :test, 'foo'
       end
     end
-    expect(connection).to have_last_search_including(:fq, '-custom_string\:test_ss:foo')
+    expect(connection).to have_last_search_including(:fq, '-custom_string__test_ss:foo')
   end
 
   it 'scopes by a dynamic field inside a disjunction' do
@@ -64,7 +64,7 @@ shared_examples_for "query with dynamic field support" do
       end
     end
     expect(connection).to have_last_search_including(
-      :fq, '(custom_string\:test_ss:foo OR title_ss:bar)'
+      :fq, '(custom_string__test_ss:foo OR title_ss:bar)'
     )
   end
 
@@ -74,7 +74,7 @@ shared_examples_for "query with dynamic field support" do
         order_by :test, :desc
       end
     end
-    expect(connection).to have_last_search_with(:sort => 'custom_integer:test_i desc')
+    expect(connection).to have_last_search_with(:sort => 'custom_integer__test_i desc')
   end
 
   it 'orders by a dynamic field and static field, with given precedence' do
@@ -84,7 +84,7 @@ shared_examples_for "query with dynamic field support" do
       end
       order_by :sort_title, :asc
     end
-    expect(connection).to have_last_search_with(:sort => 'custom_integer:test_i desc, sort_title_s asc')
+    expect(connection).to have_last_search_with(:sort => 'custom_integer__test_i desc, sort_title_s asc')
   end
 
   it 'raises an UnrecognizedFieldError if an unknown dynamic field is searched by' do
@@ -111,7 +111,7 @@ shared_examples_for "query with dynamic field support" do
         facet(:test)
       end
     end
-    expect(connection).to have_last_search_including(:"facet.field", 'custom_string:test_ss')
+    expect(connection).to have_last_search_including(:"facet.field", 'custom_string__test_ss')
   end
 
   it 'requests named field facet on dynamic field' do
@@ -120,7 +120,7 @@ shared_examples_for "query with dynamic field support" do
         facet(:test, :name => :bogus)
       end
     end
-    expect(connection).to have_last_search_including(:"facet.field", '{!key=bogus}custom_string:test_ss')
+    expect(connection).to have_last_search_including(:"facet.field", '{!key=bogus}custom_string__test_ss')
   end
 
   it 'requests query facet with internal dynamic field' do
@@ -134,7 +134,7 @@ shared_examples_for "query with dynamic field support" do
       end
     end
     expect(connection).to have_last_search_with(
-      :"facet.query" => 'custom_string\:test_ss:foo'
+      :"facet.query" => 'custom_string__test_ss:foo'
     )
   end
 
@@ -150,7 +150,7 @@ shared_examples_for "query with dynamic field support" do
     end
     expect(connection).to have_last_search_including(
       :"facet.query",
-      'custom_string\:test_ss:foo'
+      'custom_string__test_ss:foo'
     )
   end
 
@@ -160,6 +160,6 @@ shared_examples_for "query with dynamic field support" do
         with(:test, 1.23)
       end
     end
-    expect(connection).to have_last_search_including(:fq, 'custom_float\\:test_fm:1\\.23')
+    expect(connection).to have_last_search_including(:fq, 'custom_float__test_fm:1\\.23')
   end
 end

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -220,14 +220,14 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :published_at
       end
-      expect(connection).not_to have_last_search_with(:"facet.date")
+      expect(connection).not_to have_last_search_with(:"facet.range")
     end
 
     it 'sets the facet to a date facet if time range is specified' do
       search do |query|
         query.facet :published_at, :time_range => @time_range
       end
-      expect(connection).to have_last_search_with(:"facet.date" => ['published_at_dt'])
+      expect(connection).to have_last_search_with(:"facet.range" => ['published_at_dt'])
     end
 
     it 'sets the facet start and end' do
@@ -235,8 +235,8 @@ shared_examples_for "facetable query" do
         query.facet :published_at, :time_range => @time_range
       end
       expect(connection).to have_last_search_with(
-        :"f.published_at_dt.facet.date.start" => '2009-06-01T04:00:00Z',
-        :"f.published_at_dt.facet.date.end" => '2009-07-01T04:00:00Z'
+        :"f.published_at_dt.facet.range.start" => '2009-06-01T04:00:00Z',
+        :"f.published_at_dt.facet.range.end" => '2009-07-01T04:00:00Z'
       )
     end
 
@@ -244,14 +244,14 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :published_at, :time_range => @time_range
       end
-      expect(connection).to have_last_search_with(:"f.published_at_dt.facet.date.gap" => "+86400SECONDS")
+      expect(connection).to have_last_search_with(:"f.published_at_dt.facet.range.gap" => "+86400SECONDS")
     end
 
     it 'uses custom time interval' do
       search do |query|
         query.facet :published_at, :time_range => @time_range, :time_interval => 3600
       end
-      expect(connection).to have_last_search_with(:"f.published_at_dt.facet.date.gap" => "+3600SECONDS")
+      expect(connection).to have_last_search_with(:"f.published_at_dt.facet.range.gap" => "+3600SECONDS")
     end
 
     it 'does not allow date faceting on a non-date field' do

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -122,12 +122,12 @@ shared_examples_for "facetable query" do
         end
       end
       if connection.searches.last.has_key?(:"mlt.fl")
-        filter_tag = get_filter_tag('_query_:"{!geofilt sfield=coordinates_new_ll pt=32,-68 d=1}"')
+        filter_tag = get_filter_tag('_query_:"{!geofilt sfield=coordinates_new_p pt=32,-68 d=1}"')
       else
-        filter_tag = get_filter_tag('{!geofilt sfield=coordinates_new_ll pt=32,-68 d=1}')
+        filter_tag = get_filter_tag('{!geofilt sfield=coordinates_new_p pt=32,-68 d=1}')
       end
       expect(connection).to have_last_search_with(
-        :"facet.query" => "{!ex=#{filter_tag}}_query_:\"{!geofilt sfield=coordinates_new_ll pt=32,-68 d=10}\""
+        :"facet.query" => "{!ex=#{filter_tag}}_query_:\"{!geofilt sfield=coordinates_new_p pt=32,-68 d=10}\""
       )
     end
 

--- a/sunspot/spec/api/query/faceting_examples.rb
+++ b/sunspot/spec/api/query/faceting_examples.rb
@@ -279,7 +279,7 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :average_rating, :range => @range
       end
-      expect(connection).to have_last_search_with(:"facet.range" => ['average_rating_ft'])
+      expect(connection).to have_last_search_with(:"facet.range" => ['average_rating_f'])
     end
 
     it 'sets the facet start and end' do
@@ -287,8 +287,8 @@ shared_examples_for "facetable query" do
         query.facet :average_rating, :range => @range
       end
       expect(connection).to have_last_search_with(
-        :"f.average_rating_ft.facet.range.start" => '2.0',
-        :"f.average_rating_ft.facet.range.end" => '4.0'
+        :"f.average_rating_f.facet.range.start" => '2.0',
+        :"f.average_rating_f.facet.range.end" => '4.0'
       )
     end
 
@@ -296,14 +296,14 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :average_rating, :range => @range
       end
-      expect(connection).to have_last_search_with(:"f.average_rating_ft.facet.range.gap" => "10")
+      expect(connection).to have_last_search_with(:"f.average_rating_f.facet.range.gap" => "10")
     end
 
     it 'uses custom range interval' do
       search do |query|
         query.facet :average_rating, :range => @range, :range_interval => 1
       end
-      expect(connection).to have_last_search_with(:"f.average_rating_ft.facet.range.gap" => "1")
+      expect(connection).to have_last_search_with(:"f.average_rating_f.facet.range.gap" => "1")
     end
 
     it 'tags and excludes a scope filter in a range facet' do
@@ -313,7 +313,7 @@ shared_examples_for "facetable query" do
       end
       filter_tag = get_filter_tag('blog_id_i:1')
       expect(connection).to have_last_search_with(
-        :"facet.range" => %W({!ex=#{filter_tag}}average_rating_ft)
+        :"facet.range" => %W({!ex=#{filter_tag}}average_rating_f)
       )
     end
 
@@ -321,7 +321,7 @@ shared_examples_for "facetable query" do
       search do |query|
         query.facet :average_rating, :range => @range, :include => :edge
       end
-      expect(connection).to have_last_search_with(:"f.average_rating_ft.facet.range.include" => "edge")
+      expect(connection).to have_last_search_with(:"f.average_rating_f.facet.range.include" => "edge")
     end
 
     it 'does not allow date faceting on a non-continuous field' do
@@ -353,7 +353,7 @@ shared_examples_for "facetable query" do
           end
         end
       end
-      expect(connection).to have_last_search_with(:"facet.query" => 'average_rating_ft:[4\.0 TO 5\.0]')
+      expect(connection).to have_last_search_with(:"facet.query" => 'average_rating_f:[4\.0 TO 5\.0]')
     end
 
     it 'requests multiple query facets' do
@@ -369,8 +369,8 @@ shared_examples_for "facetable query" do
       end
       expect(connection).to have_last_search_with(
         :"facet.query" => [
-          'average_rating_ft:[3\.0 TO 4\.0]',
-          'average_rating_ft:[4\.0 TO 5\.0]'
+          'average_rating_f:[3\.0 TO 4\.0]',
+          'average_rating_f:[4\.0 TO 5\.0]'
         ]
       )
     end

--- a/sunspot/spec/api/query/fulltext_examples.rb
+++ b/sunspot/spec/api/query/fulltext_examples.rb
@@ -236,7 +236,7 @@ shared_examples_for 'fulltext query' do
         end
       end
     end
-    expect(connection).to have_last_search_with(:bq => ['average_rating_ft:{2\.0 TO *}^2.0'])
+    expect(connection).to have_last_search_with(:bq => ['average_rating_f:{2\.0 TO *}^2.0'])
   end
 
   it 'creates multiple boost queries' do
@@ -252,7 +252,7 @@ shared_examples_for 'fulltext query' do
     end
     expect(connection).to have_last_search_with(
       :bq => [
-        'average_rating_ft:{2\.0 TO *}^2.0',
+        'average_rating_f:{2\.0 TO *}^2.0',
         'featured_bs:true^1.5'
       ]
     )

--- a/sunspot/spec/api/query/function_spec.rb
+++ b/sunspot/spec/api/query/function_spec.rb
@@ -7,7 +7,7 @@ describe 'function query' do
         boost(function { :average_rating })
       end
     end
-    expect(connection).to have_last_search_including(:bf, 'average_rating_ft')
+    expect(connection).to have_last_search_including(:bf, 'average_rating_f')
   end
 
   it "should send query to solr with boost function and boost amount" do
@@ -16,7 +16,7 @@ describe 'function query' do
         boost(function { :average_rating }^5)
       end
     end
-    expect(connection).to have_last_search_including(:bf, 'average_rating_ft^5')
+    expect(connection).to have_last_search_including(:bf, 'average_rating_f^5')
   end
 
   it "should handle boost function with constant float" do
@@ -52,7 +52,7 @@ describe 'function query' do
         boost(function { product(:average_rating, 10) })
       end
     end
-    expect(connection).to have_last_search_including(:bf, 'product(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:bf, 'product(average_rating_f,10)')
   end
 
   it "should handle the sub function in a function query block" do
@@ -61,7 +61,7 @@ describe 'function query' do
         boost(function { sub(:average_rating, 10) })
       end
     end
-    expect(connection).to have_last_search_including(:bf, 'sub(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:bf, 'sub(average_rating_f,10)')
   end
 
   it "should handle boost amounts on function query block" do
@@ -70,7 +70,7 @@ describe 'function query' do
         boost(function { sub(:average_rating, 10)^5 })
       end
     end
-    expect(connection).to have_last_search_including(:bf, 'sub(average_rating_ft,10)^5')
+    expect(connection).to have_last_search_including(:bf, 'sub(average_rating_f,10)^5')
   end
  
   it "should handle nested functions in a function query block" do
@@ -79,7 +79,7 @@ describe 'function query' do
         boost(function { product(:average_rating, sum(:average_rating, 20)) })
       end
     end
-    expect(connection).to have_last_search_including(:bf, 'product(average_rating_ft,sum(average_rating_ft,20))')
+    expect(connection).to have_last_search_including(:bf, 'product(average_rating_f,sum(average_rating_f,20))')
   end
 
   # TODO SOLR 1.5
@@ -109,7 +109,7 @@ describe 'function query' do
         multiplicative_boost(function { :average_rating })
       end
     end
-    expect(connection).to have_last_search_including(:boost, 'average_rating_ft')
+    expect(connection).to have_last_search_including(:boost, 'average_rating_f')
   end
 
   it "should send query to solr with multiplicative boost function and boost amount" do
@@ -118,7 +118,7 @@ describe 'function query' do
         multiplicative_boost(function { :average_rating }^5)
       end
     end
-    expect(connection).to have_last_search_including(:boost, 'average_rating_ft^5')
+    expect(connection).to have_last_search_including(:boost, 'average_rating_f^5')
   end
 
   it "should handle multiplicative boost function with constant float" do
@@ -154,7 +154,7 @@ describe 'function query' do
         multiplicative_boost(function { product(:average_rating, 10) })
       end
     end
-    expect(connection).to have_last_search_including(:boost, 'product(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:boost, 'product(average_rating_f,10)')
   end
 
   it "should handle the sub function in a multiplicative boost function query block" do
@@ -163,7 +163,7 @@ describe 'function query' do
         multiplicative_boost(function { sub(:average_rating, 10) })
       end
     end
-    expect(connection).to have_last_search_including(:boost, 'sub(average_rating_ft,10)')
+    expect(connection).to have_last_search_including(:boost, 'sub(average_rating_f,10)')
   end
 
   it "should handle boost amounts on multiplicative boost function query block" do
@@ -172,7 +172,7 @@ describe 'function query' do
         multiplicative_boost(function { sub(:average_rating, 10)^5 })
       end
     end
-    expect(connection).to have_last_search_including(:boost, 'sub(average_rating_ft,10)^5')
+    expect(connection).to have_last_search_including(:boost, 'sub(average_rating_f,10)^5')
   end
  
   it "should handle nested functions in a multiplicative boost function query block" do
@@ -181,7 +181,7 @@ describe 'function query' do
         multiplicative_boost(function { product(:average_rating, sum(:average_rating, 20)) })
       end
     end
-    expect(connection).to have_last_search_including(:boost, 'product(average_rating_ft,sum(average_rating_ft,20))')
+    expect(connection).to have_last_search_including(:boost, 'product(average_rating_f,sum(average_rating_f,20))')
   end
 
   # TODO SOLR 1.5

--- a/sunspot/spec/api/query/geo_examples.rb
+++ b/sunspot/spec/api/query/geo_examples.rb
@@ -10,7 +10,7 @@ shared_examples_for 'geohash query' do
 
   it 'searches for nearby points with non-Float arguments' do
     search do
-      with(:coordinates).near(BigDecimal.new('40.7'), BigDecimal.new('-73.5'))
+      with(:coordinates).near(BigDecimal('40.7'), BigDecimal('-73.5'))
     end
     expect(connection).to have_last_search_including(:q, build_geo_query)
   end

--- a/sunspot/spec/api/query/group_spec.rb
+++ b/sunspot/spec/api/query/group_spec.rb
@@ -27,7 +27,7 @@ describe "grouping" do
       end
     end
 
-    expect(connection).to have_last_search_including(:"group.sort", "average_rating_ft asc")
+    expect(connection).to have_last_search_including(:"group.sort", "average_rating_f asc")
   end
 
   it "sends grouping field parameters to solr" do

--- a/sunspot/spec/api/query/join_spec.rb
+++ b/sunspot/spec/api/query/join_spec.rb
@@ -14,6 +14,6 @@ describe 'join' do
       with(:photo_rating).greater_than(3)
     end
     expect(connection).to have_last_search_including(
-      :fq, "{!join from=photo_container_id_i to=id_i v='type:\"Photo\" AND average_rating_ft:{3\\.0 TO *}'}")
+      :fq, "{!join from=photo_container_id_i to=id_i v='type:\"Photo\" AND average_rating_f:{3\\.0 TO *}'}")
   end
 end

--- a/sunspot/spec/api/query/ordering_pagination_examples.rb
+++ b/sunspot/spec/api/query/ordering_pagination_examples.rb
@@ -64,7 +64,7 @@ shared_examples_for 'sortable query' do
     search do
       order_by :average_rating, :desc
     end
-    expect(connection).to have_last_search_with(:sort => 'average_rating_ft desc')
+    expect(connection).to have_last_search_with(:sort => 'average_rating_f desc')
   end
 
   it 'orders by multiple fields' do
@@ -72,7 +72,7 @@ shared_examples_for 'sortable query' do
       order_by :average_rating, :desc
       order_by :sort_title, :asc
     end
-    expect(connection).to have_last_search_with(:sort => 'average_rating_ft desc, sort_title_s asc')
+    expect(connection).to have_last_search_with(:sort => 'average_rating_f desc, sort_title_s asc')
   end
 
   it 'orders by random' do

--- a/sunspot/spec/api/query/ordering_pagination_examples.rb
+++ b/sunspot/spec/api/query/ordering_pagination_examples.rb
@@ -114,7 +114,7 @@ shared_examples_for 'sortable query' do
     search do
       order_by_geodist :coordinates_new, 32, -68, :desc
     end
-    expect(connection).to have_last_search_with(:sort => 'geodist(coordinates_new_ll,32,-68) desc')
+    expect(connection).to have_last_search_with(:sort => 'geodist(coordinates_new_p,32,-68) desc')
   end
 
   it 'throws an ArgumentError if a bogus order direction is given' do

--- a/sunspot/spec/api/query/ordering_pagination_examples.rb
+++ b/sunspot/spec/api/query/ordering_pagination_examples.rb
@@ -114,7 +114,7 @@ shared_examples_for 'sortable query' do
     search do
       order_by_geodist :coordinates_new, 32, -68, :desc
     end
-    expect(connection).to have_last_search_with(:sort => 'geodist(coordinates_new_p,32,-68) desc')
+    expect(connection).to have_last_search_with(:sfield => 'coordinates_new_p', :pt => '32,-68', :sort => 'geodist() desc')
   end
 
   it 'throws an ArgumentError if a bogus order direction is given' do

--- a/sunspot/spec/api/query/scope_examples.rb
+++ b/sunspot/spec/api/query/scope_examples.rb
@@ -46,7 +46,7 @@ shared_examples_for "scoped query" do
     search do
       with(:average_rating).less_than 3.0
     end
-    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:{* TO 3\.0}')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_f:{* TO 3\.0}')
   end
 
   it 'should quote string with space in a less than match' do
@@ -60,7 +60,7 @@ shared_examples_for "scoped query" do
     search do
       with(:average_rating).greater_than 3.0
     end
-    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:{3\.0 TO *}')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_f:{3\.0 TO *}')
   end
 
   it 'scopes by short-form between match with integers' do
@@ -74,7 +74,7 @@ shared_examples_for "scoped query" do
     search do
       with(:average_rating).between 2.0..4.0
     end
-    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:[2\.0 TO 4\.0]')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_f:[2\.0 TO 4\.0]')
   end
 
   it 'scopes by any match with integer' do
@@ -116,14 +116,14 @@ shared_examples_for "scoped query" do
     search do
       without(:average_rating).less_than 3.0
     end
-    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:{* TO 3\.0}')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_f:{* TO 3\.0}')
   end
 
   it 'scopes by not greater than match with float' do
     search do
       without(:average_rating).greater_than 3.0
     end
-    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:{3\.0 TO *}')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_f:{3\.0 TO *}')
   end
   
   it 'scopes by not between match with shorthand' do
@@ -137,7 +137,7 @@ shared_examples_for "scoped query" do
     search do
       without(:average_rating).between 2.0..4.0
     end
-    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:[2\.0 TO 4\.0]')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_f:[2\.0 TO 4\.0]')
   end
 
   it 'scopes by not any match with integer' do
@@ -158,14 +158,14 @@ shared_examples_for "scoped query" do
     search do
       with :average_rating, nil
     end
-    expect(connection).to have_last_search_including(:fq, '-average_rating_ft:[* TO *]')
+    expect(connection).to have_last_search_including(:fq, '-average_rating_f:[* TO *]')
   end
 
   it 'scopes by non-empty field' do
     search do
       without :average_rating, nil
     end
-    expect(connection).to have_last_search_including(:fq, 'average_rating_ft:[* TO *]')
+    expect(connection).to have_last_search_including(:fq, 'average_rating_f:[* TO *]')
   end
 
   it 'includes by object identity' do

--- a/sunspot/spec/api/query/scope_examples.rb
+++ b/sunspot/spec/api/query/scope_examples.rb
@@ -31,7 +31,7 @@ shared_examples_for "scoped query" do
     end
     expect(connection).to have_last_search_including(
       :fq,
-      'expire_date_d:1983\-07\-08T00\:00\:00Z'
+      'expire_date_dt:1983\-07\-08T00\:00\:00Z'
     )
   end
   

--- a/sunspot/spec/api/query/spatial_examples.rb
+++ b/sunspot/spec/api/query/spatial_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for "spatial query" do
       with(:coordinates_new).in_radius(23, -46, 100)
     end
 
-    expect(connection).to have_last_search_including(:fq, "{!geofilt sfield=coordinates_new_ll pt=23,-46 d=100}")
+    expect(connection).to have_last_search_including(:fq, "{!geofilt sfield=coordinates_new_p pt=23,-46 d=100}")
   end
 
   it 'filters by radius via bbox (inexact)' do
@@ -14,7 +14,7 @@ shared_examples_for "spatial query" do
       with(:coordinates_new).in_radius(23, -46, 100, :bbox => true)
     end
 
-    expect(connection).to have_last_search_including(:fq, "{!bbox sfield=coordinates_new_ll pt=23,-46 d=100}")
+    expect(connection).to have_last_search_including(:fq, "{!bbox sfield=coordinates_new_p pt=23,-46 d=100}")
   end
 
   it 'filters by bounding box' do
@@ -22,6 +22,6 @@ shared_examples_for "spatial query" do
       with(:coordinates_new).in_bounding_box([45, -94], [46, -93])
     end
 
-    expect(connection).to have_last_search_including(:fq, "coordinates_new_ll:[45,-94 TO 46,-93]")
+    expect(connection).to have_last_search_including(:fq, "coordinates_new_p:[45,-94 TO 46,-93]")
   end
 end

--- a/sunspot/spec/api/query/stats_examples.rb
+++ b/sunspot/spec/api/query/stats_examples.rb
@@ -15,14 +15,14 @@ shared_examples_for 'stats query' do
     search do
       stats :average_rating
     end
-    expect(connection).to have_last_search_with(:"stats.field" => %w{average_rating_ft})
+    expect(connection).to have_last_search_with(:"stats.field" => %w{average_rating_f})
   end
 
   it 'requests multiple field stats' do
     search do
       stats :average_rating, :published_at
     end
-    expect(connection).to have_last_search_with(:"stats.field" => %w{average_rating_ft published_at_dt})
+    expect(connection).to have_last_search_with(:"stats.field" => %w{average_rating_f published_at_dt})
   end
 
   it 'facets on a stats field' do
@@ -31,14 +31,14 @@ shared_examples_for 'stats query' do
         facet :featured
       end
     end
-    expect(connection).to have_last_search_with(:"f.average_rating_ft.stats.facet" => %w{featured_bs})
+    expect(connection).to have_last_search_with(:"f.average_rating_f.stats.facet" => %w{featured_bs})
   end
 
   it 'only facets on a stats field when requested' do
     search do
       stats :average_rating
     end
-    expect(connection).not_to have_last_search_with(:"f.average_rating_ft.stats.facet")
+    expect(connection).not_to have_last_search_with(:"f.average_rating_f.stats.facet")
   end
 
   it 'facets on multiple stats fields' do
@@ -48,7 +48,7 @@ shared_examples_for 'stats query' do
       end
     end
     expect(connection).to have_last_search_with(
-      :"f.average_rating_ft.stats.facet" => %w{featured_bs},
+      :"f.average_rating_f.stats.facet" => %w{featured_bs},
       :"f.published_at_dt.stats.facet" => %w{featured_bs}
     )
   end
@@ -60,7 +60,7 @@ shared_examples_for 'stats query' do
       end
     end
     expect(connection).to have_last_search_with(
-      :"f.average_rating_ft.stats.facet" => %w{featured_bs primary_category_id_i}
+      :"f.average_rating_f.stats.facet" => %w{featured_bs primary_category_id_i}
     )
   end
 end

--- a/sunspot/spec/api/search/dynamic_fields_spec.rb
+++ b/sunspot/spec/api/search/dynamic_fields_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'search with dynamic fields' do
   it 'returns dynamic string facet' do
-    stub_facet(:"custom_string:test_ss", 'two' => 2, 'one' => 1)
+    stub_facet(:"custom_string__test_ss", 'two' => 2, 'one' => 1)
     result = session.search(Post) { dynamic(:custom_string) { facet(:test) }}
     expect(result.facet(:custom_string, :test).rows.map { |row| row.value }).to eq(['two', 'one'])
   end
@@ -15,7 +15,7 @@ describe 'search with dynamic fields' do
 
   it 'returns query facet specified in dynamic call' do
     stub_query_facet(
-      'custom_string\:test_ss:(foo OR bar)' => 3
+      'custom_string__test_ss:(foo OR bar)' => 3
     )
     search = session.search(Post) do
       dynamic :custom_string do

--- a/sunspot/spec/api/search/faceting_spec.rb
+++ b/sunspot/spec/api/search/faceting_spec.rb
@@ -176,7 +176,7 @@ describe 'faceting', :type => :search do
   end
 
   it 'returns date range facet' do
-    stub_date_facet(:published_at_dt, 60*60*24, '2009-07-08T04:00:00Z' => 2, '2009-07-07T04:00:00Z' => 1)
+    stub_date_facet(:published_at_dt, 60*60*24, '2009-07-08T04:00:00Z', 2, '2009-07-07T04:00:00Z', 1)
     start_time = Time.utc(2009, 7, 7, 4)
     end_time = start_time + 2*24*60*60
     result = session.search(Post) { facet(:published_at, :time_range => start_time..end_time) }
@@ -186,7 +186,7 @@ describe 'faceting', :type => :search do
   end
 
   it 'returns date range facet sorted by count' do
-    stub_date_facet(:published_at_dt, 60*60*24, '2009-07-08T04:00:00Z' => 2, '2009-07-07T04:00:00Z' => 1)
+    stub_date_facet(:published_at_dt, 60*60*24, '2009-07-08T04:00:00Z', 2, '2009-07-07T04:00:00Z', 1)
     start_time = Time.utc(2009, 7, 7, 4)
     end_time = start_time + 2*24*60*60
     result = session.search(Post) { facet(:published_at, :time_range => start_time..end_time, :sort => :count) }

--- a/sunspot/spec/api/search/faceting_spec.rb
+++ b/sunspot/spec/api/search/faceting_spec.rb
@@ -53,7 +53,7 @@ describe 'faceting', :type => :search do
   end
 
   it 'returns float facet' do
-    stub_facet(:average_rating_ft, '9.3' => 2, '1.1' => 1)
+    stub_facet(:average_rating_f, '9.3' => 2, '1.1' => 1)
     result = session.search Post do
       facet :average_rating
     end
@@ -99,16 +99,8 @@ describe 'faceting', :type => :search do
     )
   end
 
-  it 'returns trie integer facet' do
-    stub_facet(:size_it, '3' => 2, '1' => 1)
-    result = session.search Photo do
-      facet :size
-    end
-    expect(facet_values(result, :size)).to eq([3, 1])
-  end
-
   it 'returns float facet' do
-    stub_facet(:average_rating_ft, '9.3' => 2, '1.1' => 1)
+    stub_facet(:average_rating_f, '9.3' => 2, '1.1' => 1)
     result = session.search Photo do
       facet :average_rating
     end
@@ -205,8 +197,8 @@ describe 'faceting', :type => :search do
 
   it 'returns query facet' do
     stub_query_facet(
-      'average_rating_ft:[3\.0 TO 5\.0]' => 3,
-      'average_rating_ft:[1\.0 TO 3\.0]' => 1
+      'average_rating_f:[3\.0 TO 5\.0]' => 3,
+      'average_rating_f:[1\.0 TO 3\.0]' => 1
     )
     search = session.search(Post) do
       facet :average_rating do
@@ -239,10 +231,10 @@ describe 'faceting', :type => :search do
 
     before :each do
       stub_query_facet(
-        'average_rating_ft:[1\.0 TO 2\.0]' => 2,
-        'average_rating_ft:[2\.0 TO 3\.0]' => 3,
-        'average_rating_ft:[3\.0 TO 4\.0]' => 1,
-        'average_rating_ft:[4\.0 TO 5\.0]' => 0
+        'average_rating_f:[1\.0 TO 2\.0]' => 2,
+        'average_rating_f:[2\.0 TO 3\.0]' => 3,
+        'average_rating_f:[3\.0 TO 4\.0]' => 1,
+        'average_rating_f:[4\.0 TO 5\.0]' => 0
       )
     end
 

--- a/sunspot/spec/api/search/faceting_spec.rb
+++ b/sunspot/spec/api/search/faceting_spec.rb
@@ -86,7 +86,7 @@ describe 'faceting', :type => :search do
 
   it 'returns date facet' do
     stub_facet(
-      :expire_date_d,
+      :expire_date_dt,
       '2009-07-13T00:00:00Z' => 3,
       '2009-04-01T00:00:00Z' => 1
     )

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -144,7 +144,7 @@ describe 'hits', :type => :search do
   end
 
   it 'should return stored dynamic fields' do
-    stub_full_results('instance' => Post.new, 'custom_string:test_ss' => 'Custom')
+    stub_full_results('instance' => Post.new, 'custom_string__test_ss' => 'Custom')
     expect(session.search(Post, Namespaced::Comment).hits.first.stored(:custom_string, :test)).to eq('Custom')
   end
 

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -150,7 +150,7 @@ describe 'hits', :type => :search do
 
   it 'should typecast stored field values in hits' do
     time = Time.utc(2008, 7, 8, 2, 45)
-    stub_full_results('instance' => Post.new, 'last_indexed_at_ds' => time.xmlschema)
+    stub_full_results('instance' => Post.new, 'last_indexed_at_dts' => time.xmlschema)
     expect(session.search(Post).hits.first.stored(:last_indexed_at)).to eq(time)
   end
 

--- a/sunspot/spec/api/search/stats_spec.rb
+++ b/sunspot/spec/api/search/stats_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe 'stats', :type => :search do
   it 'returns field name for stats field' do
-    stub_stats(:average_rating_ft, {})
+    stub_stats(:average_rating_f, {})
     result = session.search Post do
       stats :average_rating
     end
@@ -10,7 +10,7 @@ describe 'stats', :type => :search do
   end
 
   it 'returns min for stats field' do
-    stub_stats(:average_rating_ft, { 'min' => 1.0 })
+    stub_stats(:average_rating_f, { 'min' => 1.0 })
     result = session.search Post do
       stats :average_rating
     end
@@ -18,7 +18,7 @@ describe 'stats', :type => :search do
   end
 
   it 'returns max for stats field' do
-    stub_stats(:average_rating_ft, { 'max' => 5.0 })
+    stub_stats(:average_rating_f, { 'max' => 5.0 })
     result = session.search Post do
       stats :average_rating
     end
@@ -26,7 +26,7 @@ describe 'stats', :type => :search do
   end
 
   it 'returns count for stats field' do
-    stub_stats(:average_rating_ft, { 'count' => 120 })
+    stub_stats(:average_rating_f, { 'count' => 120 })
     result = session.search Post do
       stats :average_rating
     end
@@ -34,7 +34,7 @@ describe 'stats', :type => :search do
   end
 
   it 'returns sum for stats field' do
-    stub_stats(:average_rating_ft, { 'sum' => 2200.0 })
+    stub_stats(:average_rating_f, { 'sum' => 2200.0 })
     result = session.search Post do
       stats :average_rating
     end
@@ -42,7 +42,7 @@ describe 'stats', :type => :search do
   end
 
   it 'returns facet rows for stats field' do
-    stub_stats_facets(:average_rating_ft, 'featured_bs' => {
+    stub_stats_facets(:average_rating_f, 'featured_bs' => {
       'false' => {},
       'true' => {}
     })
@@ -55,7 +55,7 @@ describe 'stats', :type => :search do
   end
 
   it 'returns facet stats for stats field' do
-    stub_stats_facets(:average_rating_ft, 'featured_bs' => {
+    stub_stats_facets(:average_rating_f, 'featured_bs' => {
       'true' => { 'min' => 2.0, 'max' => 4.0 }
     })
     result = session.search Post do
@@ -69,7 +69,7 @@ describe 'stats', :type => :search do
 
   it 'returns instantiated stats facet values' do
     blogs = 2.times.map { Blog.new }
-    stub_stats_facets(:average_rating_ft, 'blog_id_i' => {
+    stub_stats_facets(:average_rating_f, 'blog_id_i' => {
       blogs[0].id.to_s => {}, blogs[1].id.to_s => {} })
     search = session.search(Post) do
       stats :average_rating do
@@ -81,7 +81,7 @@ describe 'stats', :type => :search do
 
   it 'only returns verified instances when requested' do
     blog = Blog.new
-    stub_stats_facets(:average_rating_ft, 'blog_id_i' => {
+    stub_stats_facets(:average_rating_f, 'blog_id_i' => {
       blog.id.to_s => {}, '0' => {} })
 
     search = session.search(Post) do

--- a/sunspot/spec/helpers/search_helper.rb
+++ b/sunspot/spec/helpers/search_helper.rb
@@ -44,11 +44,11 @@ module SearchHelper
     }
   end
 
-  def stub_date_facet(name, gap, values)
+  def stub_date_facet(name, gap, *values)
     connection.response = {
       'facet_counts' => {
-        'facet_dates' => {
-          name.to_s => { 'gap' => "+#{gap}SECONDS" }.merge(values)
+        'facet_ranges' => {
+          name.to_s => { 'gap' => "+#{gap}SECONDS", 'counts' => values }
         }
       }
     }

--- a/sunspot/spec/integration/faceting_spec.rb
+++ b/sunspot/spec/integration/faceting_spec.rb
@@ -44,7 +44,6 @@ describe 'search faceting' do
   test_field_type('Float', :ratings_average, :average_rating, 2.2, 1.1)
   test_field_type('Time', :published_at, :published_at, Time.mktime(2008, 02, 17, 17, 45, 04),
                                                         Time.mktime(2008, 07, 02, 03, 56, 22))
-  test_field_type('Trie Integer', :size, :size, Photo, 3, 4)
   test_field_type('Float', :average_rating, :average_rating, Photo, 2.2, 1.1)
   test_field_type('Time', :created_at, :created_at, Photo, Time.mktime(2008, 02, 17, 17, 45, 04),
                                                            Time.mktime(2008, 07, 02, 03, 56, 22))

--- a/sunspot/spec/integration/scoped_search_spec.rb
+++ b/sunspot/spec/integration/scoped_search_spec.rb
@@ -122,10 +122,6 @@ describe 'scoped_search' do
   test_field_type 'Double', :average_rating, :average_rating, Namespaced::Comment, -2.5, 0.0, 3.2, 3.5, 16.0
   test_field_type 'Time', :published_at, :published_at, *(['1970-01-01 00:00:00 UTC', '1983-07-08 04:00:00 UTC', '1983-07-08 02:00:00 -0500',
                                                            '2005-11-05 10:00:00 UTC', Time.now.to_s].map { |t| Time.parse(t) })
-  test_field_type 'Trie Integer', :size, :size, Photo, -2, 0, 3, 12, 20
-  test_field_type 'Trie Float', :average_rating, :average_rating, Photo, -2.5, 0.0, 3.2, 3.5, 16.0
-  test_field_type 'Trie Time', :created_at, :created_at, Photo, *(['1970-01-01 00:00:00 UTC', '1983-07-08 04:00:00 UTC', '1983-07-08 02:00:00 -0500',
-                                                                   '2005-11-05 10:00:00 UTC', Time.now.to_s].map { |t| Time.parse(t) })
   describe 'Date range field type' do
     let(:date_ranges) do
       {

--- a/sunspot/spec/mocks/comment.rb
+++ b/sunspot/spec/mocks/comment.rb
@@ -13,7 +13,7 @@ end
 Sunspot.setup(Namespaced::Comment) do
   text :body, :author_name
   string :author_name
-  time :published_at, :trie => true
+  time :published_at
   long :hash
   double :average_rating
   dynamic_float :custom_float, :multiple => true

--- a/sunspot/spec/mocks/photo.rb
+++ b/sunspot/spec/mocks/photo.rb
@@ -9,9 +9,9 @@ Sunspot.setup(Photo) do
   integer :photo_container_id
   boolean :published
   boost 0.75
-  integer :size, :trie => true
-  float :average_rating, :trie => true
-  time :created_at, :trie => true
+  integer :size
+  float :average_rating
+  time :created_at
 end
 
 class Picture < MockRecord
@@ -37,7 +37,7 @@ Sunspot.setup(PhotoContainer) do
   text :description, :default_boost => 1.2
 
   join(:caption,      :target => 'Photo',   :type => :string,     :join => { :from => :photo_container_id, :to => :id })
-  join(:photo_rating, :target => 'Photo',   :type => :trie_float, :join => { :from => :photo_container_id, :to => :id }, :as => 'average_rating_ft')
+  join(:photo_rating, :target => 'Photo',   :type => :float,      :join => { :from => :photo_container_id, :to => :id }, :as => 'average_rating_f')
   join(:caption,      :target => 'Photo',   :type => :text,       :join => { :from => :photo_container_id, :to => :id })
   join(:description,  :target => 'Photo',   :type => :text,       :join => { :from => :photo_container_id, :to => :id }, :prefix => "photo")
   join(:published,    :target => 'Photo',   :type => :boolean,    :join => { :from => :photo_container_id, :to => :id }, :prefix => "photo")

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -67,7 +67,7 @@ Sunspot.setup(Post) do
   latlon(:coordinates_new) { coordinates }
 
   dynamic_string :custom_string, :stored => true
-  dynamic_string :custom_underscored_string, separator: '__'
+  dynamic_string :custom_underscored_string, separator: '___'
   dynamic_float :custom_float, :multiple => true, :using => :custom_fl
   dynamic_integer :custom_integer do
     category_ids.inject({}) do |hash, category_id|

--- a/sunspot/spec/mocks/post.rb
+++ b/sunspot/spec/mocks/post.rb
@@ -49,8 +49,8 @@ Sunspot.setup(Post) do
   string :author_name
   integer :blog_id, :references => Blog
   integer :category_ids, :multiple => true
-  float :average_rating, :using => :ratings_average, :trie => true
-  time :published_at, :trie => true
+  float :average_rating, :using => :ratings_average
+  time :published_at
   date :expire_date
   date_range :featured_for
   boolean :featured, :using => :featured?, :stored => true


### PR DESCRIPTION
This PR aims at updating the Sunspot library for recent Solr 8 versions (8.6), dropping support for now-deprecated types and syntaxes (read: this PR is not maintaining compatibility to previous Solr versions).
As the maintainer once mentioned, these compatibility changes might be best contained in a version 3 of Sunspot.

- [ ] use default managed-schema and solrconfig.xml from Solr 8 as base for recent configuration
  - [X] use dynamicField extension names from default schema (e.g. _d for Double instead of _e)
  - [ ] add new types (UUID, Currency)
- [X] remove deprecated Trie types (replace with normal types)
- [X] migrate spatial queries from LatLonType to LatLonPointSpatialField
- [ ] get all tests in sunspot folder to run with Solr 8.6
