### PR TITLE
fix highlight field_name issue

### DIFF
--- a/sunspot/lib/sunspot/search/hit.rb
+++ b/sunspot/lib/sunspot/search/hit.rb
@@ -1,6 +1,6 @@
 module Sunspot
   module Search
-    # 
+    #
     # Hit objects represent the raw information returned by Solr for a single
     # document. As well as the primary key and class name, hit objects give
     # access to stored field values, keyword relevance score, and keyword
@@ -9,11 +9,11 @@ module Sunspot
     class Hit
       SPECIAL_KEYS = Set.new(%w(id type score)) #:nodoc:
 
-      # 
+      #
       # Primary key of object associated with this hit, as string.
       #
       attr_reader :primary_key
-      # 
+      #
       # Class name of object associated with this hit, as string.
       #
       attr_reader :class_name
@@ -21,7 +21,7 @@ module Sunspot
       # ID prefix used for compositeId shard router
       #
       attr_reader :id_prefix
-      # 
+      #
       # Keyword relevance score associated with this result. Nil if this hit
       # is not from a keyword search.
       #
@@ -39,14 +39,14 @@ module Sunspot
         @stored_cache = {}
         @highlights = highlights
       end
-      
+
       #
       # Returns all highlights for this hit when called without parameters.
       # When a field_name is provided, returns only the highlight for this field.
       #
       def highlights(field_name = nil)
         if field_name.nil?
-          highlights_cache.values.flatten 
+          highlights_cache.values.flatten
         else
           highlights_cache[field_name.to_sym]
         end || []
@@ -60,7 +60,7 @@ module Sunspot
         highlights(field_name).first
       end
 
-      # 
+      #
       # Retrieve stored field value. For any attribute field configured with
       # :stored => true, the Hit object will contain the stored value for
       # that field. The value of this field will be typecast according to the
@@ -85,7 +85,7 @@ module Sunspot
         @stored_cache[field_key] = stored_value(field_name, dynamic_field_name)
       end
 
-      # 
+      #
       # Retrieve the instance associated with this hit. This is lazy-loaded, but
       # the first time it is called on any hit, all the hits for the search will
       # load their instances using the adapter's #load_all method.
@@ -127,7 +127,8 @@ module Sunspot
             cache = {}
             if @highlights
               @highlights.each_pair do |indexed_field_name, highlight_strings|
-                field_name = indexed_field_name.sub(/_[a-z]+$/, '').to_sym
+                field_name = setup.field_name(indexed_field_name).to_sym
+
                 cache[field_name] = highlight_strings.map do |highlight_string|
                   Highlight.new(field_name, highlight_string)
                 end

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -1,5 +1,5 @@
 module Sunspot
-  # 
+  #
   # This class encapsulates the search/indexing setup for a given class. Its
   # contents are built using the Sunspot.setup method.
   #
@@ -23,7 +23,7 @@ module Sunspot
       [@class_name]
     end
 
-    # 
+    #
     # Add field factory for scope/ordering
     #
     def add_field_factory(name, type, options = {}, &block)
@@ -50,7 +50,7 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # Add field_factories for fulltext search
     #
     # ==== Parameters
@@ -75,9 +75,9 @@ module Sunspot
     # Add dynamic field_factories
     #
     # ==== Parameters
-    # 
+    #
     # field_factories<Array>:: Array of dynamic field objects
-    # 
+    #
     def add_dynamic_field_factory(name, type, options = {}, &block)
       stored, more_like_this = options[:stored], options[:more_like_this]
       field_factory = FieldFactory::Dynamic.new(name, type, options, &block)
@@ -92,7 +92,7 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # Add a document boost to documents at index time. Document boost can be
     # static (the same for all documents of this class), or extracted on a per-
     # document basis using either attribute or block extraction as per usual.
@@ -128,14 +128,23 @@ module Sunspot
         end
     end
 
-    # 
+    #
     # Builder method for evaluating the setup DSL
     #
     def setup(&block)
       Util.instance_eval_or_call(@dsl, &block)
     end
 
