### PR TITLE
Update link to API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ objects such as the filesystem.
 
 This README provides a high level overview; class-by-class and
 method-by-method documentation is available in the [API
-reference](http://sunspot.github.com/sunspot/docs/).
+reference](http://sunspot.github.io/sunspot/docs/).
 
 For questions about how to use Sunspot in your app, please use the
 [Sunspot Mailing List](http://groups.google.com/group/ruby-sunspot) or search


### PR DESCRIPTION
The current link to the API documentation goes to `github.com`. The functioning link uses `github.io`.