### PR TITLE
Add Ruby 4.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
           - 'head'
         gem: ['sunspot', 'sunspot_rails', 'sunspot_solr']
         update-format: ['xml', 'json']


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to the CI matrix to prepare for Ruby 4.0 compatibility testing
