### PR TITLE
Update Formatting of Eager Loading Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,9 +1566,11 @@ end
 
 If you want to do eager loading on your sunspot search all you have to do is add this:
 
+```ruby
 Sunspot.search Post do
   data_accessor_for(Post).include = [:comment]
 end
+```
 
 This is as long as you have the relationship in the model as a has_many etc.
 


### PR DESCRIPTION
The example for how to use eager loading was a little hard to read in the README since it was in plain text.  This PR makes it a bit easier by formatting it in Ruby syntax.