### PR TITLE
Allow using methods with keyword arguments in search DSL with Ruby > 3

### DIFF
--- a/sunspot/lib/sunspot/util.rb
+++ b/sunspot/lib/sunspot/util.rb
@@ -248,7 +248,7 @@ module Sunspot
     Coordinates = Struct.new(:lat, :lng)
 
     class ContextBoundDelegate
-      class <<self
+      class << self
         def instance_eval_with_context(receiver, &block)
           calling_context = eval('self', block.binding)
           if parent_calling_context = calling_context.instance_eval{@__calling_context__ if defined?(@__calling_context__)}
@@ -289,18 +289,38 @@ module Sunspot
         __proxy_method__(:sub, *args, &block)
       end
 
-      def method_missing(method, *args, &block)
-        __proxy_method__(method, *args, &block)
-      end
+      if RUBY_VERSION >= '3.0'
+        def method_missing(method, *args, **kwargs, &block)
+          __proxy_method__(method, *args, **kwargs, &block)
+        end
 
-      def __proxy_method__(method, *args, &block)
-        begin
-          @__receiver__.__send__(method.to_sym, *args, &block)
+        def respond_to_missing?(method, _)
+          @__receiver__.respond_to?(method, true) || super
+        end
+
+        def __proxy_method__(method, *args, **kwargs, &block)
+          @__receiver__.__send__(method.to_sym, *args, **kwargs, &block)
         rescue ::NoMethodError => e
           begin
-            @__calling_context__.__send__(method.to_sym, *args, &block)
+            @__calling_context__.__send__(method.to_sym, *args, **kwargs, &block)
           rescue ::NoMethodError
             raise(e)
+          end
+        end
+      else
+        def method_missing(method, *args, &block)
+          __proxy_method__(method, *args, &block)
+        end
+
+        def __proxy_method__(method, *args, &block)
+          begin
+            @__receiver__.__send__(method.to_sym, *args, &block)
+          rescue ::NoMethodError => e
+            begin
+              @__calling_context__.__send__(method.to_sym, *args, &block)
+            rescue ::NoMethodError
+              raise(e)
+            end
           end
         end
       end

--- a/sunspot/lib/sunspot/util.rb
+++ b/sunspot/lib/sunspot/util.rb
@@ -289,39 +289,21 @@ module Sunspot
         __proxy_method__(:sub, *args, &block)
       end
 
-      if RUBY_VERSION >= '3.0'
-        def method_missing(method, *args, **kwargs, &block)
-          __proxy_method__(method, *args, **kwargs, &block)
-        end
+      def method_missing(method, *args, **kwargs, &block)
+        __proxy_method__(method, *args, **kwargs, &block)
+      end
 
-        def respond_to_missing?(method, _)
-          @__receiver__.respond_to?(method, true) || super
-        end
+      def respond_to_missing?(method, _)
+        @__receiver__.respond_to?(method, true) || super
+      end
 
-        def __proxy_method__(method, *args, **kwargs, &block)
-          @__receiver__.__send__(method.to_sym, *args, **kwargs, &block)
-        rescue ::NoMethodError => e
-          begin
-            @__calling_context__.__send__(method.to_sym, *args, **kwargs, &block)
-          rescue ::NoMethodError
-            raise(e)
-          end
-        end
-      else
-        def method_missing(method, *args, &block)
-          __proxy_method__(method, *args, &block)
-        end
-
-        def __proxy_method__(method, *args, &block)
-          begin
-            @__receiver__.__send__(method.to_sym, *args, &block)
-          rescue ::NoMethodError => e
-            begin
-              @__calling_context__.__send__(method.to_sym, *args, &block)
-            rescue ::NoMethodError
-              raise(e)
-            end
-          end
+      def __proxy_method__(method, *args, **kwargs, &block)
+        @__receiver__.__send__(method.to_sym, *args, **kwargs, &block)
+      rescue ::NoMethodError => e
+        begin
+          @__calling_context__.__send__(method.to_sym, *args, **kwargs, &block)
+        rescue ::NoMethodError
+          raise(e)
         end
       end
     end

--- a/sunspot/spec/api/binding_spec.rb
+++ b/sunspot/spec/api/binding_spec.rb
@@ -36,6 +36,17 @@ describe "DSL bindings" do
         end
       end
     end
+    expect(value).to eq('value')
+  end
+
+  it 'should give access to calling context\'s methods with keyword arguments' do
+    value = nil
+    session.search(Post) do
+      any_of do
+        value = kwargs_method(a: 10, b: 20)
+      end
+    end
+    expect(value).to eq({ a: 10, b: 20 })
   end
 
   private
@@ -46,5 +57,9 @@ describe "DSL bindings" do
 
   def id
     16
+  end
+
+  def kwargs_method(a:, b:)
+    { a: a, b: b }
   end
 end


### PR DESCRIPTION
Example:
```rb
# ruby 3.2
def kwargs_method(first:, second:)
  [first, second]
end

Sunspot.search(Post) do
  with :some_field, kwargs_method(first: 1, second: 2) # with :some_field, [1,2]
end
```