### PR TITLE
Fix rails 7.1 deprecation warning

### DIFF
--- a/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
@@ -21,7 +21,7 @@ describe Sunspot::SessionProxy::Retry5xxSessionProxy do
   end
 
   let :fake_rsolr_request do
-    {:uri => 'http://solr.test/uri'}
+    {:uri => URI('http://solr.test/uri')}
   end
 
   def fake_rsolr_response(status)

--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -33,15 +33,15 @@ module Sunspot
         name = '%s (%.1fms)' % ["SOLR Request", event.duration]
 
         # produces: path=select parameters={fq: ["type:Tag"], q: "rossi", fl: "* score", qf: "tag_name_text", defType: "edismax", start: 0, rows: 20}
-        path = color(event.payload[:path], BOLD, true)
+        path = color(event.payload[:path], nil, bold: true)
         parameters = event.payload[:parameters].map { |k, v|
           v = "\"#{v}\"" if v.is_a? String
           v = v.to_s.gsub(/\\/,'') # unescape
-          "#{k}: #{color(v, BOLD, true)}"
+          "#{k}: #{color(v, nil, bold: true)}"
         }.join(', ')
         request = "path=#{path} parameters={#{parameters}}"
 
-        debug "  #{color(name, GREEN, true)}  [ #{request} ]"
+        debug "  #{color(name, GREEN, bold: true)}  [ #{request} ]"
       end
     end
   end

--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -33,15 +33,15 @@ module Sunspot
         name = '%s (%.1fms)' % ["SOLR Request", event.duration]
 
         # produces: path=select parameters={fq: ["type:Tag"], q: "rossi", fl: "* score", qf: "tag_name_text", defType: "edismax", start: 0, rows: 20}
-        path = color(event.payload[:path], nil, bold: true)
+        path = color(event.payload[:path], BOLD, true)
         parameters = event.payload[:parameters].map { |k, v|
           v = "\"#{v}\"" if v.is_a? String
           v = v.to_s.gsub(/\\/,'') # unescape
-          "#{k}: #{color(v, nil, bold: true)}"
+          "#{k}: #{color(v, BOLD, true)}"
         }.join(', ')
         request = "path=#{path} parameters={#{parameters}}"
 
-        debug "  #{color(name, GREEN, bold: true)}  [ #{request} ]"
+        debug "  #{color(name, GREEN, true)}  [ #{request} ]"
       end
     end
   end


### PR DESCRIPTION
This PR addresses the following Rails 7.1 deprecation warnings.

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`)
DEPRECATION WARNING: BOLD is deprecated! Use MODES[:bold] instead.
```

Below is the output from the original code and the code that replaces it. Where the original code provided `BOLD` as the second argument it was generating the bold terminal escape sequence ("`\e[1m`") twice which was not achieving anything in addition to turning on bold.

```
 Original: color(event.payload[:path], BOLD, true)      => "\e[1m\e[1mupdate\e[0m"
Suggested: color(event.payload[:path], nil, bold: true) => "\e[1mupdate\e[0m"
```
```
 Original: color(name, GREEN, true)       => "\e[1m\e[32mSOLR Request (21.4ms)\e[0m"
Suggested: color(name, GREEN, bold: true) => "\e[1m\e[32mSOLR Request (21.4ms)\e[0m"
```