### PR TITLE
fix - WARNING: Using the 'raise_error' matcher without providing a sp…

### DIFF
--- a/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/master_slave_session_proxy_spec.rb
@@ -38,7 +38,7 @@ describe Sunspot::SessionProxy::MasterSlaveSessionProxy do
   end
 
   it 'should raise ArgumentError when bogus config specified' do
-    expect { @proxy.config(:bogus) }.to raise_error
+    expect { @proxy.config(:bogus) }.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'session proxy'

--- a/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('spec_helper', File.dirname(__FILE__))
 
 describe Sunspot::SessionProxy::Retry5xxSessionProxy do
-  
+
   before :each do
     Sunspot::Session.connection_class = Mock::ConnectionFactory.new
     @sunspot_session = Sunspot.session
@@ -70,12 +70,12 @@ describe Sunspot::SessionProxy::Retry5xxSessionProxy do
   it "should not retry a 4xx" do
     e = FakeRSolrErrorHttp.new(fake_rsolr_request, fake_rsolr_response(400))
     expect(@sunspot_session).to receive(:index).and_raise(e)
-    expect { Sunspot.index(post) }.to raise_error
+    expect { Sunspot.index(post) }.to raise_error(FakeRSolrErrorHttp)
   end
 
   # TODO: try against more than just Sunspot.index? but that's just testing the
   # invocation of delegate, so probably not important. -nz 11Apr12
 
   it_should_behave_like 'session proxy'
-  
+
 end


### PR DESCRIPTION
…ecific error or message risks false positives