### PR TITLE
Fix flaky indexing tests

### DIFF
--- a/sunspot/spec/integration/indexing_spec.rb
+++ b/sunspot/spec/integration/indexing_spec.rb
@@ -11,8 +11,8 @@ describe 'indexing' do
     post = Post.new(:title => 'test post')
     Sunspot.index!(post)
     Sunspot.remove!(post)
-    # Add a small sleep to ensure commit completes on Ruby 2.7
-    sleep 0.1 if RUBY_VERSION.start_with?('2.7')
+    # Add a small sleep to ensure Solr searcher refresh completes
+    sleep 0.1
     expect(Sunspot.search(Post) { with(:title, 'test post') }.results).to be_empty
   end
 
@@ -20,6 +20,8 @@ describe 'indexing' do
     post = Post.new(:title => 'test post')
     Sunspot.index!(post)
     Sunspot.remove_by_id!(Post, post.id)
+    # Add a small sleep to ensure Solr searcher refresh completes
+    sleep 0.1
     expect(Sunspot.search(Post) { with(:title, 'test post') }.results).to be_empty
   end
 


### PR DESCRIPTION
## Summary
Fix intermittent CI failures in `indexing_spec.rb` delete tests.

## Problem
The tests `should correctly remove by model instance` and `should correctly delete by ID` were failing intermittently because:

1. After `remove!` or `remove_by_id!` calls `commit`, there's a brief delay before Solr's searcher refreshes
2. The search executed immediately after may still see the deleted document
3. PR #1051 added a sleep only for Ruby 2.7, but the same race condition can occur on any Ruby version depending on CI load

## Changes
- Apply `sleep 0.1` to all Ruby versions (not just 2.7)
- Add sleep to `should correctly delete by ID` test which was missing it
- Update comments to clarify the reason (Solr searcher refresh timing)

## Evidence
Same code passed on s4na/sunspot CI but failed on sunspot/sunspot CI for `build (3.1, sunspot, json)` - classic flaky test behavior.

## Related
This PR was created to fix CI failures in https://github.com/sunspot/sunspot/pull/1052 (Add Ruby 4.0 to CI).

## Test plan
- [x] CI passes consistently across all Ruby versions and update formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)