### PR TITLE
Reallow rsolr 2.6

### DIFF
--- a/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
+++ b/sunspot/spec/api/session_proxy/retry_5xx_session_proxy_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('spec_helper', File.dirname(__FILE__))
+require 'uri'
 
 describe Sunspot::SessionProxy::Retry5xxSessionProxy do
 

--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rsolr', '>= 1.1.1', '< 2.6'
+  s.add_dependency 'rsolr', '>= 1.1.1', '< 3'
   s.add_dependency 'pr_geohash', '~>1.0'
   s.add_dependency 'bigdecimal'
   s.add_development_dependency 'rake', '~> 13.2'


### PR DESCRIPTION
The rsolr version was set to '< 2.5' in https://github.com/sunspot/sunspot/pull/1042#discussion_r1629416547

The changes in 2.6 seem rather small https://my.diffend.io/gems/rsolr/2.5.0/2.6.0

Locally I have two errors but they seem not related to rsolr.

I'm not sure if I'm running the tests correct, so I want Github to run them. Thats why I made the PR :)