### PR TITLE
Don't rebuild spellchecker after every commit

### DIFF
--- a/examples/solr7_core/conf/solrconfig.xml
+++ b/examples/solr7_core/conf/solrconfig.xml
@@ -544,7 +544,7 @@
       <!-- change field to textSpell and use copyField in schema.xml
       to spellcheck multiple fields -->
       <str name="field">textSpell</str>
-      <str name="buildOnCommit">true</str>
+      <str name="buildOnOptimize">true</str>
     </lst>
 
     <lst name="spellchecker">


### PR DESCRIPTION
This causes significant slowdown when the index is large and is not recommended for production systems.

See https://cwiki.apache.org/confluence/display/solr/SpellCheckComponent#Custom_Comparators_and_the_Lucene_Spell_Checkers_.28IndexBasedSpellChecker.2C_FileBasedSpellChecker.2C_DirectSolrSpellChecker.29