### PR TITLE
Allow aliases when loading Rails yaml config

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -377,7 +377,7 @@ module Sunspot #:nodoc:
             if File.exist?(path)
               File.open(path) do |file|
                 processed = ERB.new(file.read).result
-                YAML.load(processed)[::Rails.env]
+                YAML.load(processed, aliases: true)[::Rails.env]
               end
             else
               {}


### PR DESCRIPTION
This change is needed for Ruby 3+ since Ruby YAML changed to expect by default that aliases won't be present in the incoming yaml.

This would I think be an afterthought to #1034 and also would supersede #1023. I don't think we need to use `unsafe_load` since we don't need unsafe loading (deserializing weird classes), we just need aliases to work. 