-    # 
+    #
+    # Return field name with given index name
+    #
+    def field_name(indexed_field_name)
+      all_field_factories.find do |field_factory|
+        field_factory.build.indexed_name.to_sym == indexed_field_name.to_sym
+      end.name
+    end
+
+    #
     # Return the Field with the given (public-facing) name
     #
     def field(field_name)
@@ -149,13 +158,13 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # Return one or more text fields with the given public-facing name. This
     # implementation will always return a single field (in an array), but
     # CompositeSetup objects might return more than one.
     #
     def text_fields(field_name)
-      text_field = 
+      text_field =
         if field_factory = @text_field_factories_cache[field_name.to_sym]
           field_factory.build
         else
@@ -191,7 +200,7 @@ module Sunspot
       end
     end
 
-    # 
+    #
     # Return the DynamicFieldFactory with the given base name
     #
     def dynamic_field_factory(field_name)
@@ -201,30 +210,30 @@ module Sunspot
       )
     end
 
-    # 
+    #
     # Return all attribute fields
     #
     def fields
       field_factories.map { |field_factory| field_factory.build }
     end
 
-    # 
+    #
     # Return all text fields
     #
     def all_text_fields
       text_field_factories.map { |text_field_factory| text_field_factory.build }
     end
 
-    # 
+    #
     # Return all more_like_this fields
     #
     def all_more_like_this_fields
-      @more_like_this_field_factories_cache.values.map do |field_factories| 
+      @more_like_this_field_factories_cache.values.map do |field_factories|
         field_factories.map { |field_factory| field_factory.build }
       end.flatten
     end
 
-    # 
+    #
     # Get the field_factories associated with this setup as well as all inherited field_factories
     #
     # ==== Returns
@@ -235,7 +244,7 @@ module Sunspot
       collection_from_inheritable_hash(:field_factories)
     end
 
-    # 
+    #
     # Get the text field_factories associated with this setup as well as all inherited
     # text field_factories
     #
@@ -247,7 +256,7 @@ module Sunspot
       collection_from_inheritable_hash(:text_field_factories)
     end
 
-    # 
+    #
     # Get all static, dynamic, and text field_factories associated with this setup as
     # well as all inherited field_factories
     #
@@ -261,9 +270,9 @@ module Sunspot
       all_field_factories
     end
 
-    # 
+    #
     # Get all dynamic field_factories for this and parent setups
-    # 
+    #
     # ==== Returns
     #
     # Array:: Dynamic field_factories
@@ -272,7 +281,7 @@ module Sunspot
       collection_from_inheritable_hash(:dynamic_field_factories)
     end
 
-    # 
+    #
     # Return the class associated with this setup.
     #
     # ==== Returns
@@ -283,7 +292,7 @@ module Sunspot
       Util.full_const_get(@class_name)
     end
 
-    # 
+    #
     # Get the document boost for a given model
     #
     def document_boost_for(model)
@@ -342,11 +351,11 @@ module Sunspot
 
     protected
 
-    # 
+    #
     # Get the nearest inherited setup, if any
     #
     # ==== Returns
-    # 
+    #
     # Sunspot::Setup:: Setup for the nearest ancestor of this setup's class
     #
     def parent
@@ -368,7 +377,7 @@ module Sunspot
     end
 
     class <<self
-      # 
+      #
       # Retrieve or create the Setup instance for the given class, evaluating
       # the given block to add to the setup's configuration
       #
@@ -376,7 +385,7 @@ module Sunspot
         self.for!(clazz).setup(&block)
       end
 
-      # 
+      #
       # Retrieve the setup instance for the given class, or for the nearest
       # ancestor that has a setup, if any.
       #
@@ -388,14 +397,14 @@ module Sunspot
       #
       # Sunspot::Setup::
       #   Setup instance associated with the given class or its nearest ancestor
-      #   
+      #
       def for(clazz) #:nodoc:
         setups[clazz.name.to_sym] || self.for(clazz.superclass) if clazz
       end
 
       protected
 
-      # 
+      #
       # Retrieve or create a Setup instance for this class
       #
       # ==== Parameters


### PR DESCRIPTION
Found related issue #431. currently highlight might getting wrong field name in the following situations:
* multiple "_" character in dynamic field suffix
* dynamic fields using prefix match