### PR TITLE
wip

### DIFF
--- a/sunspot/lib/sunspot/configuration.rb
+++ b/sunspot/lib/sunspot/configuration.rb
@@ -23,6 +23,7 @@ module Sunspot
         LightConfig.build do
           solr do
             url 'http://127.0.0.1:8983/solr/default'
+            timeout nil
             read_timeout nil
             open_timeout nil
             proxy nil

--- a/sunspot/lib/sunspot/session.rb
+++ b/sunspot/lib/sunspot/session.rb
@@ -256,6 +256,7 @@ module Sunspot
     def connection
       @connection ||= self.class.connection_class.connect(
         url: config.solr.url,
+        timeout: config.solr.timeout,
         read_timeout: config.solr.read_timeout,
         open_timeout: config.solr.open_timeout,
         proxy: config.solr.proxy,

--- a/sunspot/spec/api/session_spec.rb
+++ b/sunspot/spec/api/session_spec.rb
@@ -107,6 +107,12 @@ describe 'Session' do
     end
 
     it 'should open a connection with custom read timeout' do
+      Sunspot.config.solr.timeout = 0.5
+      Sunspot.commit
+      expect(connection.opts[:timeout]).to eq(0.5)
+    end
+
+    it 'should open a connection with custom read timeout' do
       Sunspot.config.solr.read_timeout = 0.5
       Sunspot.commit
       expect(connection.opts[:read_timeout]).to eq(0.5)

--- a/sunspot_rails/generators/sunspot/templates/sunspot.yml
+++ b/sunspot_rails/generators/sunspot/templates/sunspot.yml
@@ -4,7 +4,7 @@ production:
     port: 8983
     log_level: WARNING
     path: /solr/production
-    read_timeout: 20
+    timeout: 20
     open_timeout: 1
   auto_index_callback: after_commit
   auto_remove_callback: after_commit

--- a/sunspot_rails/lib/generators/sunspot_rails/install/templates/config/sunspot.yml
+++ b/sunspot_rails/lib/generators/sunspot_rails/install/templates/config/sunspot.yml
@@ -4,7 +4,7 @@ production:
     port: 8983
     log_level: WARNING
     path: /solr/production
-    # read_timeout: 2
+    # timeout: 2
     # open_timeout: 0.5
 
 development:

--- a/sunspot_rails/lib/sunspot/rails.rb
+++ b/sunspot_rails/lib/sunspot/rails.rb
@@ -50,6 +50,7 @@ module Sunspot #:nodoc:
           :path => sunspot_rails_configuration.master_path,
           :userinfo => sunspot_rails_configuration.userinfo
         ).to_s
+        config.solr.timeout = sunspot_rails_configuration.timeout
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy
@@ -66,6 +67,7 @@ module Sunspot #:nodoc:
           :path => sunspot_rails_configuration.path,
           :userinfo => sunspot_rails_configuration.userinfo
         ).to_s
+        config.solr.timeout = sunspot_rails_configuration.timeout
         config.solr.read_timeout = sunspot_rails_configuration.read_timeout
         config.solr.open_timeout = sunspot_rails_configuration.open_timeout
         config.solr.proxy = sunspot_rails_configuration.proxy

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -23,7 +23,7 @@ module Sunspot #:nodoc:
     #       port: 8983
     #       log_level: OFF
     #       open_timeout: 0.5
-    #       read_timeout: 2
+    #       timeout: 2
     #       proxy: false
     #   production:
     #     solr:
@@ -36,7 +36,7 @@ module Sunspot #:nodoc:
     #       log_level: WARNING
     #       solr_home: /some/path
     #       open_timeout: 0.5
-    #       read_timeout: 2
+    #       timeout: 2
     #       proxy: http://proxy.com:12345
     #     master_solr:
     #       hostname: localhost
@@ -293,7 +293,14 @@ module Sunspot #:nodoc:
         @bind_address ||= user_configuration_from_key('solr', 'bind_address')
       end
 
+      def timeout
+        @timeout ||= user_configuration_from_key('solr', 'timeout')
+      end
+
       def read_timeout
+        if user_configuration_from_key('solr', 'read_timeout')
+          warn "DEPRECATION: Rsolr.new/connect option `read_timeout` is deprecated and will be removed in Rsolr 3. `timeout` is currently a synonym, use that instead."
+        end
         @read_timeout ||= user_configuration_from_key('solr', 'read_timeout')
       end
 

--- a/sunspot_rails/spec/configuration_spec.rb
+++ b/sunspot_rails/spec/configuration_spec.rb
@@ -50,6 +50,10 @@ describe Sunspot::Rails::Configuration, "default values without a sunspot.yml" d
   end
 
   it "should set the read timeout to nil when not set" do
+    expect(@config.timeout).to be_nil
+  end
+
+  it "should set the read timeout to nil when not set" do
     expect(@config.read_timeout).to be_nil
   end
 
@@ -157,6 +161,10 @@ describe Sunspot::Rails::Configuration, "user provided sunspot.yml" do
 
   it "should handle the 'bind_address' property when set" do
     expect(@config.bind_address).to eq("127.0.0.1")
+  end
+
+  it "should handle the 'timeout' property when set" do
+    expect(@config.timeout).to eq(2)
   end
 
   it "should handle the 'read_timeout' property when set" do

--- a/sunspot_rails/spec/rails_app/config/sunspot.yml
+++ b/sunspot_rails/spec/rails_app/config/sunspot.yml
@@ -21,6 +21,7 @@ config_test:
     pid_dir: /my_superior_path/pids
     solr_home: /my_superior_path
     bind_address: 127.0.0.1
+    timeout: 2
     read_timeout: 2
     open_timeout: 0.5
     update_format: json


### PR DESCRIPTION
## メモ

- read_timeout を内部で使ったままにする理由
  - rsolr3で timeout を優先して使う実装になっているため。
  - また、その実装を sunspot 側で実装しようとすると、テストが複雑になる
    - テストが複雑になる理由は、現状１つのconfigを読み込む設定になっているが、 read_timeout より timeout を優先するテストを書こうとすると、設定ファイルを２つ読み込む必要が出てくるため。
    - deprecated -> 廃止 な時に、既存の実装をいじらず消せる（優先する処理をいじらなくて済むため）
